### PR TITLE
chore(edge-functions): lock CORS allowlist and add Deno unit tests

### DIFF
--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,10 +1,10 @@
 // deno-lint-ignore-file no-explicit-any
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
 
 /** Extrait le user_id depuis le JWT présenté dans Authorization: Bearer <token>.
  *  Retourne { userId, client } où client a les permissions du user (RLS actif). */
 export async function getAuthenticatedUser(req: Request): Promise<
-  | { userId: string; client: ReturnType<typeof createClient>; token: string }
+  | { userId: string; client: SupabaseClient<any, any, any>; token: string }
   | { error: string; status: number }
 > {
   const authHeader = req.headers.get("Authorization");

--- a/supabase/functions/_shared/cors.ts
+++ b/supabase/functions/_shared/cors.ts
@@ -1,9 +1,31 @@
-export const corsHeaders: Record<string, string> = {
-  "Access-Control-Allow-Origin": "*",
+// Allowlist of origins permitted to call our Edge Functions.
+// - tauri://localhost      → macOS / Linux Tauri webview
+// - https://tauri.localhost → Windows WebView2
+// - http://localhost:1420  → Vite dev server (pnpm dev)
+const ALLOWED_ORIGINS: ReadonlySet<string> = new Set([
+  "tauri://localhost",
+  "https://tauri.localhost",
+  "http://localhost:1420",
+]);
+
+const BASE_HEADERS: Readonly<Record<string, string>> = Object.freeze({
   "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type",
   "Access-Control-Allow-Methods": "POST, OPTIONS",
-};
+  Vary: "Origin",
+});
 
-export function preflight(): Response {
-  return new Response("ok", { headers: corsHeaders });
+export function corsHeaders(req: Request): Record<string, string> {
+  const origin = req.headers.get("Origin") ?? "";
+  if (!ALLOWED_ORIGINS.has(origin)) {
+    return { ...BASE_HEADERS };
+  }
+  return { ...BASE_HEADERS, "Access-Control-Allow-Origin": origin };
+}
+
+export function preflight(req: Request): Response {
+  return new Response("ok", { headers: corsHeaders(req) });
+}
+
+export function isAllowedOrigin(origin: string): boolean {
+  return ALLOWED_ORIGINS.has(origin);
 }

--- a/supabase/functions/account-export/index.ts
+++ b/supabase/functions/account-export/index.ts
@@ -1,19 +1,28 @@
+// deno-lint-ignore-file no-explicit-any
+import { type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
 import { corsHeaders, preflight } from "../_shared/cors.ts";
 import { getAuthenticatedUser } from "../_shared/auth.ts";
 
-function json(body: unknown, status = 200): Response {
+export interface AccountExportDeps {
+  authenticate: (req: Request) => Promise<
+    | { userId: string; client: SupabaseClient<any, any, any>; token?: string }
+    | { error: string; status: number }
+  >;
+}
+
+function json(req: Request, body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
+    headers: { ...corsHeaders(req), "Content-Type": "application/json" },
   });
 }
 
-Deno.serve(async (req) => {
-  if (req.method === "OPTIONS") return preflight();
-  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+export async function handler(req: Request, deps: AccountExportDeps): Promise<Response> {
+  if (req.method === "OPTIONS") return preflight(req);
+  if (req.method !== "POST") return json(req, { error: "method not allowed" }, 405);
 
-  const auth = await getAuthenticatedUser(req);
-  if ("error" in auth) return json({ error: auth.error }, auth.status);
+  const auth = await deps.authenticate(req);
+  if ("error" in auth) return json(req, { error: auth.error }, auth.status);
 
   const { userId, client } = auth;
 
@@ -25,7 +34,7 @@ Deno.serve(async (req) => {
   ]);
 
   for (const r of [settings, dictionary, snippets, devices]) {
-    if (r.error) return json({ error: r.error.message }, 500);
+    if (r.error) return json(req, { error: r.error.message }, 500);
   }
 
   const payload = {
@@ -38,5 +47,9 @@ Deno.serve(async (req) => {
     user_devices: devices.data,
   };
 
-  return json(payload);
-});
+  return json(req, payload);
+}
+
+if (import.meta.main) {
+  Deno.serve((req) => handler(req, { authenticate: getAuthenticatedUser }));
+}

--- a/supabase/functions/account-export/test.ts
+++ b/supabase/functions/account-export/test.ts
@@ -1,0 +1,171 @@
+// deno-lint-ignore-file no-explicit-any
+import { assertEquals, assertExists } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const ENDPOINT = "http://localhost/functions/v1/account-export";
+
+interface TableData {
+  settings?: { data: any; error: any };
+  dictionary?: { data: any; error: any };
+  snippets?: { data: any; error: any };
+  devices?: { data: any; error: any };
+}
+
+function makeFakeClient(data: TableData = {}): { client: any; selects: string[] } {
+  const selects: string[] = [];
+  const client: any = {
+    from(table: string) {
+      return {
+        select(_cols: string) {
+          selects.push(table);
+          const result =
+            table === "user_settings"
+              ? data.settings ?? { data: null, error: null }
+              : table === "user_dictionary_words"
+              ? data.dictionary ?? { data: [], error: null }
+              : table === "user_snippets"
+              ? data.snippets ?? { data: [], error: null }
+              : table === "user_devices"
+              ? data.devices ?? { data: [], error: null }
+              : { data: null, error: { message: `unknown table ${table}` } };
+          return {
+            maybeSingle() {
+              return Promise.resolve(result);
+            },
+            then(resolve: any, reject: any) {
+              return Promise.resolve(result).then(resolve, reject);
+            },
+          };
+        },
+      };
+    },
+  };
+  return { client, selects };
+}
+
+function authOk(userId = "user-1", data: TableData = {}) {
+  const { client, selects } = makeFakeClient(data);
+  return {
+    authenticate: async () => ({ userId, client }),
+    selects,
+  };
+}
+
+function authFail(error = "invalid token", status = 401) {
+  return {
+    authenticate: async () => ({ error, status }),
+  };
+}
+
+Deno.test("OPTIONS from allowed origin echoes the origin", async () => {
+  const { handler } = await import("./index.ts");
+  const req = new Request(ENDPOINT, {
+    method: "OPTIONS",
+    headers: { Origin: "tauri://localhost" },
+  });
+  const res = await handler(req, authFail());
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), "tauri://localhost");
+});
+
+Deno.test("OPTIONS from disallowed origin omits Allow-Origin", async () => {
+  const { handler } = await import("./index.ts");
+  const req = new Request(ENDPOINT, {
+    method: "OPTIONS",
+    headers: { Origin: "https://evil.example.com" },
+  });
+  const res = await handler(req, authFail());
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), null);
+});
+
+Deno.test("GET returns 405", async () => {
+  const { handler } = await import("./index.ts");
+  const req = new Request(ENDPOINT, { method: "GET" });
+  const res = await handler(req, authFail());
+  assertEquals(res.status, 405);
+  assertEquals((await res.json()).error, "method not allowed");
+});
+
+Deno.test("auth failure propagates status and message", async () => {
+  const { handler } = await import("./index.ts");
+  const req = new Request(ENDPOINT, { method: "POST" });
+  const res = await handler(req, authFail("expired", 401));
+  assertEquals(res.status, 401);
+  assertEquals((await res.json()).error, "expired");
+});
+
+Deno.test("successful export returns all 4 sections + user_id + version", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-42", {
+    settings: {
+      data: { user_id: "user-42", data: { theme: "dark" } },
+      error: null,
+    },
+    dictionary: { data: [{ word: "hello" }], error: null },
+    snippets: { data: [{ id: "s1", label: "x" }], error: null },
+    devices: { data: [{ device_id: "d1" }], error: null },
+  });
+  const req = new Request(ENDPOINT, { method: "POST" });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.export_version, 1);
+  assertEquals(body.user_id, "user-42");
+  assertExists(body.exported_at);
+  assertEquals(body.user_settings, { user_id: "user-42", data: { theme: "dark" } });
+  assertEquals(body.user_dictionary_words, [{ word: "hello" }]);
+  assertEquals(body.user_snippets, [{ id: "s1", label: "x" }]);
+  assertEquals(body.user_devices, [{ device_id: "d1" }]);
+  assertEquals(auth.selects.sort(), [
+    "user_devices",
+    "user_dictionary_words",
+    "user_settings",
+    "user_snippets",
+  ]);
+});
+
+Deno.test("export with no data returns null/empty arrays", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-empty");
+  const req = new Request(ENDPOINT, { method: "POST" });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.user_settings, null);
+  assertEquals(body.user_dictionary_words, []);
+  assertEquals(body.user_snippets, []);
+  assertEquals(body.user_devices, []);
+});
+
+Deno.test("DB error on settings returns 500 with the error message", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-1", {
+    settings: { data: null, error: { message: "settings unreachable" } },
+  });
+  const req = new Request(ENDPOINT, { method: "POST" });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 500);
+  assertEquals((await res.json()).error, "settings unreachable");
+});
+
+Deno.test("DB error on dictionary returns 500", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-1", {
+    dictionary: { data: null, error: { message: "dict broken" } },
+  });
+  const req = new Request(ENDPOINT, { method: "POST" });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 500);
+  assertEquals((await res.json()).error, "dict broken");
+});
+
+Deno.test("response from allowed origin includes the origin in Access-Control-Allow-Origin", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-1");
+  const req = new Request(ENDPOINT, {
+    method: "POST",
+    headers: { Origin: "https://tauri.localhost" },
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), "https://tauri.localhost");
+});

--- a/supabase/functions/sync-push/index.ts
+++ b/supabase/functions/sync-push/index.ts
@@ -1,26 +1,34 @@
 // deno-lint-ignore-file no-explicit-any
+import { type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
 import { corsHeaders, preflight } from "../_shared/cors.ts";
 import { getAuthenticatedUser } from "../_shared/auth.ts";
 import { PushBodySchema, QUOTA_BYTES } from "./schema.ts";
 
-function json(body: unknown, status = 200): Response {
+export interface SyncPushDeps {
+  authenticate: (req: Request) => Promise<
+    | { userId: string; client: SupabaseClient<any, any, any>; token?: string }
+    | { error: string; status: number }
+  >;
+}
+
+function json(req: Request, body: unknown, status = 200): Response {
   return new Response(JSON.stringify(body), {
     status,
-    headers: { ...corsHeaders, "Content-Type": "application/json" },
+    headers: { ...corsHeaders(req), "Content-Type": "application/json" },
   });
 }
 
-Deno.serve(async (req) => {
-  if (req.method === "OPTIONS") return preflight();
-  if (req.method !== "POST") return json({ error: "method not allowed" }, 405);
+export async function handler(req: Request, deps: SyncPushDeps): Promise<Response> {
+  if (req.method === "OPTIONS") return preflight(req);
+  if (req.method !== "POST") return json(req, { error: "method not allowed" }, 405);
 
-  const auth = await getAuthenticatedUser(req);
-  if ("error" in auth) return json({ error: auth.error }, auth.status);
+  const auth = await deps.authenticate(req);
+  if ("error" in auth) return json(req, { error: auth.error }, auth.status);
 
   const raw = await req.json().catch(() => null);
   const parsed = PushBodySchema.safeParse(raw);
   if (!parsed.success) {
-    return json({ error: "invalid body", details: parsed.error.flatten() }, 400);
+    return json(req, { error: "invalid body", details: parsed.error.flatten() }, 400);
   }
   const { operations, device_id } = parsed.data;
 
@@ -115,11 +123,12 @@ Deno.serve(async (req) => {
     target_user: userId,
   });
   if (sizeErr) {
-    return json({ error: "quota check failed", details: sizeErr.message }, 500);
+    return json(req, { error: "quota check failed", details: sizeErr.message }, 500);
   }
   const size = Number(sizeData ?? 0);
   if (size > QUOTA_BYTES) {
     return json(
+      req,
       {
         error: "quota exceeded",
         quota_bytes: QUOTA_BYTES,
@@ -130,5 +139,9 @@ Deno.serve(async (req) => {
     );
   }
 
-  return json({ ok: true, server_time: nowIso, current_bytes: size, results });
-});
+  return json(req, { ok: true, server_time: nowIso, current_bytes: size, results });
+}
+
+if (import.meta.main) {
+  Deno.serve((req) => handler(req, { authenticate: getAuthenticatedUser }));
+}

--- a/supabase/functions/sync-push/test.ts
+++ b/supabase/functions/sync-push/test.ts
@@ -1,0 +1,339 @@
+// deno-lint-ignore-file no-explicit-any
+import { assertEquals } from "https://deno.land/std@0.224.0/assert/mod.ts";
+
+const ENDPOINT = "http://localhost/functions/v1/sync-push";
+
+const VALID_SETTINGS = {
+  ui: { theme: "dark" as const, language: "fr" as const },
+  hotkeys: {
+    toggle: "Ctrl+F11",
+    push_to_talk: "Ctrl+F12",
+    open_window: "Ctrl+Alt+O",
+  },
+  features: { auto_paste: "cursor" as const, sound_effects: true },
+  transcription: { provider: "OpenAI" as const, local_model: "tiny" },
+};
+
+interface UpsertCall {
+  kind: "upsert";
+  table: string;
+  record: any;
+  options: any;
+}
+interface UpdateCall {
+  kind: "update";
+  table: string;
+  record: any;
+  eqs: Array<{ col: string; val: any }>;
+}
+interface RpcCall {
+  kind: "rpc";
+  name: string;
+  args: any;
+}
+type ClientCall = UpsertCall | UpdateCall | RpcCall;
+
+interface FakeClientOptions {
+  upsertError?: { table: string; error: any };
+  updateError?: { table: string; error: any };
+  rpcResult?: { data: number | null; error: any };
+}
+
+function makeFakeClient(opts: FakeClientOptions = {}): { client: any; calls: ClientCall[] } {
+  const calls: ClientCall[] = [];
+  const client: any = {
+    from(table: string) {
+      return {
+        upsert(record: any, options: any) {
+          calls.push({ kind: "upsert", table, record, options });
+          if (opts.upsertError && opts.upsertError.table === table) {
+            return Promise.resolve({ error: opts.upsertError.error });
+          }
+          return Promise.resolve({ error: null });
+        },
+        update(record: any) {
+          const eqs: Array<{ col: string; val: any }> = [];
+          calls.push({ kind: "update", table, record, eqs });
+          const filter: any = {
+            eq(col: string, val: any) {
+              eqs.push({ col, val });
+              return filter;
+            },
+            then(resolve: any, reject: any) {
+              const err =
+                opts.updateError && opts.updateError.table === table
+                  ? opts.updateError.error
+                  : null;
+              return Promise.resolve({ error: err }).then(resolve, reject);
+            },
+          };
+          return filter;
+        },
+      };
+    },
+    rpc(name: string, args: any) {
+      calls.push({ kind: "rpc", name, args });
+      return Promise.resolve(opts.rpcResult ?? { data: 100, error: null });
+    },
+  };
+  return { client, calls };
+}
+
+function authOk(userId = "user-1", clientOpts: FakeClientOptions = {}) {
+  const { client, calls } = makeFakeClient(clientOpts);
+  return {
+    authenticate: async () => ({ userId, client }),
+    calls,
+  };
+}
+
+function authFail(error = "invalid token", status = 401) {
+  return {
+    authenticate: async () => ({ error, status }),
+  };
+}
+
+function postJson(body: unknown, headers: Record<string, string> = {}) {
+  return new Request(ENDPOINT, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers,
+  });
+}
+
+Deno.test("OPTIONS from allowed Tauri origin echoes the origin", async () => {
+  const { handler } = await import("./index.ts");
+  const req = new Request(ENDPOINT, {
+    method: "OPTIONS",
+    headers: { Origin: "tauri://localhost" },
+  });
+  const res = await handler(req, authFail());
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), "tauri://localhost");
+  assertEquals(res.headers.get("Vary"), "Origin");
+});
+
+Deno.test("OPTIONS from disallowed origin omits Allow-Origin", async () => {
+  const { handler } = await import("./index.ts");
+  const req = new Request(ENDPOINT, {
+    method: "OPTIONS",
+    headers: { Origin: "https://evil.example.com" },
+  });
+  const res = await handler(req, authFail());
+  assertEquals(res.status, 200);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), null);
+  assertEquals(res.headers.get("Vary"), "Origin");
+});
+
+Deno.test("GET returns 405", async () => {
+  const { handler } = await import("./index.ts");
+  const req = new Request(ENDPOINT, { method: "GET" });
+  const res = await handler(req, authFail());
+  assertEquals(res.status, 405);
+  assertEquals((await res.json()).error, "method not allowed");
+});
+
+Deno.test("auth failure propagates status and message", async () => {
+  const { handler } = await import("./index.ts");
+  const req = postJson({ operations: [], device_id: "x" });
+  const res = await handler(req, authFail("expired token", 401));
+  assertEquals(res.status, 401);
+  assertEquals((await res.json()).error, "expired token");
+});
+
+Deno.test("invalid JSON body returns 400 invalid body", async () => {
+  const { handler } = await import("./index.ts");
+  const req = new Request(ENDPOINT, { method: "POST", body: "not-json" });
+  const res = await handler(req, authOk());
+  assertEquals(res.status, 400);
+  assertEquals((await res.json()).error, "invalid body");
+});
+
+Deno.test("empty operations array fails Zod validation (min 1)", async () => {
+  const { handler } = await import("./index.ts");
+  const req = postJson({ operations: [], device_id: "dev-1" });
+  const res = await handler(req, authOk());
+  assertEquals(res.status, 400);
+});
+
+Deno.test("settings-upsert: posts to user_settings with userId + device_id", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-42");
+  const req = postJson({
+    operations: [{ kind: "settings-upsert", data: VALID_SETTINGS }],
+    device_id: "dev-A",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.ok, true);
+  assertEquals(body.results, [{ index: 0, ok: true }]);
+  const upserts = auth.calls.filter((c): c is UpsertCall => c.kind === "upsert");
+  assertEquals(upserts.length, 1);
+  assertEquals(upserts[0].table, "user_settings");
+  assertEquals(upserts[0].record.user_id, "user-42");
+  assertEquals(upserts[0].record.updated_by_device, "dev-A");
+  assertEquals(upserts[0].options, { onConflict: "user_id" });
+});
+
+Deno.test("dictionary-upsert: clears deleted_at on revival", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk();
+  const req = postJson({
+    operations: [{ kind: "dictionary-upsert", word: "hello" }],
+    device_id: "d",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const upserts = auth.calls.filter((c): c is UpsertCall => c.kind === "upsert");
+  assertEquals(upserts[0].table, "user_dictionary_words");
+  assertEquals(upserts[0].record.word, "hello");
+  assertEquals(upserts[0].record.deleted_at, null);
+  assertEquals(upserts[0].options, { onConflict: "user_id,word" });
+});
+
+Deno.test("dictionary-delete: soft-deletes via upsert with deleted_at set", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk();
+  const req = postJson({
+    operations: [{ kind: "dictionary-delete", word: "obsolete" }],
+    device_id: "d",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const upserts = auth.calls.filter((c): c is UpsertCall => c.kind === "upsert");
+  assertEquals(upserts[0].table, "user_dictionary_words");
+  assertEquals(upserts[0].record.word, "obsolete");
+  assertEquals(typeof upserts[0].record.deleted_at, "string");
+});
+
+Deno.test("snippet-upsert: forwards id, label, content, shortcut", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk();
+  const snippet = {
+    id: "11111111-1111-4111-8111-111111111111",
+    label: "Greeting",
+    content: "Hello world",
+    shortcut: ":hi",
+  };
+  const req = postJson({
+    operations: [{ kind: "snippet-upsert", snippet }],
+    device_id: "d",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const upserts = auth.calls.filter((c): c is UpsertCall => c.kind === "upsert");
+  assertEquals(upserts[0].table, "user_snippets");
+  assertEquals(upserts[0].record.id, snippet.id);
+  assertEquals(upserts[0].record.label, snippet.label);
+  assertEquals(upserts[0].record.content, snippet.content);
+  assertEquals(upserts[0].record.shortcut, snippet.shortcut);
+  assertEquals(upserts[0].record.deleted_at, null);
+});
+
+Deno.test("snippet-delete: scoped update with id + user_id", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-7");
+  const snippetId = "22222222-2222-4222-8222-222222222222";
+  const req = postJson({
+    operations: [{ kind: "snippet-delete", id: snippetId }],
+    device_id: "d",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const updates = auth.calls.filter((c): c is UpdateCall => c.kind === "update");
+  assertEquals(updates.length, 1);
+  assertEquals(updates[0].table, "user_snippets");
+  assertEquals(typeof updates[0].record.deleted_at, "string");
+  assertEquals(updates[0].eqs, [
+    { col: "id", val: snippetId },
+    { col: "user_id", val: "user-7" },
+  ]);
+});
+
+Deno.test("DB error on one op: batch continues, error reported per index", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-1", {
+    upsertError: { table: "user_dictionary_words", error: { message: "db boom" } },
+  });
+  const req = postJson({
+    operations: [
+      { kind: "dictionary-upsert", word: "first" },
+      { kind: "settings-upsert", data: VALID_SETTINGS },
+    ],
+    device_id: "d",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const body = await res.json();
+  assertEquals(body.results.length, 2);
+  assertEquals(body.results[0].ok, false);
+  assertEquals(body.results[0].error, "db boom");
+  assertEquals(body.results[1].ok, true);
+});
+
+Deno.test("RPC quota error returns 500 quota check failed", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-1", {
+    rpcResult: { data: null, error: { message: "rpc down" } },
+  });
+  const req = postJson({
+    operations: [{ kind: "dictionary-upsert", word: "x" }],
+    device_id: "d",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 500);
+  const body = await res.json();
+  assertEquals(body.error, "quota check failed");
+  assertEquals(body.details, "rpc down");
+});
+
+Deno.test("quota exceeded returns 413 with quota_bytes + current_bytes", async () => {
+  const { handler } = await import("./index.ts");
+  const QUOTA = 5 * 1024 * 1024;
+  const over = QUOTA + 1;
+  const auth = authOk("user-1", {
+    rpcResult: { data: over, error: null },
+  });
+  const req = postJson({
+    operations: [{ kind: "dictionary-upsert", word: "x" }],
+    device_id: "d",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 413);
+  const body = await res.json();
+  assertEquals(body.error, "quota exceeded");
+  assertEquals(body.quota_bytes, QUOTA);
+  assertEquals(body.current_bytes, over);
+  assertEquals(body.results.length, 1);
+});
+
+Deno.test("RPC is invoked with target_user = userId", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk("user-rpc-check");
+  const req = postJson({
+    operations: [{ kind: "dictionary-upsert", word: "x" }],
+    device_id: "d",
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.status, 200);
+  const rpcs = auth.calls.filter((c): c is RpcCall => c.kind === "rpc");
+  assertEquals(rpcs.length, 1);
+  assertEquals(rpcs[0].name, "compute_user_sync_size");
+  assertEquals(rpcs[0].args, { target_user: "user-rpc-check" });
+});
+
+Deno.test("response from allowed origin includes the origin in Access-Control-Allow-Origin", async () => {
+  const { handler } = await import("./index.ts");
+  const auth = authOk();
+  const req = new Request(ENDPOINT, {
+    method: "POST",
+    body: JSON.stringify({
+      operations: [{ kind: "dictionary-upsert", word: "x" }],
+      device_id: "d",
+    }),
+    headers: { Origin: "https://tauri.localhost" },
+  });
+  const res = await handler(req, auth);
+  assertEquals(res.headers.get("Access-Control-Allow-Origin"), "https://tauri.localhost");
+});


### PR DESCRIPTION
## Summary
- Replace wildcard `Access-Control-Allow-Origin: *` with an allowlist of Tauri webview origins (`tauri://localhost`, `https://tauri.localhost`) + Vite dev (`http://localhost:1420`). Origin echoed only when whitelisted, `Vary: Origin` set.
- Refactor `sync-push` and `account-export` to expose a testable `handler(req, deps)` with dependency-injected `authenticate`. Backwards-compatible at runtime via `if (import.meta.main) Deno.serve(...)`.
- Add 16 sync-push unit tests + 9 account-export unit tests (Deno test, mocked Supabase client). All 32 Edge Functions tests green (incl. 7 pre-existing on `purge-account-deletions`).
- Fix pre-existing TS2322 in `_shared/auth.ts` that blocked `deno check` (`ReturnType<typeof createClient>` → `SupabaseClient<any, any, any>`).

Closes the ADR 0010 follow-ups *"Lock CORS Edge Functions aux origines Tauri officielles"* and *"Tests Deno Edge Functions"*.

## Test plan
- [x] `deno check` passes on all 5 Edge Functions files
- [x] `deno test` passes 32/32 (16 + 9 + 7)
- [ ] Re-deploy `sync-push` + `account-export` on the dev Supabase project; smoke-test from the running app to confirm CORS still allows the Tauri webview
- [ ] Smoke-test that a `curl` request from `https://evil.example.com` is blocked at preflight

## Notes for reviewer
- `_shared/cors.ts` is now a function `corsHeaders(req)` instead of a static object; both call sites updated to pass `req` to the local `json()` helper.
- The auth.ts type fix is unrelated to CORS but was required to unblock `deno check` — kept in the same PR rather than splitting (single-line change).
- Lint warnings on `https://` imports and `require-await` match the pattern of existing `purge-account-deletions/test.ts`. Not enforced in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)