### PR TITLE
Fix link opening behavior on single click

### DIFF
--- a/src/components/notes-editor.tsx
+++ b/src/components/notes-editor.tsx
@@ -74,20 +74,22 @@ export function NotesEditor({
       attributes: {
         class: "prose prose-sm dark:prose-invert max-w-none w-full h-full p-4 focus:outline-none text-foreground text-sm leading-relaxed",
       },
-      handleClick: (_view, _pos, event) => {
-        const target = event.target as HTMLElement;
-        const link = target.closest("a");
-        if (!link) return false;
+      handleDOMEvents: {
+        click: (_view, event) => {
+          const target = event.target as HTMLElement;
+          const link = target.closest("a");
+          if (!link) return false;
 
-        event.preventDefault();
+          event.preventDefault();
 
-        if (event.ctrlKey || event.metaKey) {
-          const href = link.getAttribute("href");
-          if (href) {
-            import("@tauri-apps/plugin-opener").then(({ openUrl }) => openUrl(href));
+          if (event.ctrlKey || event.metaKey) {
+            const href = link.getAttribute("href");
+            if (href) {
+              import("@tauri-apps/plugin-opener").then(({ openUrl }) => openUrl(href));
+            }
           }
-        }
-        return true;
+          return true;
+        },
       },
       handlePaste: (_view, event) => {
         const items = event.clipboardData?.items;

--- a/src/components/notes-editor.tsx
+++ b/src/components/notes-editor.tsx
@@ -74,6 +74,21 @@ export function NotesEditor({
       attributes: {
         class: "prose prose-sm dark:prose-invert max-w-none w-full h-full p-4 focus:outline-none text-foreground text-sm leading-relaxed",
       },
+      handleClick: (_view, _pos, event) => {
+        const target = event.target as HTMLElement;
+        const link = target.closest("a");
+        if (!link) return false;
+
+        event.preventDefault();
+
+        if (event.ctrlKey || event.metaKey) {
+          const href = link.getAttribute("href");
+          if (href) {
+            import("@tauri-apps/plugin-opener").then(({ openUrl }) => openUrl(href));
+          }
+        }
+        return true;
+      },
       handlePaste: (_view, event) => {
         const items = event.clipboardData?.items;
         if (!items) return false;
@@ -453,7 +468,7 @@ export function NotesEditor({
             ) : (
               <EditorContent
                 editor={editor}
-                className="h-full [&_.tiptap]:h-full [&_.tiptap]:overflow-auto [&_.tiptap_img]:max-w-full [&_.tiptap_img]:h-auto [&_.tiptap_img]:rounded-md [&_.tiptap_img]:my-2"
+                className="h-full [&_.tiptap]:h-full [&_.tiptap]:overflow-auto [&_.tiptap_img]:max-w-full [&_.tiptap_img]:h-auto [&_.tiptap_img]:rounded-md [&_.tiptap_img]:my-2 [&_.tiptap_a]:cursor-text"
               />
             )}
             {aiState === "loading" && (


### PR DESCRIPTION
Prevent links in the notes editor from opening on plain click. Links should only open on `Ctrl+Click` (or `Cmd+Click` on Mac), allowing users to select/copy link text normally. Currently, clicking a link immediately navigates, which blocks text selection and copying.