### PR TITLE
feat: add dark/light theme toggle in settings

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,16 +4,24 @@ import { ProfilesProvider } from "./contexts/ProfilesContext";
 import { SettingsProvider } from "./contexts/SettingsContext";
 import { UpdaterProvider } from "./contexts/UpdaterContext";
 import { Toaster } from "sonner";
+import { useSettings } from "./hooks/useSettings";
+
+function AppShell() {
+  const { settings } = useSettings();
+  return (
+    <main>
+      <Dashboard />
+      <Toaster position="bottom-right" theme={settings.theme} />
+    </main>
+  );
+}
 
 function App() {
   return (
     <ProfilesProvider>
       <SettingsProvider>
         <UpdaterProvider>
-          <main className="dark">
-            <Dashboard />
-            <Toaster position="bottom-right" theme="dark" />
-          </main>
+          <AppShell />
         </UpdaterProvider>
       </SettingsProvider>
     </ProfilesProvider>

--- a/src/components/mini-window/MiniShell.tsx
+++ b/src/components/mini-window/MiniShell.tsx
@@ -58,7 +58,7 @@ export function MiniShell() {
 
   return (
     <div
-      className="dark flex h-full w-full items-center justify-center bg-transparent overflow-hidden"
+      className="flex h-full w-full items-center justify-center bg-transparent overflow-hidden"
       data-tauri-drag-region
     >
       <div

--- a/src/components/settings/sections/SystemSection.tsx
+++ b/src/components/settings/sections/SystemSection.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 import { invoke } from "@tauri-apps/api/core";
-import { Minus, Plus, Settings } from "lucide-react";
+import { Minus, Moon, Plus, Settings, Sun } from "lucide-react";
 import { Label } from "@/components/ui/label";
 import { Checkbox } from "@/components/ui/checkbox";
 import { Button } from "@/components/ui/button";
@@ -56,6 +56,40 @@ export function SystemSection() {
           </Select>
           <p className="text-xs text-muted-foreground">
             {t('settings.system.languageDesc')}
+          </p>
+        </div>
+
+        <Divider />
+
+        {/* Theme selector */}
+        <div className="space-y-1.5">
+          <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wide">
+            {t('settings.system.theme')}
+          </Label>
+          <div className="inline-flex rounded-lg border bg-background/50 p-1">
+            <Button
+              type="button"
+              variant={settings.theme === "dark" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => updateSetting("theme", "dark")}
+            >
+              <Moon className="w-3.5 h-3.5" />
+              {t('settings.system.themeDark')}
+            </Button>
+            <Button
+              type="button"
+              variant={settings.theme === "light" ? "secondary" : "ghost"}
+              size="sm"
+              className="h-8 gap-1.5"
+              onClick={() => updateSetting("theme", "light")}
+            >
+              <Sun className="w-3.5 h-3.5" />
+              {t('settings.system.themeLight')}
+            </Button>
+          </div>
+          <p className="text-xs text-muted-foreground">
+            {t('settings.system.themeDesc')}
           </p>
         </div>
 

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { emit, listen } from "@tauri-apps/api/event";
 import { AppSettings, DEFAULT_SETTINGS, mergeSettings } from "@/lib/settings";
 import { changeLanguage } from "@/i18n";
+import { applyTheme } from "@/lib/theme";
 
 let store: Store | null = null;
 
@@ -66,6 +67,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
 
           setSettings(merged);
 
+          // Apply the stored theme immediately so the UI matches persisted state.
+          applyTheme(merged.settings.theme);
+
           // Broadcast current translate_mode so the mini window stays in sync
           // on startup (it may have loaded before we wrote defaults).
           try { await emit("translate-mode-changed", merged.settings.translate_mode); } catch {}
@@ -84,6 +88,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
           }
         } else {
           // First time: save default settings
+          applyTheme(DEFAULT_SETTINGS.settings.theme);
           await storeInstance.set("settings", DEFAULT_SETTINGS);
           await storeInstance.save();
         }
@@ -130,6 +135,10 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
         await emit(
           "mini-visualizer-mode-changed",
           settingsRef.current.settings.mini_visualizer_mode,
+        );
+        await emit(
+          "theme-changed",
+          settingsRef.current.settings.theme,
         );
       } catch {}
     }).then((fn) => {
@@ -185,6 +194,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
       // Keep the mini window in sync when translate_mode is toggled from settings
       if (key === "translate_mode") {
         try { await emit("translate-mode-changed", value); } catch {}
+      }
+
+      // Apply theme change live and broadcast to the mini window
+      if (key === "theme" && (value === "light" || value === "dark")) {
+        applyTheme(value);
+        try { await emit("theme-changed", value); } catch {}
       }
 
       await storeInstance.set("settings", newSettings);

--- a/src/hooks/useMiniWindowState.ts
+++ b/src/hooks/useMiniWindowState.ts
@@ -4,6 +4,7 @@ import { invoke } from "@tauri-apps/api/core";
 import { Store } from "@tauri-apps/plugin-store";
 import i18n from "@/i18n";
 import { DEFAULT_SETTINGS, type AppSettings } from "@/lib/settings";
+import { applyTheme, type Theme } from "@/lib/theme";
 
 export type WindowStatus =
   | "idle"
@@ -81,6 +82,7 @@ export function useMiniWindowState() {
     let unlistenTranslateModeChangedFn: (() => void) | null = null;
     let unlistenLanguageChangedFn: (() => void) | null = null;
     let unlistenVisualizerModeChangedFn: (() => void) | null = null;
+    let unlistenThemeChangedFn: (() => void) | null = null;
 
     const setupListeners = async () => {
       try {
@@ -103,6 +105,11 @@ export function useMiniWindowState() {
               setShowTranscriptPreview(s.show_transcription_in_mini_window);
             }
             if (s.language) setLanguage(s.language);
+            if (s.theme === "light" || s.theme === "dark") {
+              applyTheme(s.theme);
+            } else {
+              applyTheme(DEFAULT_SETTINGS.settings.theme);
+            }
           }
         } catch (e) {
           console.log("Mini window: could not load settings from store", e);
@@ -128,6 +135,15 @@ export function useMiniWindowState() {
           (event) => {
             if (event.payload === "bars" || event.payload === "waveform") {
               setVisualizerMode(event.payload);
+            }
+          },
+        );
+
+        unlistenThemeChangedFn = await listen<Theme>(
+          "theme-changed",
+          (event) => {
+            if (event.payload === "light" || event.payload === "dark") {
+              applyTheme(event.payload);
             }
           },
         );
@@ -207,6 +223,7 @@ export function useMiniWindowState() {
       if (unlistenTranslateModeChangedFn) unlistenTranslateModeChangedFn();
       if (unlistenLanguageChangedFn) unlistenLanguageChangedFn();
       if (unlistenVisualizerModeChangedFn) unlistenVisualizerModeChangedFn();
+      if (unlistenThemeChangedFn) unlistenThemeChangedFn();
     };
   }, []);
 

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -49,6 +49,7 @@ export interface AppSettings {
 
     // Interface
     ui_language: "fr" | "en";
+    theme: "light" | "dark";
 
     // Mini Window
     /**
@@ -120,6 +121,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 
     // Interface
     ui_language: "fr",
+    theme: "dark",
 
     // Mini Window
     show_transcription_in_mini_window: true,

--- a/src/lib/theme.ts
+++ b/src/lib/theme.ts
@@ -1,0 +1,18 @@
+export type Theme = "light" | "dark";
+
+export const DEFAULT_THEME: Theme = "dark";
+
+/**
+ * Apply the theme to the document root by toggling the `dark` class.
+ * Tailwind v4 dark variant is configured as `&:is(.dark *)` in globals.css,
+ * so a single class on <html> flips the whole UI.
+ */
+export function applyTheme(theme: Theme) {
+  if (typeof document === "undefined") return;
+  const root = document.documentElement;
+  if (theme === "dark") {
+    root.classList.add("dark");
+  } else {
+    root.classList.remove("dark");
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -198,6 +198,10 @@
       "recordingsKeepHelp": "Number of audio files to keep locally",
       "language": "Language",
       "languageDesc": "Interface language",
+      "theme": "Theme",
+      "themeDesc": "Dark or light appearance of the interface",
+      "themeDark": "Dark",
+      "themeLight": "Light",
       "danger": {
         "title": "Danger zone",
         "subtitle": "Wipe all application data and start over from a clean install.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -198,6 +198,10 @@
       "recordingsKeepHelp": "Nombre de fichiers audio à conserver localement",
       "language": "Langue",
       "languageDesc": "Langue de l'interface",
+      "theme": "Thème",
+      "themeDesc": "Apparence sombre ou claire de l'interface",
+      "themeDark": "Sombre",
+      "themeLight": "Clair",
       "danger": {
         "title": "Zone de danger",
         "subtitle": "Effacer toutes les données du logiciel et repartir d'une installation vierge.",


### PR DESCRIPTION
Adds a theme toggle in the System settings with persistence via the Tauri Store. Default remains dark. Theme is applied by toggling the `dark` class on <html> and synced to the mini window via a `theme-changed` event.