### PR TITLE
fix(2fa): pass userId to admin.mfa.deleteFactor in recovery flow

### DIFF
--- a/supabase/functions/consume-recovery-code/index.ts
+++ b/supabase/functions/consume-recovery-code/index.ts
@@ -92,7 +92,7 @@ function realDeps(): Deps {
       const { data, error: listErr } = await (admin.auth.admin as any).mfa.listFactors({ userId });
       if (listErr) return { error: listErr };
       for (const f of data?.factors ?? []) {
-        const { error: delErr } = await (admin.auth.admin as any).mfa.deleteFactor({ id: f.id });
+        const { error: delErr } = await (admin.auth.admin as any).mfa.deleteFactor({ id: f.id, userId });
         if (delErr) return { error: delErr };
       }
       return { error: null };


### PR DESCRIPTION
## Summary
- Pass `userId` alongside `id` to `admin.mfa.deleteFactor` when consuming a recovery code, mirroring the `listFactors({ userId })` call just above.

## Test plan
- [ ] Consume a recovery code on an account with an active TOTP factor → factor is removed and 2FA is disabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)