### PR TITLE
fix(edge-functions): switch from esm.sh to npm: imports

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,9 +61,9 @@ jobs:
       - uses: actions/checkout@v4
       - uses: denoland/setup-deno@v2
         with:
-          deno-version: v1.x
+          deno-version: v2.x
       - name: Run all tests in supabase/functions
-        run: deno test --allow-env --allow-net supabase/functions/
+        run: deno test --allow-env --allow-net --allow-read --config supabase/functions/deno.json supabase/functions/
 
   pgtap:
     name: Database tests (pgtap)

--- a/supabase/functions/_shared/auth.ts
+++ b/supabase/functions/_shared/auth.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { createClient, type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { createClient, type SupabaseClient } from "npm:@supabase/supabase-js@2.49.1";
 
 /** Extrait le user_id depuis le JWT présenté dans Authorization: Bearer <token>.
  *  Retourne { userId, client } où client a les permissions du user (RLS actif). */

--- a/supabase/functions/_shared/rate-limit.ts
+++ b/supabase/functions/_shared/rate-limit.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { type SupabaseClient } from "npm:@supabase/supabase-js@2.49.1";
 
 /**
  * Returns true if the operation should be rejected (rate-limit exceeded).

--- a/supabase/functions/account-export/deno.json
+++ b/supabase/functions/account-export/deno.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.49.1"
-  }
-}

--- a/supabase/functions/account-export/index.ts
+++ b/supabase/functions/account-export/index.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { type SupabaseClient } from "npm:@supabase/supabase-js@2.49.1";
 import { corsHeaders, preflight } from "../_shared/cors.ts";
 import { getAuthenticatedUser } from "../_shared/auth.ts";
 import { isRateLimited } from "../_shared/rate-limit.ts";

--- a/supabase/functions/consume-recovery-code/index.ts
+++ b/supabase/functions/consume-recovery-code/index.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { createClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { createClient } from "npm:@supabase/supabase-js@2.49.1";
 import { corsHeaders, preflight } from "../_shared/cors.ts";
 import { getAuthenticatedUser } from "../_shared/auth.ts";
 import { isRateLimited } from "../_shared/rate-limit.ts";

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,3 @@
+{
+  "nodeModulesDir": "auto"
+}

--- a/supabase/functions/purge-account-deletions/deno.json
+++ b/supabase/functions/purge-account-deletions/deno.json
@@ -1,5 +1,0 @@
-{
-  "imports": {
-    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.49.1"
-  }
-}

--- a/supabase/functions/purge-account-deletions/index.ts
+++ b/supabase/functions/purge-account-deletions/index.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { createClient, SupabaseClient } from "@supabase/supabase-js";
+import { createClient, SupabaseClient } from "npm:@supabase/supabase-js@2.49.1";
 
 interface Deps {
   cronSecret: string;

--- a/supabase/functions/sync-push/deno.json
+++ b/supabase/functions/sync-push/deno.json
@@ -1,6 +1,0 @@
-{
-  "imports": {
-    "@supabase/supabase-js": "https://esm.sh/@supabase/supabase-js@2.49.1",
-    "zod": "https://esm.sh/zod@3.23.8"
-  }
-}

--- a/supabase/functions/sync-push/index.ts
+++ b/supabase/functions/sync-push/index.ts
@@ -1,5 +1,5 @@
 // deno-lint-ignore-file no-explicit-any
-import { type SupabaseClient } from "https://esm.sh/@supabase/supabase-js@2.49.1";
+import { type SupabaseClient } from "npm:@supabase/supabase-js@2.49.1";
 import { corsHeaders, preflight } from "../_shared/cors.ts";
 import { getAuthenticatedUser } from "../_shared/auth.ts";
 import { isRateLimited } from "../_shared/rate-limit.ts";

--- a/supabase/functions/sync-push/schema.ts
+++ b/supabase/functions/sync-push/schema.ts
@@ -1,4 +1,4 @@
-import { z } from "zod";
+import { z } from "npm:zod@3.23.8";
 
 export const CloudSettingsDataSchema = z.object({
   ui: z.object({


### PR DESCRIPTION
## Context

The `Edge functions tests (Deno)` CI check failed on the last run with HTTP 522 (Cloudflare timeout) when fetching `https://esm.sh/@supabase/supabase-js@2.49.1`. esm.sh has a known reliability issue. With `main` now requiring this check to be green, transient esm.sh outages would block every PR.

## Change

- Replace `https://esm.sh/...` imports with `npm:...` specifiers (resolved via npm registry — far more reliable, recommended by Supabase since 2 years)
- Drop the now-redundant per-function `deno.json` files
- Add a single `supabase/functions/deno.json` with `nodeModulesDir: "auto"` so Deno's node_modules is scoped to `supabase/functions/`, not colliding with pnpm's at repo root
- Pass `--config supabase/functions/deno.json` and `--allow-read` in CI; bump setup-deno to v2.x

## Test plan

- [x] `deno test --allow-env --allow-net --allow-read --config supabase/functions/deno.json supabase/functions/` — 47/47 passed locally
- [ ] CI green on this PR
- [ ] After merge: add `Edge functions tests (Deno)` to required status checks on `main`

🤖 Generated with [Claude Code](https://claude.com/claude-code)