### PR TITLE
feat(devices): persist app_version + os_version in user_devices

### DIFF
--- a/src-tauri/src/commands/system.rs
+++ b/src-tauri/src/commands/system.rs
@@ -23,6 +23,22 @@ pub async fn get_system_info() -> SystemInfo {
     }
 }
 
+#[derive(Serialize)]
+pub struct DeviceInfo {
+    pub app_version: String,
+    pub os_name: String,
+    pub os_version: String,
+}
+
+#[tauri::command]
+pub fn get_device_info() -> DeviceInfo {
+    DeviceInfo {
+        app_version: env!("CARGO_PKG_VERSION").to_string(),
+        os_name: System::name().unwrap_or_else(|| "Unknown".to_string()),
+        os_version: System::os_version().unwrap_or_else(|| "Unknown".to_string()),
+    }
+}
+
 fn detect_discrete_gpu() -> (bool, Option<String>) {
     let instance = wgpu::Instance::new(wgpu::InstanceDescriptor {
         backends: wgpu::Backends::VULKAN | wgpu::Backends::DX12,
@@ -41,5 +57,31 @@ fn detect_discrete_gpu() -> (bool, Option<String>) {
     match discrete {
         Some(a) => (true, Some(a.get_info().name)),
         None => (false, None),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn device_info_app_version_matches_cargo_pkg() {
+        let info = get_device_info();
+        assert_eq!(info.app_version, env!("CARGO_PKG_VERSION"));
+        assert!(!info.app_version.is_empty(), "app_version must not be empty");
+        // user_devices_app_version_len constraint: <= 50 chars.
+        assert!(
+            info.app_version.chars().count() <= 50,
+            "app_version length must fit DB constraint (50 chars)"
+        );
+    }
+
+    #[test]
+    fn device_info_os_fields_present() {
+        let info = get_device_info();
+        // sysinfo may return "Unknown" on minimal/sandboxed environments — accept that
+        // but never an empty string (we always coerce to "Unknown").
+        assert!(!info.os_name.is_empty(), "os_name must never be empty");
+        assert!(!info.os_version.is_empty(), "os_version must never be empty");
     }
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -91,6 +91,7 @@ pub fn run() {
             commands::model::any_local_model_exists,
             commands::model::delete_local_model,
             commands::system::get_system_info,
+            commands::system::get_device_info,
             commands::files::delete_recording_files,
             commands::ai::ai_process_text,
             commands::ai::post_process_text,

--- a/src/components/settings/sections/DevicesList.tsx
+++ b/src/components/settings/sections/DevicesList.tsx
@@ -7,6 +7,7 @@ interface DeviceRow {
   id: string;
   device_fingerprint: string;
   os_name: string | null;
+  os_version: string | null;
   app_version: string | null;
   last_seen_at: string;
 }
@@ -54,7 +55,7 @@ export function DevicesList() {
     }
     const { data } = await supabase
       .from("user_devices")
-      .select("id,device_fingerprint,os_name,app_version,last_seen_at")
+      .select("id,device_fingerprint,os_name,os_version,app_version,last_seen_at")
       .order("last_seen_at", { ascending: false });
     setDevices(data ?? []);
     setLoaded(true);
@@ -158,6 +159,7 @@ export function DevicesList() {
                   <div className="flex items-center gap-2">
                     <span className="text-[13px] font-medium">
                       {d.os_name ?? t("auth.security.unknownOs", { defaultValue: "Appareil inconnu" })}
+                      {d.os_version ? ` ${d.os_version}` : ""}
                       {d.app_version ? ` · ${d.app_version}` : ""}
                     </span>
                     {current && (

--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -260,20 +260,33 @@ export function AuthProvider({ children }: { children: ReactNode }) {
   async function upsertDevice(userId: string) {
     try {
       const fp = await invoke<string>("get_or_create_device_id");
-      const osName = typeof navigator !== "undefined" ? navigator.platform || "Unknown" : "Unknown";
-      // TODO(v3.1): include app_version via a Tauri command when exposed.
+      let osName = typeof navigator !== "undefined" ? navigator.platform || "Unknown" : "Unknown";
+      let osVersion: string | null = null;
+      let appVersion: string | null = null;
+      try {
+        const info = await invoke<{ app_version: string; os_name: string; os_version: string }>(
+          "get_device_info",
+        );
+        appVersion = info.app_version;
+        osVersion = info.os_version;
+        if (info.os_name) osName = info.os_name;
+      } catch (e) {
+        flog(`get_device_info failed, falling back to navigator.platform: ${e}`, "warn");
+      }
       const { error } = await supabase.from("user_devices").upsert(
         {
           user_id: userId,
           device_fingerprint: fp,
           os_name: osName,
+          os_version: osVersion,
+          app_version: appVersion,
           last_seen_at: new Date().toISOString(),
         },
         { onConflict: "user_id,device_fingerprint" },
       );
-      if (error) console.warn("upsert user_devices failed", error.message);
+      if (error) flog(`upsert user_devices failed: ${error.message}`, "warn");
     } catch (e) {
-      console.warn("device upsert skipped", e);
+      flog(`device upsert skipped: ${e}`, "warn");
     }
   }
 

--- a/supabase/migrations/20260601000300_user_devices_length_limits.sql
+++ b/supabase/migrations/20260601000300_user_devices_length_limits.sql
@@ -1,0 +1,13 @@
+-- Bound user-controlled metadata columns to prevent oversized payloads
+-- (e.g. spoofed clients) from bloating the table or breaking UI display.
+-- Source: docs/superpowers/plans/2026-04-26-v3-post-review-fixes.md (Task 14, Step 4).
+--
+-- Values populated by the desktop client via `get_device_info` Tauri command:
+--   - app_version: env!("CARGO_PKG_VERSION") — semver, in practice <= 30 chars.
+--   - os_name / os_version: sysinfo::System::{name, os_version} — vendor-defined, in
+--     practice <= 50 chars but capped at 100 for safety.
+
+alter table public.user_devices
+  add constraint user_devices_os_name_len check (char_length(os_name) <= 100),
+  add constraint user_devices_os_version_len check (char_length(os_version) <= 100),
+  add constraint user_devices_app_version_len check (char_length(app_version) <= 50);

--- a/supabase/tests/constraints_user_devices.sql
+++ b/supabase/tests/constraints_user_devices.sql
@@ -1,0 +1,58 @@
+begin;
+select plan(6);
+
+-- Fixture
+insert into auth.users (id, email, aud, role) values
+  ('11111111-1111-1111-1111-111111111111', 'a@test.local', 'authenticated', 'authenticated');
+
+set local role authenticated;
+set local "request.jwt.claim.sub" = '11111111-1111-1111-1111-111111111111';
+
+-- Boundary values pass (50 / 100 / 100 chars exactly).
+select lives_ok(
+  $$ insert into public.user_devices (user_id, device_fingerprint, app_version, os_name, os_version) values
+     ('11111111-1111-1111-1111-111111111111', 'fp-boundary',
+      repeat('a', 50), repeat('b', 100), repeat('c', 100)) $$,
+  'app_version=50 / os_name=100 / os_version=100 chars accepted'
+);
+
+-- Above the cap is rejected with the expected check_violation code (23514).
+select throws_ok(
+  $$ insert into public.user_devices (user_id, device_fingerprint, app_version) values
+     ('11111111-1111-1111-1111-111111111111', 'fp-overflow-app', repeat('a', 51)) $$,
+  '23514',
+  null,
+  'app_version > 50 chars rejected by user_devices_app_version_len'
+);
+
+select throws_ok(
+  $$ insert into public.user_devices (user_id, device_fingerprint, os_name) values
+     ('11111111-1111-1111-1111-111111111111', 'fp-overflow-osname', repeat('b', 101)) $$,
+  '23514',
+  null,
+  'os_name > 100 chars rejected by user_devices_os_name_len'
+);
+
+select throws_ok(
+  $$ insert into public.user_devices (user_id, device_fingerprint, os_version) values
+     ('11111111-1111-1111-1111-111111111111', 'fp-overflow-osversion', repeat('c', 101)) $$,
+  '23514',
+  null,
+  'os_version > 100 chars rejected by user_devices_os_version_len'
+);
+
+-- NULL values stay valid (the columns are nullable; constraints only fire on non-NULL inputs).
+select lives_ok(
+  $$ insert into public.user_devices (user_id, device_fingerprint, app_version, os_name, os_version) values
+     ('11111111-1111-1111-1111-111111111111', 'fp-nulls', null, null, null) $$,
+  'NULL values accepted (constraints only apply to non-NULL)'
+);
+
+-- Cleanup
+set local role postgres;
+delete from auth.users where id = '11111111-1111-1111-1111-111111111111';
+
+select pass('Cleanup OK');
+
+select * from finish();
+rollback;


### PR DESCRIPTION
## Summary

- Adds `get_device_info` Tauri command exposing `CARGO_PKG_VERSION` and `sysinfo` OS name/version (`src-tauri/src/commands/system.rs`).
- `AuthContext.upsertDevice` now populates the `app_version` and `os_version` columns on `user_devices` — they were previously left `NULL` despite the schema and Settings → Security UI already expecting them. `console.warn` swapped for `flog` in the same function.
- `DevicesList.tsx` displays `os_version` next to `os_name` ("Windows 11 · 3.0.0-beta.4").
- Migration `20260601000300_user_devices_length_limits.sql`: bound `app_version <= 50`, `os_name`/`os_version <= 100` to guard against oversized payloads (Step 4 of the v3 post-review hardening plan).
- pgtap test `constraints_user_devices.sql` covers boundary, overflow (per column), and NULL.

Closes the `TODO(v3.1)` left in `AuthContext.tsx:264`.

## Test plan

- [x] `cargo test commands::system` (2/2 pass — `app_version` matches `CARGO_PKG_VERSION`, OS fields non-empty)
- [x] `cargo check --no-default-features`
- [x] `pnpm build` (tsc + vite)
- [x] `pnpm test` (90/90)
- [ ] CI pgtap suite picks up the new test
- [ ] Manual: sign in, verify `user_devices` row has `app_version` + `os_version` populated, and Settings → Security shows the formatted label.