### PR TITLE
Cursor-focused text insertion mode with 3-mode setting

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-progress": "^1.1.8",
+    "@radix-ui/react-radio-group": "^1.3.8",
     "@radix-ui/react-select": "^2.2.6",
     "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tabs": "^1.1.13",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -20,6 +20,9 @@ importers:
       '@radix-ui/react-progress':
         specifier: ^1.1.8
         version: 1.1.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-radio-group':
+        specifier: ^1.3.8
+        version: 1.3.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@radix-ui/react-select':
         specifier: ^2.2.6
         version: 2.2.6(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
@@ -606,6 +609,19 @@ packages:
 
   '@radix-ui/react-progress@1.1.8':
     resolution: {integrity: sha512-+gISHcSPUJ7ktBy9RnTqbdKW78bcGke3t6taawyZ71pio1JewwGSJizycs7rLhGTvMJYCQB1DBK4KQsxs7U8dA==}
+    peerDependencies:
+      '@types/react': '*'
+      '@types/react-dom': '*'
+      react: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@radix-ui/react-radio-group@1.3.8':
+    resolution: {integrity: sha512-VBKYIYImA5zsxACdisNQ3BjCBfmbGH3kQlnFVqlWU4tXwjy7cGX8ta80BcrO+WJXIn5iBylEH3K6ZTlee//lgQ==}
     peerDependencies:
       '@types/react': '*'
       '@types/react-dom': '*'
@@ -2197,6 +2213,24 @@ snapshots:
     dependencies:
       '@radix-ui/react-context': 1.1.3(@types/react@19.2.2)(react@19.2.0)
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+    optionalDependencies:
+      '@types/react': 19.2.2
+      '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
+  '@radix-ui/react-radio-group@1.3.8(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@radix-ui/primitive': 1.1.3
+      '@radix-ui/react-compose-refs': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-context': 1.1.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-direction': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-presence': 1.1.5(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-primitive': 2.1.3(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-roving-focus': 1.1.11(@types/react-dom@19.2.2(@types/react@19.2.2))(@types/react@19.2.2)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@radix-ui/react-use-controllable-state': 1.2.2(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-previous': 1.1.1(@types/react@19.2.2)(react@19.2.0)
+      '@radix-ui/react-use-size': 1.1.1(@types/react@19.2.2)(react@19.2.0)
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:

--- a/src-tauri/.cargo/config.toml
+++ b/src-tauri/.cargo/config.toml
@@ -1,0 +1,7 @@
+# Redirect build artifacts to a shorter path to avoid Windows 260-char path limit.
+# This is necessary because whisper-rs-sys (CMake/MSBuild) creates deeply nested
+# build paths that exceed the limit when the project is in a deep directory.
+# The main repo at C:\Users\nolyo\www\voice-tool\ is fine, but worktrees and
+# other deep locations need this workaround.
+[build]
+target-dir = "C:/tmp/vt-build"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1104,6 +1104,36 @@ fn paste_text_to_active_window(_text: String) -> Result<(), String> {
     Ok(())
 }
 
+/// Type text directly at the cursor position using keyboard simulation
+/// Unlike paste_text_to_active_window, this does NOT touch the clipboard
+#[tauri::command]
+fn type_text_at_cursor(text: String) -> Result<(), String> {
+    use enigo::{Enigo, Keyboard, Settings};
+    use std::thread;
+    use std::time::Duration;
+
+    tracing::info!(
+        "Typing transcription directly at cursor position ({} chars)",
+        text.len()
+    );
+
+    // Small delay to ensure target window has focus
+    thread::sleep(Duration::from_millis(50));
+
+    let mut enigo = Enigo::new(&Settings::default()).map_err(|e| {
+        tracing::error!("Failed to initialize keyboard simulation: {}", e);
+        format!("Failed to initialize keyboard: {}", e)
+    })?;
+
+    enigo.text(&text).map_err(|e| {
+        tracing::error!("Failed to type text: {}", e);
+        format!("Failed to type text: {}", e)
+    })?;
+
+    tracing::info!("Text typed successfully at cursor position");
+    Ok(())
+}
+
 #[tauri::command]
 async fn delete_recording_files(paths: Vec<String>) -> Result<(), String> {
     for path in paths {
@@ -1185,6 +1215,7 @@ pub fn run() {
             transcribe_audio,
             load_recording,
             paste_text_to_active_window,
+            type_text_at_cursor,
             start_deepgram_streaming,
             stop_deepgram_streaming,
             is_deepgram_connected,

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -110,17 +110,21 @@ export default function Dashboard() {
       setSelectedTranscription(newEntry);
       playSuccess();
 
-      if (settings.paste_at_cursor) {
+      // Text insertion based on mode
+      if (settings.insertion_mode === "cursor") {
+        await invoke("type_text_at_cursor", { text: finalText });
+      } else if (settings.insertion_mode === "clipboard") {
         const { writeText } = await import(
           "@tauri-apps/plugin-clipboard-manager"
         );
         await writeText(finalText);
         await invoke("paste_text_to_active_window", { text: finalText });
       }
+      // "none" mode: no insertion, text only in history
 
       return newEntry;
     },
-    [addTranscription, playSuccess, settings.paste_at_cursor, settings.snippets],
+    [addTranscription, playSuccess, settings.insertion_mode, settings.snippets],
   );
 
   const handleTranscriptionFinalRef = useRef(handleTranscriptionFinal);

--- a/src/components/setting-tabs.tsx
+++ b/src/components/setting-tabs.tsx
@@ -22,6 +22,7 @@ import { Progress } from "./ui/progress";
 import { toast } from "sonner";
 import { listen } from "@tauri-apps/api/event";
 import { Checkbox } from "./ui/checkbox";
+import { RadioGroup, RadioGroupItem } from "./ui/radio-group";
 import {
   Select,
   SelectContent,
@@ -904,27 +905,63 @@ export function SettingTabs() {
         title="Texte"
         subtitle="Formatage et insertion automatique"
       >
-        <div className="space-y-1">
-          <div
-            className="flex items-start gap-3 p-2.5 rounded-lg hover:bg-muted/30 transition-colors cursor-pointer"
-            onClick={() =>
-              updateSetting("paste_at_cursor", !settings.paste_at_cursor)
-            }
-          >
-            <Checkbox
-              id="auto-insert"
-              checked={settings.paste_at_cursor}
-              onCheckedChange={(checked) =>
-                updateSetting("paste_at_cursor", checked as boolean)
-              }
-              className="mt-0.5"
-            />
-            <Label
-              htmlFor="auto-insert"
-              className="text-sm text-foreground cursor-pointer leading-relaxed flex-1"
-            >
-              Insertion automatique au curseur après transcription
+        <div className="space-y-4">
+          <div className="space-y-1">
+            <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+              Mode d'insertion
             </Label>
+            <RadioGroup
+              value={settings.insertion_mode}
+              onValueChange={(value) =>
+                updateSetting("insertion_mode", value as "cursor" | "clipboard" | "none")
+              }
+              className="gap-0"
+            >
+              <label
+                htmlFor="mode-cursor"
+                className="flex items-start gap-3 p-2.5 rounded-lg hover:bg-muted/30 transition-colors cursor-pointer"
+              >
+                <RadioGroupItem value="cursor" id="mode-cursor" className="mt-0.5" />
+                <div className="flex-1">
+                  <span className="text-sm font-medium text-foreground leading-relaxed">
+                    Saisie directe au curseur
+                  </span>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Le texte est tapé directement, sans utiliser le presse-papiers
+                  </p>
+                </div>
+              </label>
+
+              <label
+                htmlFor="mode-clipboard"
+                className="flex items-start gap-3 p-2.5 rounded-lg hover:bg-muted/30 transition-colors cursor-pointer"
+              >
+                <RadioGroupItem value="clipboard" id="mode-clipboard" className="mt-0.5" />
+                <div className="flex-1">
+                  <span className="text-sm font-medium text-foreground leading-relaxed">
+                    Copier-coller
+                  </span>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Le texte est copié dans le presse-papiers puis collé (Ctrl+V)
+                  </p>
+                </div>
+              </label>
+
+              <label
+                htmlFor="mode-none"
+                className="flex items-start gap-3 p-2.5 rounded-lg hover:bg-muted/30 transition-colors cursor-pointer"
+              >
+                <RadioGroupItem value="none" id="mode-none" className="mt-0.5" />
+                <div className="flex-1">
+                  <span className="text-sm font-medium text-foreground leading-relaxed">
+                    Aucune insertion
+                  </span>
+                  <p className="text-xs text-muted-foreground mt-0.5">
+                    Le texte est uniquement ajouté à l'historique
+                  </p>
+                </div>
+              </label>
+            </RadioGroup>
           </div>
 
           <div

--- a/src/components/ui/radio-group.tsx
+++ b/src/components/ui/radio-group.tsx
@@ -1,0 +1,45 @@
+"use client"
+
+import * as React from "react"
+import * as RadioGroupPrimitive from "@radix-ui/react-radio-group"
+import { CircleIcon } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+function RadioGroup({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Root>) {
+  return (
+    <RadioGroupPrimitive.Root
+      data-slot="radio-group"
+      className={cn("grid gap-3", className)}
+      {...props}
+    />
+  )
+}
+
+function RadioGroupItem({
+  className,
+  ...props
+}: React.ComponentProps<typeof RadioGroupPrimitive.Item>) {
+  return (
+    <RadioGroupPrimitive.Item
+      data-slot="radio-group-item"
+      className={cn(
+        "border-input dark:bg-input/30 text-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive aspect-square size-4 shrink-0 rounded-full border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+        className
+      )}
+      {...props}
+    >
+      <RadioGroupPrimitive.Indicator
+        data-slot="radio-group-indicator"
+        className="grid place-content-center text-current transition-none"
+      >
+        <CircleIcon className="size-2 fill-current" />
+      </RadioGroupPrimitive.Indicator>
+    </RadioGroupPrimitive.Item>
+  )
+}
+
+export { RadioGroup, RadioGroupItem }

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -45,7 +45,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
           const merged = mergeSettings(savedSettings);
 
           // Migrate old paste_at_cursor boolean to new insertion_mode enum
-          const raw = savedSettings as Record<string, unknown>;
+          const raw = savedSettings as unknown as Record<string, unknown>;
           const rawSettings = (raw.settings ?? {}) as Record<string, unknown>;
           if ("paste_at_cursor" in rawSettings && !("insertion_mode" in rawSettings)) {
             merged.settings.insertion_mode = rawSettings.paste_at_cursor ? "cursor" : "none";

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -42,7 +42,20 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         const savedSettings = await storeInstance.get<AppSettings>("settings");
 
         if (savedSettings) {
-          setSettings(mergeSettings(savedSettings));
+          const merged = mergeSettings(savedSettings);
+
+          // Migrate old paste_at_cursor boolean to new insertion_mode enum
+          const raw = savedSettings as Record<string, unknown>;
+          const rawSettings = (raw.settings ?? {}) as Record<string, unknown>;
+          if ("paste_at_cursor" in rawSettings && !("insertion_mode" in rawSettings)) {
+            merged.settings.insertion_mode = rawSettings.paste_at_cursor ? "cursor" : "none";
+            delete (merged.settings as Record<string, unknown>).paste_at_cursor;
+            // Persist migrated settings back to store
+            await storeInstance.set("settings", merged);
+            await storeInstance.save();
+          }
+
+          setSettings(merged);
         } else {
           // First time: save default settings
           await storeInstance.set("settings", DEFAULT_SETTINGS);

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -24,7 +24,7 @@ export interface AppSettings {
     google_api_key: string;
 
     // Text
-    paste_at_cursor: boolean;
+    insertion_mode: "cursor" | "clipboard" | "none";
 
     // System
     recordings_keep_last: number;
@@ -79,7 +79,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     google_api_key: "",
 
     // Text
-    paste_at_cursor: true,
+    insertion_mode: "cursor",
 
     // System
     recordings_keep_last: 25,


### PR DESCRIPTION
Currently, the voice-tool application inserts transcribed text by writing it to the system clipboard and simulating Ctrl+V to paste. This is disruptive because it overwrites whatever the user previously had in their clipboard (e.g., a screenshot, copied text). The goal is to implement a **direct cursor insertion mode** that uses keyboard simulation to type the text character-by-character at the active cursor position — without touching the clipboard — and make this the **default** mode. The existing clipboard-based paste behavior must remain available as an opt-in alternative. The settings UI must be redesigned to clearly communicate the distinction between these two modes.