### PR TITLE
feat(emails): branded Supabase Auth templates (phase 1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,9 @@ lerna-debug.log*
 node_modules
 dist
 dist-ssr
+# Email-specific dist is committed for traceability — Vite-built dist remains ignored
+!/dist/emails/
+!/dist/emails/**
 *.local
 
 # Editor directories and files

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -360,6 +360,22 @@ Built with React 19, TypeScript, and Tailwind CSS v4.
 - Checklist E2E : `docs/v3/02-sync-settings-e2e-checklist.md`
 - ADR de clôture : `docs/v3/decisions/0010-sub-epic-02-closure.md`
 
+### V3 Email templates Supabase Auth (livré phase 1, 2026-05-02)
+
+- Source de vérité : `emails/templates/*.tsx` (React Email + `@react-email/components` 1.0.12)
+- 3 templates Supabase Auth : `MagicLink`, `SignupConfirmation`, `PasswordReset` (EN uniquement v3.0)
+- Build : `pnpm email:build` → `dist/emails/*.html` (commités pour traçabilité)
+- Preview : `pnpm email:dev` → `localhost:3001` (nécessite `@react-email/ui` en devDep)
+- Composants partagés : `emails/components/` (Layout, Header, Footer, Button, Heading, Text, SecurityNote, tokens)
+- `tokens.ts` : `colors`, `fontStack` (Inter + fallbacks), `logoUrl` (GitHub raw monogram, placeholder à migrer post-marketing site)
+- Liquid safety : `unescapeLiquid()` dans `build.tsx` post-traite le HTML pour préserver `{{ .ConfirmationURL }}`
+- Tests : 23 vitest (4 tokens + 18 templates + 5 build dont 1 regression `git show HEAD:dist/...`)
+- Procédure de déploiement Supabase : `emails/DEPLOY_SUPABASE.md` (manuel, dashboard)
+- Checklist multi-clients : `emails/COMPATIBILITY.md` (à remplir via Litmus / Email on Acid)
+- Phase 2 prévue : 4 templates Resend via Edge Functions (welcome, new-device, deletion ×2)
+- Spec : `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md`
+- Plan : `docs/superpowers/plans/2026-05-02-email-templates-supabase-auth.md`
+
 ## Commit and Push
 
 - Use conventional commits: - Format: `<type>: <message>`

--- a/dist/emails/magic-link.html
+++ b/dist/emails/magic-link.html
@@ -1,0 +1,196 @@
+<!-- Subject: Sign in to Lexena -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <link
+      rel="preload"
+      as="image"
+      href="https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png" />
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <style>
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 400;
+        mso-font-alt: 'Helvetica';
+        src: url(https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap) format('woff2');
+      }
+
+      * {
+        font-family: 'Inter', Helvetica;
+      }
+    </style>
+  </head>
+  <body style="background-color:#F6F6F7;margin:0;padding:0">
+    <!--$--><!--html--><!--head-->
+    <div
+      style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
+      data-skip-in-text="true">
+      Sign in to your Lexena account
+      <div>
+         ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+      </div>
+    </div>
+    <!--body-->
+    <table
+      border="0"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      align="center">
+      <tbody>
+        <tr>
+          <td
+            style="background-color:#F6F6F7;font-family:Inter, -apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, Helvetica, Arial, sans-serif;margin:0;padding:32px 0">
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="max-width:560px;background-color:#FFFFFF;border-radius:12px;margin:0 auto;overflow:hidden;box-shadow:0 1px 3px rgba(0, 0, 0, 0.05)">
+              <tbody>
+                <tr style="width:100%">
+                  <td>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="background-color:#0D1B2A;padding:32px 0;text-align:center">
+                      <tbody>
+                        <tr>
+                          <td>
+                            <img
+                              alt="Lexena"
+                              height="56"
+                              src="https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png"
+                              style="display:block;outline:none;border:none;text-decoration:none;margin:0 auto;border-radius:8px"
+                              width="56" />
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="padding:40px">
+                      <tbody>
+                        <tr>
+                          <td>
+                            <h1
+                              style="color:#0D1B2A;font-size:24px;font-weight:600;line-height:32px;margin:0 0 16px 0">
+                              Sign in to Lexena
+                            </h1>
+                            <p
+                              style="font-size:16px;line-height:26px;color:#374151;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              Click the button below to sign in to your account.
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="text-align:center;margin:32px 0">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <a
+                                      href="{{ .ConfirmationURL }}"
+                                      style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;background-color:#1D9E75;color:#FFFFFF;padding:14px 28px;border-radius:8px;font-size:16px;font-weight:500;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px"
+                                      target="_blank"
+                                      ><span
+                                        ><!--[if mso]><i style="mso-font-width:466.6666666666667%;mso-text-raise:21" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
+                                      ><span
+                                        style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:10.5px"
+                                        >Sign in</span
+                                      ><span
+                                        ><!--[if mso]><i style="mso-font-width:466.6666666666667%" hidden>&#8202;&#8202;&#8202;&#8203;</i><![endif]--></span
+                                      ></a
+                                    >
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <p
+                              style="font-size:14px;line-height:22px;color:#6B7280;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              This link is valid for 1 hour and can only be used
+                              once.
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="background-color:#F3F4F6;border-left:3px solid #1D9E75;border-radius:6px;padding:16px;margin:24px 0">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <p
+                                      style="font-size:14px;line-height:22px;color:#374151;font-style:italic;margin:0;margin-top:0;margin-bottom:0;margin-left:0;margin-right:0">
+                                      Didn&#x27;t request this sign-in? You can
+                                      safely ignore this message — your account
+                                      remains secure.
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <p
+                              style="font-size:14px;line-height:22px;color:#6B7280;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              — The Lexena team
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="padding:0 40px 32px 40px">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <hr
+                                      style="width:100%;border:none;border-top:1px solid #eaeaea;border-color:#E5E7EB;margin:32px 0 24px 0" />
+                                    <p
+                                      style="font-size:12px;line-height:18px;color:#6B7280;margin:0;margin-top:0;margin-bottom:0;margin-left:0;margin-right:0">
+                                      Lexena · lexena.app
+                                    </p>
+                                    <p
+                                      style="font-size:12px;line-height:18px;color:#6B7280;margin:8px 0 0 0;margin-top:8px;margin-right:0;margin-bottom:0;margin-left:0">
+                                      You received this email because of a
+                                      sign-in request on your Lexena account.
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <!--/$-->
+  </body>
+</html>

--- a/dist/emails/password-reset.html
+++ b/dist/emails/password-reset.html
@@ -1,0 +1,199 @@
+<!-- Subject: Reset your Lexena password -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <link
+      rel="preload"
+      as="image"
+      href="https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png" />
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <style>
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 400;
+        mso-font-alt: 'Helvetica';
+        src: url(https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap) format('woff2');
+      }
+
+      * {
+        font-family: 'Inter', Helvetica;
+      }
+    </style>
+  </head>
+  <body style="background-color:#F6F6F7;margin:0;padding:0">
+    <!--$--><!--html--><!--head-->
+    <div
+      style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
+      data-skip-in-text="true">
+      Reset your Lexena password
+      <div>
+         ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+      </div>
+    </div>
+    <!--body-->
+    <table
+      border="0"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      align="center">
+      <tbody>
+        <tr>
+          <td
+            style="background-color:#F6F6F7;font-family:Inter, -apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, Helvetica, Arial, sans-serif;margin:0;padding:32px 0">
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="max-width:560px;background-color:#FFFFFF;border-radius:12px;margin:0 auto;overflow:hidden;box-shadow:0 1px 3px rgba(0, 0, 0, 0.05)">
+              <tbody>
+                <tr style="width:100%">
+                  <td>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="background-color:#0D1B2A;padding:32px 0;text-align:center">
+                      <tbody>
+                        <tr>
+                          <td>
+                            <img
+                              alt="Lexena"
+                              height="56"
+                              src="https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png"
+                              style="display:block;outline:none;border:none;text-decoration:none;margin:0 auto;border-radius:8px"
+                              width="56" />
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="padding:40px">
+                      <tbody>
+                        <tr>
+                          <td>
+                            <h1
+                              style="color:#0D1B2A;font-size:24px;font-weight:600;line-height:32px;margin:0 0 16px 0">
+                              Reset your password
+                            </h1>
+                            <p
+                              style="font-size:16px;line-height:26px;color:#374151;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              Click the button below to choose a new password.
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="text-align:center;margin:32px 0">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <a
+                                      href="{{ .ConfirmationURL }}"
+                                      style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;background-color:#1D9E75;color:#FFFFFF;padding:14px 28px;border-radius:8px;font-size:16px;font-weight:500;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px"
+                                      target="_blank"
+                                      ><span
+                                        ><!--[if mso]><i style="mso-font-width:466.6666666666667%;mso-text-raise:21" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
+                                      ><span
+                                        style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:10.5px"
+                                        >Reset password</span
+                                      ><span
+                                        ><!--[if mso]><i style="mso-font-width:466.6666666666667%" hidden>&#8202;&#8202;&#8202;&#8203;</i><![endif]--></span
+                                      ></a
+                                    >
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <p
+                              style="font-size:14px;line-height:22px;color:#6B7280;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              This link is valid for 1 hour and can only be used
+                              once.
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="background-color:#F3F4F6;border-left:3px solid #1D9E75;border-radius:6px;padding:16px;margin:24px 0">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <p
+                                      style="font-size:14px;line-height:22px;color:#374151;font-style:italic;margin:0;margin-top:0;margin-bottom:0;margin-left:0;margin-right:0">
+                                      If you didn&#x27;t request this, ignore
+                                      this message — your current password
+                                      remains valid. On the next successful
+                                      login after reset, all your active
+                                      sessions on other devices will be revoked.
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <p
+                              style="font-size:14px;line-height:22px;color:#6B7280;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              — The Lexena team
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="padding:0 40px 32px 40px">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <hr
+                                      style="width:100%;border:none;border-top:1px solid #eaeaea;border-color:#E5E7EB;margin:32px 0 24px 0" />
+                                    <p
+                                      style="font-size:12px;line-height:18px;color:#6B7280;margin:0;margin-top:0;margin-bottom:0;margin-left:0;margin-right:0">
+                                      Lexena · lexena.app
+                                    </p>
+                                    <p
+                                      style="font-size:12px;line-height:18px;color:#6B7280;margin:8px 0 0 0;margin-top:8px;margin-right:0;margin-bottom:0;margin-left:0">
+                                      You received this email because of a
+                                      password reset request on your Lexena
+                                      account.
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <!--/$-->
+  </body>
+</html>

--- a/dist/emails/signup-confirmation.html
+++ b/dist/emails/signup-confirmation.html
@@ -1,0 +1,195 @@
+<!-- Subject: Confirm your Lexena email address -->
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html dir="ltr" lang="en">
+  <head>
+    <link
+      rel="preload"
+      as="image"
+      href="https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png" />
+    <meta content="text/html; charset=UTF-8" http-equiv="Content-Type" />
+    <meta name="x-apple-disable-message-reformatting" />
+    <style>
+      @font-face {
+        font-family: 'Inter';
+        font-style: normal;
+        font-weight: 400;
+        mso-font-alt: 'Helvetica';
+        src: url(https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap) format('woff2');
+      }
+
+      * {
+        font-family: 'Inter', Helvetica;
+      }
+    </style>
+  </head>
+  <body style="background-color:#F6F6F7;margin:0;padding:0">
+    <!--$--><!--html--><!--head-->
+    <div
+      style="display:none;overflow:hidden;line-height:1px;opacity:0;max-height:0;max-width:0"
+      data-skip-in-text="true">
+      Confirm your Lexena email to finalize your account
+      <div>
+         ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿ ‌​‍‎‏﻿
+      </div>
+    </div>
+    <!--body-->
+    <table
+      border="0"
+      width="100%"
+      cellpadding="0"
+      cellspacing="0"
+      role="presentation"
+      align="center">
+      <tbody>
+        <tr>
+          <td
+            style="background-color:#F6F6F7;font-family:Inter, -apple-system, BlinkMacSystemFont, &#x27;Segoe UI&#x27;, Helvetica, Arial, sans-serif;margin:0;padding:32px 0">
+            <table
+              align="center"
+              width="100%"
+              border="0"
+              cellpadding="0"
+              cellspacing="0"
+              role="presentation"
+              style="max-width:560px;background-color:#FFFFFF;border-radius:12px;margin:0 auto;overflow:hidden;box-shadow:0 1px 3px rgba(0, 0, 0, 0.05)">
+              <tbody>
+                <tr style="width:100%">
+                  <td>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="background-color:#0D1B2A;padding:32px 0;text-align:center">
+                      <tbody>
+                        <tr>
+                          <td>
+                            <img
+                              alt="Lexena"
+                              height="56"
+                              src="https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png"
+                              style="display:block;outline:none;border:none;text-decoration:none;margin:0 auto;border-radius:8px"
+                              width="56" />
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                    <table
+                      align="center"
+                      width="100%"
+                      border="0"
+                      cellpadding="0"
+                      cellspacing="0"
+                      role="presentation"
+                      style="padding:40px">
+                      <tbody>
+                        <tr>
+                          <td>
+                            <h1
+                              style="color:#0D1B2A;font-size:24px;font-weight:600;line-height:32px;margin:0 0 16px 0">
+                              Welcome to Lexena
+                            </h1>
+                            <p
+                              style="font-size:16px;line-height:26px;color:#374151;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              To finalize your account creation, please confirm
+                              your email address.
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="text-align:center;margin:32px 0">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <a
+                                      href="{{ .ConfirmationURL }}"
+                                      style="line-height:100%;text-decoration:none;display:inline-block;max-width:100%;mso-padding-alt:0px;background-color:#1D9E75;color:#FFFFFF;padding:14px 28px;border-radius:8px;font-size:16px;font-weight:500;padding-top:14px;padding-right:28px;padding-bottom:14px;padding-left:28px"
+                                      target="_blank"
+                                      ><span
+                                        ><!--[if mso]><i style="mso-font-width:466.6666666666667%;mso-text-raise:21" hidden>&#8202;&#8202;&#8202;</i><![endif]--></span
+                                      ><span
+                                        style="max-width:100%;display:inline-block;line-height:120%;mso-padding-alt:0px;mso-text-raise:10.5px"
+                                        >Confirm my email</span
+                                      ><span
+                                        ><!--[if mso]><i style="mso-font-width:466.6666666666667%" hidden>&#8202;&#8202;&#8202;&#8203;</i><![endif]--></span
+                                      ></a
+                                    >
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <p
+                              style="font-size:14px;line-height:22px;color:#6B7280;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              This link is valid for 24 hours.
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="background-color:#F3F4F6;border-left:3px solid #1D9E75;border-radius:6px;padding:16px;margin:24px 0">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <p
+                                      style="font-size:14px;line-height:22px;color:#374151;font-style:italic;margin:0;margin-top:0;margin-bottom:0;margin-left:0;margin-right:0">
+                                      Didn&#x27;t create a Lexena account? You
+                                      can safely ignore this message.
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                            <p
+                              style="font-size:14px;line-height:22px;color:#6B7280;margin:0 0 16px 0;margin-top:0;margin-right:0;margin-bottom:16px;margin-left:0">
+                              — The Lexena team
+                            </p>
+                            <table
+                              align="center"
+                              width="100%"
+                              border="0"
+                              cellpadding="0"
+                              cellspacing="0"
+                              role="presentation"
+                              style="padding:0 40px 32px 40px">
+                              <tbody>
+                                <tr>
+                                  <td>
+                                    <hr
+                                      style="width:100%;border:none;border-top:1px solid #eaeaea;border-color:#E5E7EB;margin:32px 0 24px 0" />
+                                    <p
+                                      style="font-size:12px;line-height:18px;color:#6B7280;margin:0;margin-top:0;margin-bottom:0;margin-left:0;margin-right:0">
+                                      Lexena · lexena.app
+                                    </p>
+                                    <p
+                                      style="font-size:12px;line-height:18px;color:#6B7280;margin:8px 0 0 0;margin-top:8px;margin-right:0;margin-bottom:0;margin-left:0">
+                                      You received this email because someone
+                                      signed up to Lexena with this address.
+                                    </p>
+                                  </td>
+                                </tr>
+                              </tbody>
+                            </table>
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <!--/$-->
+  </body>
+</html>

--- a/docs/superpowers/plans/2026-05-02-email-templates-supabase-auth.md
+++ b/docs/superpowers/plans/2026-05-02-email-templates-supabase-auth.md
@@ -1,0 +1,1609 @@
+# Email Templates Phase 1 — Supabase Auth Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build 3 branded HTML email templates (magic link, signup confirmation, password reset) for Supabase Auth using React Email, replacing the default Supabase templates.
+
+**Architecture:** A standalone `emails/` subdirectory at repo root containing React Email components (`Layout`, `Header`, `Footer`, `Button`, `Heading`, `Text`, `SecurityNote`) and 3 templates (`MagicLink`, `SignupConfirmation`, `PasswordReset`). A `build.ts` script renders each template to `dist/emails/*.html`. Compiled HTML is committed for traceability and pasted manually into Supabase Dashboard. Vitest snapshot tests guard against drift. Single root `package.json` — React Email goes in root `devDependencies`.
+
+**Tech Stack:** React Email (`@react-email/components`, `@react-email/render`), `react-email` CLI for live preview, `tsx` (already in devDeps) for running the build script, `vitest` (already in devDeps) for snapshot tests.
+
+**Reference spec:** `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md`
+
+**Working branch:** `feat/email-templates` (already created)
+
+---
+
+## File Structure
+
+```
+emails/
+├── tsconfig.json                       ← Local TS config extending repo's
+├── components/
+│   ├── tokens.ts                       ← Colors, font stack, logo URL, spacing
+│   ├── EmailLayout.tsx                 ← Html, Head, Body, Container shell
+│   ├── EmailHeader.tsx                 ← Navy header with monogram image
+│   ├── EmailFooter.tsx                 ← Footer "Lexena · lexena.app"
+│   ├── EmailButton.tsx                 ← Signal Green CTA
+│   ├── EmailHeading.tsx                ← Styled H1
+│   ├── EmailText.tsx                   ← Styled paragraph (default + muted)
+│   └── EmailSecurityNote.tsx           ← Bordered security callout box
+├── templates/
+│   ├── MagicLink.tsx                   ← Component + subject export
+│   ├── SignupConfirmation.tsx
+│   └── PasswordReset.tsx
+├── build.ts                            ← Renders templates → dist/emails/*.html
+├── README.md                           ← Edit/deploy procedure
+└── __tests__/
+    ├── tokens.test.ts                  ← Token shape assertion
+    ├── templates.test.ts               ← Per-template content + Liquid var assertions
+    └── build.test.ts                   ← End-to-end build + snapshot regression
+
+dist/emails/                            ← Compiled HTML, committed
+├── magic-link.html
+├── signup-confirmation.html
+└── password-reset.html
+```
+
+**Decisions locked in by this plan:**
+- Single root `package.json`. No pnpm workspace.
+- `dist/emails/*.html` committed to git.
+- No `RESEND_API_KEY` needed at this stage (Supabase Auth handles delivery).
+
+---
+
+## Task 1: Install React Email dependencies
+
+**Files:**
+- Modify: `package.json`
+
+- [ ] **Step 1: Install React Email packages**
+
+```bash
+pnpm add -D @react-email/components @react-email/render react-email
+```
+
+Expected: 3 new entries in `devDependencies` of `package.json`. `pnpm-lock.yaml` updated.
+
+- [ ] **Step 2: Verify installation**
+
+```bash
+pnpm list @react-email/components @react-email/render react-email
+```
+
+Expected: Each listed with a version number, no warnings about missing peer deps.
+
+- [ ] **Step 3: Add email scripts to `package.json`**
+
+In the `"scripts"` block, add:
+
+```json
+"email:dev": "cd emails && react-email dev --port 3001",
+"email:build": "tsx emails/build.ts"
+```
+
+Note: Port 3001 to avoid collision with Vite (1420) and other tools. The `build` command is run from repo root via `tsx`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add package.json pnpm-lock.yaml
+git commit -m "chore: add React Email dependencies for transactional emails"
+```
+
+---
+
+## Task 2: Create `emails/` directory and TypeScript config
+
+**Files:**
+- Create: `emails/tsconfig.json`
+- Create: `emails/.gitkeep` (temporary)
+
+- [ ] **Step 1: Create the directory**
+
+```bash
+mkdir -p emails/components emails/templates emails/__tests__
+```
+
+- [ ] **Step 2: Write `emails/tsconfig.json`**
+
+```json
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}
+```
+
+- [ ] **Step 3: Verify TypeScript can resolve the directory**
+
+```bash
+pnpm exec tsc --project emails/tsconfig.json --noEmit
+```
+
+Expected: No output (success). If errors complain about no input files, that's fine for now — we'll add files in next tasks.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add emails/tsconfig.json
+git commit -m "chore: scaffold emails/ directory with TS config"
+```
+
+---
+
+## Task 3: Create tokens module (TDD)
+
+**Files:**
+- Create: `emails/components/tokens.ts`
+- Create: `emails/__tests__/tokens.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `emails/__tests__/tokens.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { colors, fontStack, logoUrl, spacing } from "../components/tokens";
+
+describe("tokens", () => {
+  it("exposes Lexena brand colors", () => {
+    expect(colors.navy).toBe("#0D1B2A");
+    expect(colors.signalGreen).toBe("#1D9E75");
+    expect(colors.bg).toBe("#F6F6F7");
+    expect(colors.card).toBe("#FFFFFF");
+  });
+
+  it("provides a font stack starting with Inter", () => {
+    expect(fontStack).toMatch(/^Inter,/);
+    expect(fontStack).toContain("-apple-system");
+    expect(fontStack).toContain("Segoe UI");
+  });
+
+  it("exposes a stable logo URL", () => {
+    expect(logoUrl).toMatch(/^https:\/\//);
+    expect(logoUrl).toContain("monogram");
+  });
+
+  it("provides spacing scale", () => {
+    expect(spacing.lg).toBe("32px");
+    expect(spacing.xl).toBe("40px");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test emails/__tests__/tokens.test.ts
+```
+
+Expected: FAIL with module-not-found error for `../components/tokens`.
+
+- [ ] **Step 3: Write the tokens module**
+
+Create `emails/components/tokens.ts`:
+
+```ts
+export const colors = {
+  navy: "#0D1B2A",
+  signalGreen: "#1D9E75",
+  bg: "#F6F6F7",
+  card: "#FFFFFF",
+  text: "#374151",
+  textMuted: "#6B7280",
+  border: "#E5E7EB",
+  noteBg: "#F3F4F6",
+} as const;
+
+export const fontStack =
+  "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+
+export const logoUrl =
+  "https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png";
+
+export const spacing = {
+  xs: "8px",
+  sm: "16px",
+  md: "24px",
+  lg: "32px",
+  xl: "40px",
+} as const;
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test emails/__tests__/tokens.test.ts
+```
+
+Expected: PASS, 4 tests passing.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add emails/components/tokens.ts emails/__tests__/tokens.test.ts
+git commit -m "feat(emails): add brand tokens for email templates"
+```
+
+---
+
+## Task 4: Build `EmailLayout` component
+
+**Files:**
+- Create: `emails/components/EmailLayout.tsx`
+
+This component is the outer shell. It is consumed by every template. We don't write a unit test for it directly — its rendering is exercised by the per-template tests in Tasks 8–10. We do verify it compiles.
+
+- [ ] **Step 1: Write the component**
+
+Create `emails/components/EmailLayout.tsx`:
+
+```tsx
+import { Body, Container, Font, Head, Html, Preview } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors, fontStack } from "./tokens";
+
+interface EmailLayoutProps {
+  preview: string;
+  children: ReactNode;
+}
+
+export function EmailLayout({ preview, children }: EmailLayoutProps) {
+  return (
+    <Html lang="en">
+      <Head>
+        <Font
+          fontFamily="Inter"
+          fallbackFontFamily="Helvetica"
+          webFont={{
+            url: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap",
+            format: "woff2",
+          }}
+          fontWeight={400}
+          fontStyle="normal"
+        />
+      </Head>
+      <Preview>{preview}</Preview>
+      <Body
+        style={{
+          backgroundColor: colors.bg,
+          fontFamily: fontStack,
+          margin: 0,
+          padding: "32px 0",
+        }}
+      >
+        <Container
+          style={{
+            backgroundColor: colors.card,
+            borderRadius: "12px",
+            maxWidth: "560px",
+            margin: "0 auto",
+            overflow: "hidden",
+            boxShadow: "0 1px 3px rgba(0, 0, 0, 0.05)",
+          }}
+        >
+          {children}
+        </Container>
+      </Body>
+    </Html>
+  );
+}
+```
+
+- [ ] **Step 2: Verify it type-checks**
+
+```bash
+pnpm exec tsc --project emails/tsconfig.json --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add emails/components/EmailLayout.tsx
+git commit -m "feat(emails): add EmailLayout shell component"
+```
+
+---
+
+## Task 5: Build `EmailHeader` component
+
+**Files:**
+- Create: `emails/components/EmailHeader.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { Img, Section } from "@react-email/components";
+import { colors, logoUrl } from "./tokens";
+
+export function EmailHeader() {
+  return (
+    <Section
+      style={{
+        backgroundColor: colors.navy,
+        padding: "32px 0",
+        textAlign: "center",
+      }}
+    >
+      <Img
+        src={logoUrl}
+        alt="Lexena"
+        width="56"
+        height="56"
+        style={{
+          margin: "0 auto",
+          display: "block",
+          borderRadius: "8px",
+        }}
+      />
+    </Section>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check**
+
+```bash
+pnpm exec tsc --project emails/tsconfig.json --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add emails/components/EmailHeader.tsx
+git commit -m "feat(emails): add EmailHeader with monogram"
+```
+
+---
+
+## Task 6: Build `EmailFooter` component
+
+**Files:**
+- Create: `emails/components/EmailFooter.tsx`
+
+- [ ] **Step 1: Write the component**
+
+```tsx
+import { Hr, Section, Text } from "@react-email/components";
+import { colors } from "./tokens";
+
+interface EmailFooterProps {
+  contextLine: string;
+}
+
+export function EmailFooter({ contextLine }: EmailFooterProps) {
+  return (
+    <Section style={{ padding: "0 40px 32px 40px" }}>
+      <Hr style={{ borderColor: colors.border, margin: "32px 0 24px 0" }} />
+      <Text
+        style={{
+          color: colors.textMuted,
+          fontSize: "12px",
+          lineHeight: "18px",
+          margin: 0,
+        }}
+      >
+        Lexena · lexena.app
+      </Text>
+      <Text
+        style={{
+          color: colors.textMuted,
+          fontSize: "12px",
+          lineHeight: "18px",
+          margin: "8px 0 0 0",
+        }}
+      >
+        {contextLine}
+      </Text>
+    </Section>
+  );
+}
+```
+
+- [ ] **Step 2: Type-check and commit**
+
+```bash
+pnpm exec tsc --project emails/tsconfig.json --noEmit
+git add emails/components/EmailFooter.tsx
+git commit -m "feat(emails): add EmailFooter with context line slot"
+```
+
+---
+
+## Task 7: Build content components (`EmailButton`, `EmailHeading`, `EmailText`, `EmailSecurityNote`)
+
+**Files:**
+- Create: `emails/components/EmailButton.tsx`
+- Create: `emails/components/EmailHeading.tsx`
+- Create: `emails/components/EmailText.tsx`
+- Create: `emails/components/EmailSecurityNote.tsx`
+
+- [ ] **Step 1: Write `EmailButton.tsx`**
+
+```tsx
+import { Button } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors } from "./tokens";
+
+interface EmailButtonProps {
+  href: string;
+  children: ReactNode;
+}
+
+export function EmailButton({ href, children }: EmailButtonProps) {
+  return (
+    <Button
+      href={href}
+      style={{
+        backgroundColor: colors.signalGreen,
+        color: "#FFFFFF",
+        padding: "14px 28px",
+        borderRadius: "8px",
+        fontSize: "16px",
+        fontWeight: 500,
+        textDecoration: "none",
+        display: "inline-block",
+      }}
+    >
+      {children}
+    </Button>
+  );
+}
+```
+
+- [ ] **Step 2: Write `EmailHeading.tsx`**
+
+```tsx
+import { Heading } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors } from "./tokens";
+
+interface EmailHeadingProps {
+  children: ReactNode;
+}
+
+export function EmailHeading({ children }: EmailHeadingProps) {
+  return (
+    <Heading
+      as="h1"
+      style={{
+        color: colors.navy,
+        fontSize: "24px",
+        fontWeight: 600,
+        lineHeight: "32px",
+        margin: "0 0 16px 0",
+      }}
+    >
+      {children}
+    </Heading>
+  );
+}
+```
+
+- [ ] **Step 3: Write `EmailText.tsx`**
+
+```tsx
+import { Text } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors } from "./tokens";
+
+interface EmailTextProps {
+  children: ReactNode;
+  variant?: "default" | "muted";
+}
+
+export function EmailText({ children, variant = "default" }: EmailTextProps) {
+  const isMuted = variant === "muted";
+  return (
+    <Text
+      style={{
+        color: isMuted ? colors.textMuted : colors.text,
+        fontSize: isMuted ? "14px" : "16px",
+        lineHeight: isMuted ? "22px" : "26px",
+        margin: "0 0 16px 0",
+      }}
+    >
+      {children}
+    </Text>
+  );
+}
+```
+
+- [ ] **Step 4: Write `EmailSecurityNote.tsx`**
+
+```tsx
+import { Section, Text } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors } from "./tokens";
+
+interface EmailSecurityNoteProps {
+  children: ReactNode;
+}
+
+export function EmailSecurityNote({ children }: EmailSecurityNoteProps) {
+  return (
+    <Section
+      style={{
+        backgroundColor: colors.noteBg,
+        borderLeft: `3px solid ${colors.signalGreen}`,
+        borderRadius: "6px",
+        padding: "16px",
+        margin: "24px 0",
+      }}
+    >
+      <Text
+        style={{
+          color: colors.text,
+          fontSize: "14px",
+          lineHeight: "22px",
+          fontStyle: "italic",
+          margin: 0,
+        }}
+      >
+        {children}
+      </Text>
+    </Section>
+  );
+}
+```
+
+- [ ] **Step 5: Type-check**
+
+```bash
+pnpm exec tsc --project emails/tsconfig.json --noEmit
+```
+
+Expected: No errors.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add emails/components/EmailButton.tsx emails/components/EmailHeading.tsx emails/components/EmailText.tsx emails/components/EmailSecurityNote.tsx
+git commit -m "feat(emails): add content components (button, heading, text, security note)"
+```
+
+---
+
+## Task 8: Build `MagicLink` template (TDD)
+
+**Files:**
+- Create: `emails/templates/MagicLink.tsx`
+- Create: `emails/__tests__/templates.test.ts`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `emails/__tests__/templates.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { render } from "@react-email/render";
+import MagicLink, { subject as magicLinkSubject } from "../templates/MagicLink";
+
+describe("MagicLink template", () => {
+  it("exports the expected subject", () => {
+    expect(magicLinkSubject).toBe("Sign in to Lexena");
+  });
+
+  it("renders the H1 'Sign in to Lexena'", async () => {
+    const html = await render(<MagicLink />);
+    expect(html).toContain("Sign in to Lexena");
+  });
+
+  it("includes the Liquid placeholder for the confirmation URL, unescaped", async () => {
+    const html = await render(<MagicLink />);
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;&#123;");
+    expect(html).not.toContain("&lbrace;");
+  });
+
+  it("includes the validity duration", async () => {
+    const html = await render(<MagicLink />);
+    expect(html).toMatch(/valid for 1 hour/i);
+  });
+
+  it("includes the security note for unsolicited sign-in", async () => {
+    const html = await render(<MagicLink />);
+    expect(html).toMatch(/didn'?t request this sign-in/i);
+  });
+
+  it("includes the CTA button label", async () => {
+    const html = await render(<MagicLink />);
+    expect(html).toContain(">Sign in</a>");
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pnpm test emails/__tests__/templates.test.ts
+```
+
+Expected: FAIL with "Cannot find module '../templates/MagicLink'".
+
+- [ ] **Step 3: Write the template**
+
+Create `emails/templates/MagicLink.tsx`:
+
+```tsx
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { EmailHeader } from "../components/EmailHeader";
+import { EmailFooter } from "../components/EmailFooter";
+import { EmailHeading } from "../components/EmailHeading";
+import { EmailText } from "../components/EmailText";
+import { EmailButton } from "../components/EmailButton";
+import { EmailSecurityNote } from "../components/EmailSecurityNote";
+
+export const subject = "Sign in to Lexena";
+
+export default function MagicLink() {
+  return (
+    <EmailLayout preview="Sign in to your Lexena account">
+      <EmailHeader />
+      <Section style={{ padding: "40px" }}>
+        <EmailHeading>Sign in to Lexena</EmailHeading>
+        <EmailText>Click the button below to sign in to your account.</EmailText>
+        <Section style={{ textAlign: "center", margin: "32px 0" }}>
+          <EmailButton href="{{ .ConfirmationURL }}">Sign in</EmailButton>
+        </Section>
+        <EmailText variant="muted">
+          This link is valid for 1 hour and can only be used once.
+        </EmailText>
+        <EmailSecurityNote>
+          Didn't request this sign-in? You can safely ignore this message — your account remains secure.
+        </EmailSecurityNote>
+        <EmailText variant="muted">— The Lexena team</EmailText>
+        <EmailFooter contextLine="You received this email because of a sign-in request on your Lexena account." />
+      </Section>
+    </EmailLayout>
+  );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pnpm test emails/__tests__/templates.test.ts
+```
+
+Expected: PASS, 6 tests for `MagicLink template`. If `{{ .ConfirmationURL }}` is HTML-escaped (e.g., `&#123;&#123;`), test will fail — proceed to Task 11 escape handling.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add emails/templates/MagicLink.tsx emails/__tests__/templates.test.ts
+git commit -m "feat(emails): add MagicLink template"
+```
+
+---
+
+## Task 9: Build `SignupConfirmation` template (TDD)
+
+**Files:**
+- Create: `emails/templates/SignupConfirmation.tsx`
+- Modify: `emails/__tests__/templates.test.ts`
+
+- [ ] **Step 1: Add failing tests to `templates.test.ts`**
+
+Append to `emails/__tests__/templates.test.ts`:
+
+```ts
+import SignupConfirmation, { subject as signupSubject } from "../templates/SignupConfirmation";
+
+describe("SignupConfirmation template", () => {
+  it("exports the expected subject", () => {
+    expect(signupSubject).toBe("Confirm your Lexena email address");
+  });
+
+  it("renders the H1 'Welcome to Lexena'", async () => {
+    const html = await render(<SignupConfirmation />);
+    expect(html).toContain("Welcome to Lexena");
+  });
+
+  it("includes the Liquid placeholder for the confirmation URL, unescaped", async () => {
+    const html = await render(<SignupConfirmation />);
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;&#123;");
+  });
+
+  it("mentions the 24-hour validity", async () => {
+    const html = await render(<SignupConfirmation />);
+    expect(html).toMatch(/valid for 24 hours/i);
+  });
+
+  it("includes the CTA 'Confirm my email'", async () => {
+    const html = await render(<SignupConfirmation />);
+    expect(html).toContain(">Confirm my email</a>");
+  });
+
+  it("includes the security note for unsolicited signup", async () => {
+    const html = await render(<SignupConfirmation />);
+    expect(html).toMatch(/didn'?t create a Lexena account/i);
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+```bash
+pnpm test emails/__tests__/templates.test.ts
+```
+
+Expected: 6 PASS (MagicLink), 6 FAIL (SignupConfirmation, module not found).
+
+- [ ] **Step 3: Write the template**
+
+Create `emails/templates/SignupConfirmation.tsx`:
+
+```tsx
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { EmailHeader } from "../components/EmailHeader";
+import { EmailFooter } from "../components/EmailFooter";
+import { EmailHeading } from "../components/EmailHeading";
+import { EmailText } from "../components/EmailText";
+import { EmailButton } from "../components/EmailButton";
+import { EmailSecurityNote } from "../components/EmailSecurityNote";
+
+export const subject = "Confirm your Lexena email address";
+
+export default function SignupConfirmation() {
+  return (
+    <EmailLayout preview="Confirm your Lexena email to finalize your account">
+      <EmailHeader />
+      <Section style={{ padding: "40px" }}>
+        <EmailHeading>Welcome to Lexena</EmailHeading>
+        <EmailText>
+          To finalize your account creation, please confirm your email address.
+        </EmailText>
+        <Section style={{ textAlign: "center", margin: "32px 0" }}>
+          <EmailButton href="{{ .ConfirmationURL }}">Confirm my email</EmailButton>
+        </Section>
+        <EmailText variant="muted">This link is valid for 24 hours.</EmailText>
+        <EmailSecurityNote>
+          Didn't create a Lexena account? You can safely ignore this message.
+        </EmailSecurityNote>
+        <EmailText variant="muted">— The Lexena team</EmailText>
+        <EmailFooter contextLine="You received this email because someone signed up to Lexena with this address." />
+      </Section>
+    </EmailLayout>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pnpm test emails/__tests__/templates.test.ts
+```
+
+Expected: 12 tests passing (6 MagicLink + 6 SignupConfirmation).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add emails/templates/SignupConfirmation.tsx emails/__tests__/templates.test.ts
+git commit -m "feat(emails): add SignupConfirmation template"
+```
+
+---
+
+## Task 10: Build `PasswordReset` template (TDD)
+
+**Files:**
+- Create: `emails/templates/PasswordReset.tsx`
+- Modify: `emails/__tests__/templates.test.ts`
+
+- [ ] **Step 1: Add failing tests to `templates.test.ts`**
+
+Append:
+
+```ts
+import PasswordReset, { subject as resetSubject } from "../templates/PasswordReset";
+
+describe("PasswordReset template", () => {
+  it("exports the expected subject", () => {
+    expect(resetSubject).toBe("Reset your Lexena password");
+  });
+
+  it("renders the H1 'Reset your password'", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toContain("Reset your password");
+  });
+
+  it("includes the Liquid placeholder for the confirmation URL, unescaped", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;&#123;");
+  });
+
+  it("mentions the 1-hour validity", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toMatch(/valid for 1 hour/i);
+  });
+
+  it("warns about session revocation", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toMatch(/active sessions on other devices will be revoked/i);
+  });
+
+  it("includes the CTA 'Reset password'", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toContain(">Reset password</a>");
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify the new ones fail**
+
+```bash
+pnpm test emails/__tests__/templates.test.ts
+```
+
+Expected: 12 PASS, 6 FAIL.
+
+- [ ] **Step 3: Write the template**
+
+Create `emails/templates/PasswordReset.tsx`:
+
+```tsx
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { EmailHeader } from "../components/EmailHeader";
+import { EmailFooter } from "../components/EmailFooter";
+import { EmailHeading } from "../components/EmailHeading";
+import { EmailText } from "../components/EmailText";
+import { EmailButton } from "../components/EmailButton";
+import { EmailSecurityNote } from "../components/EmailSecurityNote";
+
+export const subject = "Reset your Lexena password";
+
+export default function PasswordReset() {
+  return (
+    <EmailLayout preview="Reset your Lexena password">
+      <EmailHeader />
+      <Section style={{ padding: "40px" }}>
+        <EmailHeading>Reset your password</EmailHeading>
+        <EmailText>Click the button below to choose a new password.</EmailText>
+        <Section style={{ textAlign: "center", margin: "32px 0" }}>
+          <EmailButton href="{{ .ConfirmationURL }}">Reset password</EmailButton>
+        </Section>
+        <EmailText variant="muted">
+          This link is valid for 1 hour and can only be used once.
+        </EmailText>
+        <EmailSecurityNote>
+          If you didn't request this, ignore this message — your current password remains valid. On the next successful login after reset, all your active sessions on other devices will be revoked.
+        </EmailSecurityNote>
+        <EmailText variant="muted">— The Lexena team</EmailText>
+        <EmailFooter contextLine="You received this email because of a password reset request on your Lexena account." />
+      </Section>
+    </EmailLayout>
+  );
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pnpm test emails/__tests__/templates.test.ts
+```
+
+Expected: 18 tests passing (6 × 3 templates).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add emails/templates/PasswordReset.tsx emails/__tests__/templates.test.ts
+git commit -m "feat(emails): add PasswordReset template"
+```
+
+---
+
+## Task 11: Build the build script with Liquid-var safety post-processing
+
+**Files:**
+- Create: `emails/build.ts`
+- Create: `emails/__tests__/build.test.ts`
+- Modify: `.gitignore` (if needed)
+
+- [ ] **Step 1: Verify `dist/emails/` is NOT gitignored**
+
+Check `.gitignore`:
+
+```bash
+grep -n "dist" .gitignore
+```
+
+If a line excludes all `dist/`, add an exception for our subdirectory. Example: append to `.gitignore`:
+
+```
+# Email-specific dist is committed for traceability — Vite-built dist remains ignored
+!/dist/emails/
+!/dist/emails/**
+```
+
+If `dist` was not ignored at all, no change needed.
+
+- [ ] **Step 2: Write the failing test**
+
+Create `emails/__tests__/build.test.ts`:
+
+```ts
+import { describe, it, expect, beforeAll } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { build } from "../build";
+
+const distDir = path.resolve(__dirname, "../../dist/emails");
+
+describe("build", () => {
+  beforeAll(async () => {
+    await build();
+  });
+
+  it("produces magic-link.html", async () => {
+    const html = await fs.readFile(path.join(distDir, "magic-link.html"), "utf8");
+    expect(html.length).toBeGreaterThan(500);
+    expect(html).toContain("<!DOCTYPE html");
+    expect(html).toContain("Sign in to Lexena");
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;");
+  });
+
+  it("produces signup-confirmation.html", async () => {
+    const html = await fs.readFile(
+      path.join(distDir, "signup-confirmation.html"),
+      "utf8",
+    );
+    expect(html).toContain("Welcome to Lexena");
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;");
+  });
+
+  it("produces password-reset.html", async () => {
+    const html = await fs.readFile(
+      path.join(distDir, "password-reset.html"),
+      "utf8",
+    );
+    expect(html).toContain("Reset your password");
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;");
+  });
+
+  it("includes subject as HTML comment at top of each file", async () => {
+    const magicLink = await fs.readFile(path.join(distDir, "magic-link.html"), "utf8");
+    expect(magicLink.startsWith("<!-- Subject: Sign in to Lexena -->")).toBe(true);
+
+    const signup = await fs.readFile(
+      path.join(distDir, "signup-confirmation.html"),
+      "utf8",
+    );
+    expect(
+      signup.startsWith("<!-- Subject: Confirm your Lexena email address -->"),
+    ).toBe(true);
+
+    const reset = await fs.readFile(path.join(distDir, "password-reset.html"), "utf8");
+    expect(
+      reset.startsWith("<!-- Subject: Reset your Lexena password -->"),
+    ).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+pnpm test emails/__tests__/build.test.ts
+```
+
+Expected: FAIL with "Cannot find module '../build'".
+
+- [ ] **Step 4: Write the build script**
+
+Create `emails/build.ts`:
+
+```ts
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import { render } from "@react-email/render";
+import type { ComponentType } from "react";
+
+import MagicLink, { subject as magicLinkSubject } from "./templates/MagicLink";
+import SignupConfirmation, {
+  subject as signupSubject,
+} from "./templates/SignupConfirmation";
+import PasswordReset, { subject as resetSubject } from "./templates/PasswordReset";
+
+interface TemplateEntry {
+  slug: string;
+  subject: string;
+  Component: ComponentType;
+}
+
+const TEMPLATES: TemplateEntry[] = [
+  { slug: "magic-link", subject: magicLinkSubject, Component: MagicLink },
+  {
+    slug: "signup-confirmation",
+    subject: signupSubject,
+    Component: SignupConfirmation,
+  },
+  { slug: "password-reset", subject: resetSubject, Component: PasswordReset },
+];
+
+/**
+ * React HTML-escapes `{` and `}` in attribute values, which would break Supabase
+ * Liquid templating. We restore the literal `{{ ... }}` placeholders post-render.
+ */
+function unescapeLiquid(html: string): string {
+  return html
+    .replace(/&#123;&#123;/g, "{{")
+    .replace(/&#125;&#125;/g, "}}")
+    .replace(/&#123;/g, "{")
+    .replace(/&#125;/g, "}")
+    .replace(/&lbrace;/g, "{")
+    .replace(/&rbrace;/g, "}");
+}
+
+export async function build(): Promise<void> {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const outDir = path.resolve(here, "../dist/emails");
+  await fs.mkdir(outDir, { recursive: true });
+
+  for (const { slug, subject, Component } of TEMPLATES) {
+    const rawHtml = await render(<Component />, { pretty: true });
+    const safeHtml = unescapeLiquid(rawHtml);
+    const withSubject = `<!-- Subject: ${subject} -->\n${safeHtml}`;
+    const outPath = path.join(outDir, `${slug}.html`);
+    await fs.writeFile(outPath, withSubject, "utf8");
+    console.log(`✓ ${slug}.html (${withSubject.length} bytes)`);
+  }
+}
+
+// Cross-platform "is this file the script entrypoint?" check.
+// Compares resolved paths (handles Windows backslash vs URL forward-slash).
+const isEntrypoint =
+  process.argv[1] !== undefined &&
+  path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1]);
+
+if (isEntrypoint) {
+  build().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}
+```
+
+- [ ] **Step 5: Run the build manually first**
+
+```bash
+pnpm email:build
+```
+
+Expected: 3 lines of output `✓ magic-link.html (...)` etc. Files appear in `dist/emails/`.
+
+- [ ] **Step 6: Inspect one HTML output**
+
+```bash
+pnpm exec node -e "console.log(require('fs').readFileSync('dist/emails/magic-link.html', 'utf8').slice(0, 800))"
+```
+
+Verify visually:
+- Starts with `<!-- Subject: Sign in to Lexena -->`
+- Contains `<!DOCTYPE html`
+- Contains `{{ .ConfirmationURL }}` (literal, NOT `&#123;&#123;`)
+
+- [ ] **Step 7: Run the build test**
+
+```bash
+pnpm test emails/__tests__/build.test.ts
+```
+
+Expected: 4 tests passing.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add emails/build.ts emails/__tests__/build.test.ts dist/emails/ .gitignore
+git commit -m "feat(emails): add build script with Liquid-var safety + commit compiled HTML"
+```
+
+---
+
+## Task 12: Add snapshot regression test (CI guard)
+
+**Files:**
+- Modify: `emails/__tests__/build.test.ts`
+
+This guards against `dist/emails/*.html` drifting from the `.tsx` sources without a rebuild. We compare freshly-built HTML against committed HTML.
+
+- [ ] **Step 1: Add the regression test**
+
+Append to `emails/__tests__/build.test.ts`:
+
+```ts
+import { execSync } from "node:child_process";
+
+describe("regression: dist/emails/ is in sync with templates", () => {
+  it("freshly built HTML matches committed dist/emails/", async () => {
+    // Read committed snapshots BEFORE rebuilding
+    const committed = {
+      "magic-link.html": await fs.readFile(
+        path.join(distDir, "magic-link.html"),
+        "utf8",
+      ),
+      "signup-confirmation.html": await fs.readFile(
+        path.join(distDir, "signup-confirmation.html"),
+        "utf8",
+      ),
+      "password-reset.html": await fs.readFile(
+        path.join(distDir, "password-reset.html"),
+        "utf8",
+      ),
+    };
+
+    // Rebuild
+    await build();
+
+    // Compare
+    for (const [name, before] of Object.entries(committed)) {
+      const after = await fs.readFile(path.join(distDir, name), "utf8");
+      expect(after).toBe(before);
+    }
+  });
+});
+```
+
+Note: this test runs AFTER the `beforeAll(build())` in the same file, but reads committed content first. If a developer modifies a `.tsx` without running `pnpm email:build` and committing the new HTML, this test will fail.
+
+- [ ] **Step 2: Run tests**
+
+```bash
+pnpm test emails/__tests__/build.test.ts
+```
+
+Expected: All tests pass (5 total in this file now).
+
+- [ ] **Step 3: Sanity check the failure mode**
+
+Temporarily edit `emails/templates/MagicLink.tsx` — change "Sign in" to "Log in" in the H1. Then:
+
+```bash
+pnpm test emails/__tests__/build.test.ts
+```
+
+Expected: Snapshot regression test FAILS. Revert the change:
+
+```bash
+git checkout emails/templates/MagicLink.tsx
+```
+
+Re-run tests:
+
+```bash
+pnpm test emails/__tests__/build.test.ts
+```
+
+Expected: All pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add emails/__tests__/build.test.ts
+git commit -m "test(emails): add regression test guarding dist/emails sync"
+```
+
+---
+
+## Task 13: Verify React Email dev server preview works
+
+**Files:** None (verification only)
+
+- [ ] **Step 1: Start the dev server**
+
+```bash
+pnpm email:dev
+```
+
+Expected: Output mentions `localhost:3001`. Server stays running.
+
+- [ ] **Step 2: Open browser**
+
+Navigate to `http://localhost:3001`.
+
+Expected:
+- Sidebar lists "MagicLink", "SignupConfirmation", "PasswordReset"
+- Clicking each renders the email preview in iframe
+- Visual: navy header with monogram, white body, green button, security note
+
+- [ ] **Step 3: Check responsive width**
+
+In the preview iframe, switch device preview to mobile (typically a button at top of preview). Verify:
+- Layout still readable on 375px width
+- Button doesn't overflow
+- Header padding still acceptable
+
+- [ ] **Step 4: Stop the server (Ctrl+C) and commit nothing**
+
+This task is verification only. No commit needed.
+
+If preview is broken (white page, error), debug before continuing — likely a missing import or React Email version mismatch.
+
+---
+
+## Task 14: Multi-client compatibility test (manual checklist)
+
+**Files:** None (verification + optional documentation)
+
+- [ ] **Step 1: Open each compiled HTML in Chrome**
+
+```bash
+start dist/emails/magic-link.html
+start dist/emails/signup-confirmation.html
+start dist/emails/password-reset.html
+```
+
+(On macOS/Linux: `open` instead of `start`. On Linux: `xdg-open`.)
+
+Verify visually that:
+- Layout renders correctly
+- Logo image loads (GitHub raw URL is reachable from the browser)
+- Inter font loads (fallbacks acceptable if blocked)
+- CTA button shows in Signal Green
+
+- [ ] **Step 2: Sign up for Email on Acid free trial OR Litmus free trial**
+
+Either provider has a 7-day free trial sufficient for one round of testing.
+
+- [ ] **Step 3: Upload each HTML file and run previews**
+
+For each of the 3 templates, run previews on at least:
+- Gmail (web, iOS, Android)
+- Outlook (Windows desktop 365, web)
+- Apple Mail (macOS, iOS)
+
+- [ ] **Step 4: Document findings**
+
+Create or append to `emails/COMPATIBILITY.md`:
+
+```markdown
+# Email client compatibility (Phase 1)
+
+Tested via [Email on Acid | Litmus] on YYYY-MM-DD.
+
+| Template | Gmail Web | Gmail iOS | Gmail Android | Outlook Win | Outlook Web | Apple Mail macOS | Apple Mail iOS |
+|---|---|---|---|---|---|---|---|
+| Magic Link | ✅ | ✅ | ✅ | ⚠️ note | ✅ | ✅ | ✅ |
+| Signup Confirmation | ✅ | ✅ | ✅ | ⚠️ note | ✅ | ✅ | ✅ |
+| Password Reset | ✅ | ✅ | ✅ | ⚠️ note | ✅ | ✅ | ✅ |
+
+## Known issues
+- ⚠️ Outlook Win: <describe any issue, e.g. font fallback to Segoe UI>
+
+## Dark mode
+- Gmail iOS auto-invert: <observation>
+- Apple Mail iOS dark mode: <observation>
+```
+
+- [ ] **Step 5: Fix any blocking issues**
+
+If a template renders unusably broken on a major client (Gmail, Outlook, Apple Mail), iterate on the components and re-run Tasks 11–12 to rebuild + re-test. Common fixes:
+- Outlook flexbox issues → React Email already uses tables, but verify no custom flex sneaked in
+- Padding ignored in Outlook → use `<table>` cellpadding instead of CSS padding for that section
+- Background colors stripped → add `bgcolor` HTML attribute as fallback to `style`
+
+- [ ] **Step 6: Commit compatibility doc**
+
+```bash
+git add emails/COMPATIBILITY.md
+git commit -m "docs(emails): document multi-client compatibility test results"
+```
+
+---
+
+## Task 15: Deploy to Supabase Auth (manual)
+
+**Files:** None (Supabase Dashboard configuration)
+
+- [ ] **Step 1: Open Supabase Dashboard**
+
+Navigate to your project → Authentication → Email Templates.
+
+- [ ] **Step 2: Configure Magic Link**
+
+- Read the subject from `dist/emails/magic-link.html` first line: `<!-- Subject: Sign in to Lexena -->`
+- In Supabase: select "Magic Link" template
+- Set Subject: `Sign in to Lexena`
+- Open `dist/emails/magic-link.html` in a text editor
+- Copy the entire file content (including the comment line — Supabase ignores HTML comments)
+- Paste into the Message Body / HTML field, replacing existing content
+- Click Save
+
+- [ ] **Step 3: Send a test email**
+
+In Supabase Dashboard, use the "Send test email" button (or, lacking that, trigger a magic link from the Lexena app to your own email).
+
+Expected: Email arrives within 1 minute. Open it on:
+- Gmail web → visual matches preview
+- Mobile (Gmail iOS or Android) → visual still good
+- Click "Sign in" button → URL is the actual Supabase magic link, NOT `{{ .ConfirmationURL }}` literal
+
+If the email shows literal `{{ .ConfirmationURL }}` text instead of an actual link, **Liquid substitution failed** — the placeholder was lost in copy-paste, or the build script did not properly unescape. Re-check `dist/emails/magic-link.html`.
+
+- [ ] **Step 4: Repeat for Signup Confirmation**
+
+Same procedure with `dist/emails/signup-confirmation.html`. Subject: `Confirm your Lexena email address`. Test by signing up a new throwaway account.
+
+- [ ] **Step 5: Repeat for Password Reset**
+
+Same procedure with `dist/emails/password-reset.html`. Subject: `Reset your Lexena password`. Test by triggering a password reset from the Lexena app.
+
+- [ ] **Step 6: Document the deployment in commit message**
+
+No code change needed, but capture the deployment in a commit (next task) or as a record:
+
+```bash
+git commit --allow-empty -m "chore(emails): deploy phase 1 templates to Supabase Auth (manual)"
+```
+
+---
+
+## Task 16: Write `emails/README.md`
+
+**Files:**
+- Create: `emails/README.md`
+
+- [ ] **Step 1: Write the README**
+
+```markdown
+# Lexena Email Templates
+
+React Email-based transactional email templates for Lexena.
+
+## Phase 1 (current)
+
+3 templates served by Supabase Auth:
+- `templates/MagicLink.tsx`
+- `templates/SignupConfirmation.tsx`
+- `templates/PasswordReset.tsx`
+
+## Workflow
+
+### Editing a template
+
+1. Modify the `.tsx` file under `templates/`.
+2. Preview live: `pnpm email:dev` → open `http://localhost:3001`.
+3. When done, build: `pnpm email:build` → produces `dist/emails/<slug>.html`.
+4. Commit the `.tsx` AND the rebuilt `dist/emails/*.html` together.
+5. Open `dist/emails/<slug>.html`, copy the full content, paste into Supabase Dashboard → Authentication → Email Templates → <template>.
+6. Update the Subject field in Supabase using the value from the `<!-- Subject: ... -->` comment at the top of the HTML file.
+7. Send a test email from Supabase Dashboard to verify rendering.
+
+### Adding a new template
+
+1. Create `templates/<NewTemplate>.tsx` exporting `default` (the component) and `subject` (the subject string).
+2. Register it in `build.ts` in the `TEMPLATES` array.
+3. Add tests to `__tests__/templates.test.ts`.
+4. Run `pnpm test` and `pnpm email:build`.
+5. Commit, then deploy to Supabase as in step 5 above.
+
+## Architecture
+
+- `components/tokens.ts` — design tokens (colors, font stack, logo URL)
+- `components/EmailLayout.tsx` — outer shell (Html, Head, Body, Container)
+- `components/EmailHeader.tsx` — navy header with monogram
+- `components/EmailFooter.tsx` — footer with context line slot
+- `components/EmailButton.tsx` — Signal Green CTA
+- `components/EmailHeading.tsx` — H1 styled
+- `components/EmailText.tsx` — paragraph (default + muted variants)
+- `components/EmailSecurityNote.tsx` — bordered callout
+
+## Liquid placeholder safety
+
+Supabase Auth uses Liquid templating (`{{ .ConfirmationURL }}`). React HTML-escapes braces in attribute values, which would break the substitution. The build script (`build.ts`) post-processes the HTML to restore literal `{{ }}`. This is guarded by a test in `__tests__/build.test.ts`.
+
+If you add a template with a NEW Liquid variable (e.g., `{{ .Email }}`), verify it survives the build by checking `dist/emails/<your-template>.html` for the literal placeholder.
+
+## Logo asset
+
+The header monogram is currently a placeholder loaded from GitHub raw:
+
+```
+https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png
+```
+
+This URL is centralized in `components/tokens.ts`. Migrate to a stable CDN (e.g., `lexena.app/static/email/monogram@2x.png`) once the marketing site is deployed.
+
+## Phase 2 (planned)
+
+Edge Functions Resend templates, sharing the same components:
+- Welcome (post-signup, French/English by user locale)
+- New device alert (rebuilds `send-new-device-email` HTML output)
+- Account deletion request
+- Account deletion completion
+
+See `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md` section 9 (out of scope).
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add emails/README.md
+git commit -m "docs(emails): add README with edit/deploy procedure"
+```
+
+---
+
+## Task 17: Update `docs/v3/legal/email-templates.md`
+
+**Files:**
+- Modify: `docs/v3/legal/email-templates.md`
+
+- [ ] **Step 1: Add a "source of truth" header**
+
+Edit the top of `docs/v3/legal/email-templates.md` (right after the existing `> **Statut**` block). Insert:
+
+```markdown
+> **⚠️ Phase 1 livrée le 2026-05-02** — les 3 templates Supabase Auth (magic link, signup confirmation, password reset) sont implémentés en HTML stylé via React Email.
+> **Source de vérité** : `emails/templates/*.tsx`. Le markdown ci-dessous reste de référence textuelle (FR + EN) pour comparaison et préparation des phases suivantes.
+> **Langue déployée v3.0** : EN uniquement. FR reporté à une phase ultérieure (Edge Function `auth-email-hook` selon `user_settings.ui_language`).
+```
+
+- [ ] **Step 2: Mark FR sections of templates 1, 2, 4 as deferred**
+
+Find sections `## 1 — Magic link`, `## 2 — Signup confirmation`, and `## 4 — Password reset request`. Above each `### FR` subheading, add:
+
+```markdown
+> 🚧 FR différé post-launch (v3.1+).
+```
+
+The EN versions remain authoritative for the deployed copy.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/v3/legal/email-templates.md
+git commit -m "docs(v3): mark phase 1 email templates as delivered, FR deferred"
+```
+
+---
+
+## Task 18: Update `CLAUDE.md`
+
+**Files:**
+- Modify: `CLAUDE.md`
+
+- [ ] **Step 1: Add an "Email templates" subsection under V3 Documentation**
+
+In `CLAUDE.md`, find the `## V3 Documentation` section. After the existing `### V3 Sync settings (livré sous-épique 02)` subsection, add:
+
+```markdown
+### V3 Email templates Supabase Auth (livré phase 1, 2026-05-02)
+
+- Source de vérité : `emails/templates/*.tsx` (React Email)
+- 3 templates Supabase Auth : MagicLink, SignupConfirmation, PasswordReset (EN uniquement v3.0)
+- Build : `pnpm email:build` → `dist/emails/*.html` (commités pour traçabilité)
+- Preview : `pnpm email:dev` → `localhost:3001`
+- Composants partagés : `emails/components/` (Layout, Header, Footer, Button, Heading, Text, SecurityNote, tokens)
+- Procédure de déploiement Supabase : copier `dist/emails/<slug>.html` dans Dashboard → Authentication → Email Templates
+- Snapshot regression test garde `dist/emails/` en sync avec `.tsx`
+- Phase 2 prévue : 4 templates Resend via Edge Functions (welcome, new-device, deletion ×2)
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add CLAUDE.md
+git commit -m "docs: add email templates phase 1 to CLAUDE.md"
+```
+
+---
+
+## Task 19: Open the pull request
+
+**Files:** None (Git operations)
+
+- [ ] **Step 1: Push the branch**
+
+```bash
+git push -u origin feat/email-templates
+```
+
+- [ ] **Step 2: Verify all tests pass once more**
+
+```bash
+pnpm test
+```
+
+Expected: All tests pass, including new ones in `emails/__tests__/`.
+
+- [ ] **Step 3: Open the PR**
+
+```bash
+gh pr create --title "feat(emails): branded Supabase Auth templates (phase 1)" --body "$(cat <<'EOF'
+## Summary
+
+- Replaces the default Supabase Auth email templates with branded Lexena HTML via React Email.
+- Covers 3 templates: magic link, signup confirmation, password reset (EN only for v3.0).
+- New `emails/` directory with reusable components (Layout, Header, Footer, Button, Heading, Text, SecurityNote, tokens).
+- Build script `pnpm email:build` renders `.tsx` to `dist/emails/*.html` with Liquid placeholder safety.
+- Snapshot regression test guards against `dist/` drifting from `.tsx` sources.
+- Logo is a temporary GitHub-raw placeholder of the current monogram (to be replaced when the marketing site hosts a stable asset).
+
+## Spec
+
+`docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md`
+
+## Test plan
+
+- [x] `pnpm test` passes (~24 new tests in `emails/__tests__/`)
+- [x] `pnpm email:build` produces 3 valid HTML files with Liquid placeholders intact
+- [x] `pnpm email:dev` renders preview correctly at `localhost:3001`
+- [x] Multi-client compatibility check via Email on Acid / Litmus (see `emails/COMPATIBILITY.md`)
+- [x] Manual deployment to Supabase Dashboard for all 3 templates
+- [x] Test emails sent from Supabase Dashboard render correctly with substituted URLs
+
+## Out of scope
+
+Phase 2 (welcome / new-device / deletion ×2 via Resend Edge Functions) tracked separately.
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL printed. Browse to it to confirm.
+
+---
+
+## Summary of files
+
+**Created (16 files + dist):**
+- `emails/tsconfig.json`
+- `emails/components/tokens.ts`
+- `emails/components/EmailLayout.tsx`
+- `emails/components/EmailHeader.tsx`
+- `emails/components/EmailFooter.tsx`
+- `emails/components/EmailButton.tsx`
+- `emails/components/EmailHeading.tsx`
+- `emails/components/EmailText.tsx`
+- `emails/components/EmailSecurityNote.tsx`
+- `emails/templates/MagicLink.tsx`
+- `emails/templates/SignupConfirmation.tsx`
+- `emails/templates/PasswordReset.tsx`
+- `emails/build.ts`
+- `emails/__tests__/tokens.test.ts`
+- `emails/__tests__/templates.test.ts`
+- `emails/__tests__/build.test.ts`
+- `emails/README.md`
+- `emails/COMPATIBILITY.md`
+- `dist/emails/magic-link.html`
+- `dist/emails/signup-confirmation.html`
+- `dist/emails/password-reset.html`
+
+**Modified:**
+- `package.json` (add deps + scripts)
+- `pnpm-lock.yaml`
+- `.gitignore` (if `dist/` was excluded)
+- `docs/v3/legal/email-templates.md`
+- `CLAUDE.md`
+
+**Total commits:** ~16 (one per task on average).

--- a/docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md
+++ b/docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md
@@ -1,0 +1,346 @@
+# Email templates — Supabase Auth (phase 1, 3 templates)
+
+**Date** : 2026-05-02
+**Branche cible** : `feat/email-templates`
+**Statut** : design approuvé, prêt à être planifié
+**Phase** : 1 sur 2 — couvre les 3 templates servis par Supabase Auth (magic link, signup confirmation, password reset). Phase 2 (4 templates Resend via Edge Functions : welcome, new-device, deletion request, deletion completion) fera l'objet d'un spec séparé.
+
+---
+
+## 1. Contexte et problème
+
+Les emails transactionnels actuellement envoyés aux utilisateurs Lexena se répartissent en deux familles :
+
+1. **Emails servis par Supabase Auth** (magic link, signup confirmation, password reset) — actuellement les templates **par défaut Supabase**, génériques, sans identité visuelle Lexena. Ce sont les premiers emails que reçoit un nouvel utilisateur, et l'impression initiale est mauvaise : pas de logo, copie générique, ne reflète pas le ton sobre/pro de Lexena.
+
+2. **Emails envoyés via Edge Functions Resend** — actuellement une seule fonction (`send-new-device-email`) qui envoie en **plain text uniquement**, sans HTML.
+
+Le doc `docs/v3/legal/email-templates.md` liste 7 templates rédigés en plain text (FR + EN miroir), mais aucun n'est implémenté en HTML stylé.
+
+L'épique v3 se prépare à un launch "Public Beta" avec ouverture publique. Les emails transactionnels doivent au minimum (a) inspirer confiance pour les flows de sécurité (magic link, reset password) et (b) refléter l'identité visuelle Lexena déjà déployée dans l'app (`#1D9E75` Signal Green, `#0D1B2A` navy, monogramme).
+
+Ce spec couvre la **phase 1** : les 3 templates Supabase Auth. Une phase 2 réutilisera l'infra mise en place ici pour traiter les 4 emails Resend.
+
+## 2. Décisions de design
+
+| # | Sujet | Décision |
+|---|---|---|
+| Q1 | Outillage | **React Email** (`@react-email/components`, `@react-email/render`) |
+| Q2 | Direction visuelle | **Sobre + accent navy** : header navy plein, body blanc, CTA Signal Green |
+| Q3 | Langue | **EN uniquement** pour la v3.0 (cible internationale). FR via override hook plus tard. |
+| Q4 | Logo | **Monogramme PNG via GitHub raw** (`src-tauri/icons/monogram-512.png`) — placeholder temporaire, à migrer dès que le site marketing héberge un asset propre OU dès que le nouveau monogramme est disponible |
+| Q5 | Largeur | 600px container, 560px carte intérieure (standard email) |
+| Q6 | Police | **Inter** via Google Fonts `<link>` + fallback `-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif` |
+| Q7 | Localisation des fichiers | Dossier `emails/` à la racine, sous-projet React Email autonome |
+| Q8 | Versionnement du HTML compilé | Commit dans `dist/emails/` pour traçabilité et diffs visuels entre releases |
+| Q9 | Variables Liquid Supabase | Écrites comme strings brutes `{{ .ConfirmationURL }}` dans les `.tsx`, vérification post-build qu'elles ne sont pas échappées |
+| Q10 | Dark mode | Pas de support explicite — couleurs choisies pour rester lisibles si Gmail/Apple Mail auto-inverse |
+
+## 3. Architecture
+
+### 3.1 Layout des fichiers
+
+```
+emails/                                  ← nouveau, racine du repo
+├── package.json                         ← scripts email:dev, email:build
+├── tsconfig.json
+├── components/
+│   ├── EmailLayout.tsx                  ← Html, Head, Body, Container + Google Fonts
+│   ├── EmailHeader.tsx                  ← header navy + monogramme
+│   ├── EmailFooter.tsx                  ← footer "Lexena · lexena.app"
+│   ├── EmailButton.tsx                  ← CTA Signal Green
+│   ├── EmailHeading.tsx                 ← H1 stylé
+│   ├── EmailText.tsx                    ← paragraphe stylé
+│   ├── EmailSecurityNote.tsx            ← encadré sécu border-left vert
+│   └── tokens.ts                        ← couleurs, espacements, polices
+├── templates/
+│   ├── MagicLink.tsx
+│   ├── SignupConfirmation.tsx
+│   └── PasswordReset.tsx
+├── build.ts                             ← script Node : render() chaque template → dist/
+└── README.md                            ← procédure d'édition + déploiement Supabase
+
+dist/emails/                             ← HTML compilés, commités
+├── magic-link.html
+├── signup-confirmation.html
+└── password-reset.html
+```
+
+### 3.2 Pipeline de rendu
+
+```
+emails/templates/MagicLink.tsx
+            │
+            │  pnpm email:build
+            ▼
+   render() de @react-email/render
+            │
+            ▼
+dist/emails/magic-link.html  ← contient {{ .ConfirmationURL }} non échappé
+            │
+            │  copie manuelle
+            ▼
+Supabase Dashboard → Auth → Email Templates → Magic Link
+            │
+            │  user clique sur "Recevoir un lien"
+            ▼
+Supabase substitue {{ .ConfirmationURL }} → URL réelle
+            │
+            ▼
+       Email envoyé
+```
+
+Le rendu n'est **pas dynamique côté serveur** : on builde une fois en local, on copie-colle dans Supabase, c'est figé tant qu'on ne ré-édite pas le `.tsx`.
+
+### 3.3 Workflow d'édition
+
+```
+1. Modifier emails/templates/MagicLink.tsx
+2. pnpm email:dev  → preview live sur localhost:3000
+3. pnpm email:build → écrit dist/emails/magic-link.html
+4. git diff dist/emails/  → revue du HTML compilé
+5. git commit
+6. Manuellement : copier dist/emails/magic-link.html dans Supabase Dashboard
+7. Test "Send test email" depuis Supabase
+```
+
+## 4. Design visuel
+
+### 4.1 Layout commun
+
+```
+┌─────────────────────────────────────────┐  ← fond extérieur #F6F6F7, padding 32px haut/bas
+│                                         │
+│  ┌───────────────────────────────────┐  │  ← carte 560px, fond blanc, radius 12px,
+│  │                                   │  │     ombre légère 0 1px 3px rgba(0,0,0,0.05)
+│  │   ████ HEADER NAVY ████          │  │
+│  │   #0D1B2A, padding 32px           │  │  ← monogramme PNG 56×56, centré
+│  │       [monogram 56×56]            │  │
+│  │   ████████████████████            │  │
+│  │                                   │  │
+│  │   [BODY blanc, padding 40px h /   │  │
+│  │    32px v]                        │  │
+│  │                                   │  │
+│  │   H1  24px / 600 / #0D1B2A        │  │
+│  │                                   │  │
+│  │   P 16px / 400 / #374151 / 1.6   │  │
+│  │                                   │  │
+│  │   ┌─────────────────┐             │  │  ← CTA: bg #1D9E75, padding 14px 28px,
+│  │   │  CTA TEXT       │             │  │     radius 8px, color #fff, weight 500
+│  │   └─────────────────┘             │  │
+│  │                                   │  │
+│  │   P_secondary 14px / #6B7280     │  │  ← durée du lien
+│  │                                   │  │
+│  │   ╭─ encadré sécu ──────╮         │  │  ← bg #F3F4F6, border-left 3px #1D9E75,
+│  │   │ texte 14px italique │         │  │     padding 16px, radius 6px
+│  │   ╰─────────────────────╯         │  │
+│  │                                   │  │
+│  │   "— The Lexena team"             │  │  ← 14px / #6B7280
+│  │                                   │  │
+│  │   ─── separator ───                │  │
+│  │                                   │  │
+│  │   FOOTER 12px / #6B7280           │  │
+│  │   "Lexena · lexena.app"           │  │
+│  │   "You received this email        │  │
+│  │    because of an action on        │  │
+│  │    your account."                 │  │
+│  └───────────────────────────────────┘  │
+│                                         │
+└─────────────────────────────────────────┘
+```
+
+### 4.2 Tokens (`emails/components/tokens.ts`)
+
+```ts
+export const colors = {
+  navy: "#0D1B2A",
+  signalGreen: "#1D9E75",
+  bg: "#F6F6F7",          // fond extérieur
+  card: "#FFFFFF",         // fond carte
+  text: "#374151",         // corps
+  textMuted: "#6B7280",    // footer, durée du lien
+  border: "#E5E7EB",
+  noteBg: "#F3F4F6",
+};
+
+export const fontStack =
+  "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+```
+
+### 4.3 Logo placeholder
+
+URL : `https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png`
+
+Affiché en `width="56" height="56"` via `<Img>` de React Email.
+
+**À remplacer** :
+- Quand le nouveau monogramme arrive (changement design en cours)
+- Quand le site marketing `lexena.app` héberge un asset stable type `lexena.app/static/email/monogram@2x.png`
+
+L'URL est centralisée dans `emails/components/tokens.ts` pour migration en un seul endroit.
+
+## 5. Contenus des templates (EN)
+
+### 5.1 Magic Link
+
+- **Subject** : `Sign in to Lexena`
+- **H1** : `Sign in to Lexena`
+- **Body** : "Click the button below to sign in to your account."
+- **CTA** : `Sign in` → `{{ .ConfirmationURL }}`
+- **Sous-CTA** : "This link is valid for 1 hour and can only be used once."
+- **Note de sécurité** : "Didn't request this sign-in? You can safely ignore this message — your account remains secure."
+- **Signature** : "— The Lexena team"
+
+### 5.2 Signup Confirmation
+
+- **Subject** : `Confirm your Lexena email address`
+- **H1** : `Welcome to Lexena`
+- **Body** : "To finalize your account creation, please confirm your email address."
+- **CTA** : `Confirm my email` → `{{ .ConfirmationURL }}`
+- **Sous-CTA** : "This link is valid for 24 hours."
+- **Note de sécurité** : "Didn't create a Lexena account? You can safely ignore this message."
+- **Signature** : "— The Lexena team"
+
+### 5.3 Password Reset
+
+- **Subject** : `Reset your Lexena password`
+- **H1** : `Reset your password`
+- **Body** : "Click the button below to choose a new password."
+- **CTA** : `Reset password` → `{{ .ConfirmationURL }}`
+- **Sous-CTA** : "This link is valid for 1 hour and can only be used once."
+- **Note de sécurité** : "If you didn't request this, ignore this message — your current password remains valid. On the next successful login after reset, all your active sessions on other devices will be revoked."
+- **Signature** : "— The Lexena team"
+
+## 6. Plan d'implémentation
+
+### Étape 1 — Setup React Email (~30 min)
+
+- Créer `emails/` avec son propre `package.json` (workspace pnpm OU sous-projet indépendant — à choisir lors de la planification fine)
+- Installer `@react-email/components`, `@react-email/render`, `react-email` (CLI dev preview), `tsx` (runner TypeScript pour `build.ts`)
+- Ajouter `tsconfig.json` avec resolution Node + JSX React
+- Ajouter scripts au `package.json` racine :
+  - `email:dev` → délègue à `cd emails && react-email dev`
+  - `email:build` → délègue à `cd emails && tsx build.ts`
+- Vérifier que `pnpm email:dev` ouvre `localhost:3000` avec liste des templates
+
+### Étape 2 — Tokens et composants partagés (~1h)
+
+- `emails/components/tokens.ts` : couleurs, fontStack, URL logo
+- `EmailLayout.tsx` : structure `<Html><Head><Preview><Body><Container>` avec Google Fonts `<link>` Inter + fallback CSS
+- `EmailHeader.tsx` : section navy 32px padding, `<Img src={tokens.logoUrl} width="56" height="56" />`
+- `EmailButton.tsx` : `<Button>` React Email avec styles tokens
+- `EmailHeading.tsx`, `EmailText.tsx`, `EmailSecurityNote.tsx`
+- `EmailFooter.tsx` : "Lexena · lexena.app" + ligne contextuelle paramétrable
+
+### Étape 3 — 3 templates (~1h30)
+
+- `MagicLink.tsx`, `SignupConfirmation.tsx`, `PasswordReset.tsx`
+- Chacun assemble les composants partagés avec le contenu EN défini section 5
+- Variables Supabase Liquid `{{ .ConfirmationURL }}` écrites comme strings brutes dans les props `href`
+- Preview de chaque template dans `pnpm email:dev`, vérification visuelle desktop + mobile (responsive width)
+
+### Étape 4 — Build script (~30 min)
+
+- `emails/build.ts` : importe chaque template, appelle `render()`, écrit dans `../dist/emails/{slug}.html`
+- Vérification post-build : grep des occurrences `{{ .ConfirmationURL }}` dans le HTML produit (doit être ≥ 1 par fichier, **non échappé**)
+- Si React échappe en `&#123;&#123; .ConfirmationURL &#125;&#125;`, post-traitement string-replace dans `build.ts` pour restaurer les `{{ }}`
+- `pnpm email:build` → 3 fichiers HTML dans `dist/emails/`
+
+### Étape 5 — Tests automatisés (~1h)
+
+- **Snapshot test** (vitest, dans `emails/__tests__/build.test.ts`) :
+  - Lance le build
+  - Compare chaque HTML produit à un snapshot commité
+  - Fail si les `.tsx` modifient le HTML sans rebuild des snapshots
+- **Lint check** : test custom qui vérifie que chaque HTML contient `{{ .ConfirmationURL }}` (pas échappé) et un `<a>` valide pointant dessus
+
+### Étape 6 — Tests de compatibilité multi-clients (~1h)
+
+- Ouvrir chaque HTML compilé dans Chrome localement → validation visuelle
+- **Litmus** ou **Email on Acid** (free trial 7 jours) → previews :
+  - Gmail (web, iOS, Android)
+  - Outlook (desktop Win, web)
+  - Apple Mail (macOS, iOS)
+  - Yahoo, ProtonMail (bonus)
+- Vérifier dark mode auto-invert Gmail iOS
+- Si rendu cassé sur un client majeur → ajustements (table-based si Outlook, etc.)
+
+### Étape 7 — Intégration Supabase Auth (~15 min)
+
+- Pour chacun des 3 templates :
+  - Dashboard Supabase → Authentication → Email Templates → sélectionner le template
+  - Remplacer le contenu HTML par celui de `dist/emails/{slug}.html`
+  - Modifier le subject correspondant
+  - "Send test email" → réception dans la boîte de l'opérateur
+  - Vérification visuelle finale dans le client mail réel
+
+### Étape 8 — Documentation (~30 min)
+
+- Mettre à jour `docs/v3/legal/email-templates.md` :
+  - Ajouter une note en tête : "EN-only pour v3.0 ; `emails/templates/*.tsx` est la source de vérité"
+  - Marquer les sections FR comme "à venir post-launch via locale hook"
+- Ajouter section "Email templates" au `CLAUDE.md` :
+  - Pointer vers `emails/README.md`
+  - Procédure d'édition + déploiement Supabase
+- Créer `emails/README.md` :
+  - Explication du pipeline
+  - Comment ajouter un nouveau template (préparation phase 2)
+  - Procédure de copie vers Supabase
+
+### Charge totale estimée
+
+~5h de travail effectif, à répartir en 1-2 sessions.
+
+## 7. Tests
+
+### 7.1 Tests automatisés
+
+- `emails/__tests__/build.test.ts` (vitest) :
+  - Lance `build()` → produit du HTML attendu
+  - Snapshot test sur chaque fichier HTML
+  - Vérifie présence de `{{ .ConfirmationURL }}` non échappé
+  - Vérifie présence du subject (commenté en début de fichier ou exporté séparément)
+
+### 7.2 Tests manuels (checklist post-implémentation)
+
+- [ ] `pnpm email:dev` ouvre la preview, les 3 templates s'affichent
+- [ ] `pnpm email:build` produit 3 fichiers HTML cohérents
+- [ ] Chaque HTML contient `{{ .ConfirmationURL }}` non échappé
+- [ ] Rendu Gmail web (compte test) ✓
+- [ ] Rendu Gmail iOS (mode clair + dark) ✓
+- [ ] Rendu Outlook desktop (Windows) ✓
+- [ ] Rendu Apple Mail iOS ✓
+- [ ] Bouton CTA cliquable et navigue vers la bonne URL après substitution Supabase
+- [ ] Logo s'affiche (image GitHub raw chargée)
+- [ ] "Send test email" dans Supabase → réception OK pour les 3 templates
+
+## 8. Risques et mitigations
+
+| # | Risque | Probabilité | Impact | Mitigation |
+|---|---|---|---|---|
+| R1 | React Email échappe `{` `}` dans les attributs `href` | Moyenne | Élevé (templates inutilisables) | Détection au build (grep), post-traitement string-replace dans `build.ts` si besoin |
+| R2 | Inter via Google Fonts non chargé sur Outlook desktop | Certaine | Faible | Fallback `-apple-system, Segoe UI` déjà prévu — Outlook utilisera Segoe UI, très proche d'Inter |
+| R3 | Image GitHub raw rate-limited à grande échelle | Faible (Public Beta) | Moyen | 5000 req/h gratuites suffisent largement. Issue de suivi pour migrer dès site marketing |
+| R4 | `dist/emails/` désync du `.tsx` (oubli de rebuild) | Moyenne | Moyen | Snapshot test CI rebuild + compare → fail si désync |
+| R5 | CSS non supporté par Outlook (flexbox, grid) | Élevée si non géré | Élevé | React Email utilise par défaut des `<table>` et CSS inline → mitigé par l'outil. Validation manuelle via Litmus en étape 6 |
+| R6 | Logo monogramme actuel obsolète au moment du déploiement | Élevée (changement annoncé) | Faible | URL centralisée dans `tokens.ts` → migration en un point |
+
+## 9. Out of scope explicite (Phase 2, autre spec)
+
+- Les 4 autres emails via Edge Functions Resend :
+  - Welcome (post-signup)
+  - New device alert (refonte HTML de `send-new-device-email`)
+  - Account deletion request
+  - Account deletion completion
+- Localisation FR/EN par préférence user (hook `auth-email-hook` qui lit `user_settings.ui_language`)
+- Migration vers asset hébergé sur `lexena.app/static/email/...` (dépend du site marketing)
+- Configuration SMTP custom Resend dans Supabase Auth (déjà partiellement en place pour `send-new-device-email`)
+- Tests de deliverability poussés (DMARC/BIMI/SPF) — déjà tracés dans `docs/v3/runbooks/`
+- Logo wordmark "lexena" complet (pas seulement le monogramme) — décidé après livraison du site marketing
+
+## 10. Décisions structurelles à confirmer en planification fine
+
+Ces points sont laissés au plan d'implémentation pour décision finale, car ils n'impactent pas le design fonctionnel :
+
+- `emails/` en **workspace pnpm** ou **sous-projet indépendant** (`pnpm install` à part) ?
+- Variable `RESEND_API_KEY` ou autre secret nécessaire à ce stade ? (a priori **non**, Supabase Auth gère lui-même l'envoi tant qu'on n'a pas migré au SMTP custom)

--- a/docs/v3/legal/email-templates.md
+++ b/docs/v3/legal/email-templates.md
@@ -6,6 +6,11 @@
 > **Convention** : versions FR + EN miroir. Variables Supabase entre `{{ }}` (template Liquid).
 > **À relire** : par un copywriter avant publication. Tonalité actuelle : factuelle, sobre, pro-friendly.
 
+> ⚠️ **Phase 1 livrée 2026-05-02** — les 3 templates Supabase Auth (magic link, signup confirmation, password reset) sont implémentés en HTML stylé via React Email.
+> **Source de vérité** : `emails/templates/*.tsx`. Le markdown ci-dessous reste de référence textuelle (FR + EN) pour comparaison et préparation des phases suivantes.
+> **Langue déployée v3.0** : EN uniquement. FR reporté à une phase ultérieure (Edge Function `auth-email-hook` selon `user_settings.ui_language`).
+> **Spec & plan** : `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md` + `docs/superpowers/plans/2026-05-02-email-templates-supabase-auth.md`.
+
 ---
 
 ## Index des templates
@@ -23,6 +28,9 @@
 ---
 
 ## 1 — Magic link
+
+> ✅ Livré phase 1 (EN). Source de vérité : `emails/templates/MagicLink.tsx`.
+> 🚧 FR différé post-launch (v3.1+).
 
 ### FR
 
@@ -65,6 +73,9 @@ The Lexena team
 ---
 
 ## 2 — Signup confirmation
+
+> ✅ Livré phase 1 (EN). Source de vérité : `emails/templates/SignupConfirmation.tsx`.
+> 🚧 FR différé post-launch (v3.1+).
 
 ### FR
 
@@ -185,6 +196,9 @@ The Lexena team
 ---
 
 ## 4 — Password reset request
+
+> ✅ Livré phase 1 (EN). Source de vérité : `emails/templates/PasswordReset.tsx`.
+> 🚧 FR différé post-launch (v3.1+).
 
 ### FR
 

--- a/emails/COMPATIBILITY.md
+++ b/emails/COMPATIBILITY.md
@@ -1,0 +1,49 @@
+# Email client compatibility (Phase 1)
+
+Multi-client rendering tests for the 3 Supabase Auth templates.
+
+## Status
+
+**Pending operator action.** The matrix below is empty until tested via [Email on Acid](https://emailonacid.com) or [Litmus](https://litmus.com) (free trial sufficient for one round).
+
+## How to run the test
+
+1. Start a free trial at Email on Acid OR Litmus (7-day windows are typically enough).
+2. For each of the 3 HTML files in `dist/emails/`, upload it as a campaign / test, OR paste its contents into the in-browser HTML editor of the chosen tool.
+3. Run the multi-client preview against at least the clients listed below.
+4. Update the matrix in this file with ✅ / ⚠️ / ❌ per cell.
+5. Commit the updated `COMPATIBILITY.md`.
+
+If a client renders unusably broken on a major target (Gmail, Outlook desktop, Apple Mail), iterate on the components and re-run `pnpm email:build` + `pnpm test` before re-testing.
+
+## Matrix (to fill in)
+
+Tested via [tool] on YYYY-MM-DD.
+
+| Template | Gmail Web | Gmail iOS | Gmail Android | Outlook Win | Outlook Web | Apple Mail macOS | Apple Mail iOS |
+|---|---|---|---|---|---|---|---|
+| Magic Link | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ |
+| Signup Confirmation | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ |
+| Password Reset | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ | ⏳ |
+
+Legend: ✅ renders correctly · ⚠️ minor issue (still acceptable) · ❌ blocker · ⏳ not tested yet
+
+## Known issues
+
+(Populate after testing. Common categories: Outlook flexbox quirks, padding stripped on certain clients, font fallbacks, CTA button spacing.)
+
+## Dark mode
+
+(Populate after testing.)
+
+- Gmail iOS auto-invert: …
+- Apple Mail iOS dark mode: …
+
+## Built-in safeguards
+
+These mitigations are already in place from Phase 1:
+
+- **Inter font**: served via Google Fonts `<link>` with `-apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif` fallback. Outlook desktop will use Segoe UI (visually very close to Inter).
+- **Tables-based layout**: handled by React Email's components (no flex/grid).
+- **Inline styles**: all styles inline; no `<style>` blocks beyond the Google Fonts `@font-face` declaration React Email injects.
+- **Liquid placeholders preserved**: `unescapeLiquid()` post-processing in `build.ts` ensures `{{ .ConfirmationURL }}` is never HTML-escaped.

--- a/emails/DEPLOY_SUPABASE.md
+++ b/emails/DEPLOY_SUPABASE.md
@@ -1,0 +1,115 @@
+# Deploy to Supabase Auth — Phase 1
+
+Manual procedure for deploying the 3 compiled HTML templates (`dist/emails/*.html`) into Supabase Auth → Email Templates.
+
+This step is **operator-only** and cannot be automated from CI without giving CI access to the Supabase Dashboard.
+
+## Prerequisites
+
+- Access to the Lexena Supabase project Dashboard (admin role).
+- The latest committed `dist/emails/*.html` files on disk.
+- An operator email address you can receive test emails on (Gmail recommended for visual confirmation).
+
+## Procedure (per template)
+
+For each of the 3 templates, repeat these steps. Total time: ~5 minutes per template.
+
+### 1. Open the Supabase Dashboard
+
+Navigate to:
+
+```
+Supabase Dashboard → [project] → Authentication → Email Templates
+```
+
+### 2. Select the template type
+
+| File | Supabase template name |
+|---|---|
+| `dist/emails/magic-link.html` | **Magic Link** |
+| `dist/emails/signup-confirmation.html` | **Confirm signup** |
+| `dist/emails/password-reset.html` | **Reset Password** |
+
+### 3. Read the subject from the HTML file
+
+The subject is stored as a literal HTML comment on line 1 of each compiled file:
+
+```html
+<!-- Subject: Sign in to Lexena -->
+```
+
+Set the **Subject** field in Supabase to the value after `Subject: ` (exclude the comment markers).
+
+| File | Subject to set |
+|---|---|
+| `magic-link.html` | `Sign in to Lexena` |
+| `signup-confirmation.html` | `Confirm your Lexena email address` |
+| `password-reset.html` | `Reset your Lexena password` |
+
+### 4. Replace the HTML body
+
+- Open the local file in a text editor (e.g. VS Code).
+- Select all content (the HTML comment line is fine to keep — Supabase ignores it).
+- Copy.
+- In the Supabase template form, click in the **Message Body** / HTML editor.
+- Select all existing HTML (defaults from Supabase) and replace.
+- Paste your file contents.
+
+### 5. Save
+
+Click **Save** on the Supabase template form.
+
+### 6. Send a test email
+
+In the Supabase Dashboard you may have a "Send test email" affordance, OR trigger the flow from the Lexena app:
+
+| Template | How to trigger |
+|---|---|
+| Magic Link | Lexena app → Settings → Account → "Sign in with email" → enter your operator address |
+| Confirm signup | Sign up a fresh throwaway account (use a `+test` Gmail alias) |
+| Reset Password | Lexena app → Sign in screen → "Forgot password?" → enter your operator address |
+
+### 7. Verify in your inbox
+
+Open the email on:
+
+- **Gmail web** (desktop browser): visual matches preview from `pnpm email:dev`
+- **Mobile** (Gmail iOS / Android): layout still readable, button tappable
+- **Click the CTA**: the URL should be a real Supabase confirmation link, NOT the literal text `{{ .ConfirmationURL }}`. If you see the literal placeholder, the Liquid substitution failed — re-check that you copied the full file content (including the `<!DOCTYPE html…>` and surrounding HTML) and saved.
+
+### 8. Repeat for the next template
+
+Go back to step 1 with the next file in the table.
+
+## Common issues
+
+**"I see literal `{{ .ConfirmationURL }}` in my received email."**
+The Liquid substitution didn't fire. Most likely the HTML body field in Supabase contained extra escaping (e.g., the file was pasted into a Markdown form which re-encoded the braces). Fix: paste the file content into a raw HTML field, not a rich-text editor.
+
+**"The Inter font isn't loading."**
+Outlook desktop ignores Google Fonts `<link>` tags. The fallback Segoe UI / Helvetica is used instead — this is expected. Check the rendered font weight is still 500 on the CTA button (it should be).
+
+**"The monogram isn't loading."**
+The image URL is `https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png`. Verify the URL still resolves (the repo may have been renamed). If you're getting CSP / privacy-blocker errors in the email client, that's expected for some users — alt text "Lexena" will display.
+
+## Re-deployment after a template change
+
+After modifying any `.tsx`:
+
+```bash
+pnpm email:build
+git add dist/emails/ emails/
+git commit
+```
+
+Then re-run the procedure above only for the changed templates.
+
+## After deployment
+
+Once all 3 templates are live, mark this checklist in the PR description:
+
+```markdown
+- [ ] Magic Link template deployed and tested
+- [ ] Signup Confirmation template deployed and tested
+- [ ] Password Reset template deployed and tested
+```

--- a/emails/README.md
+++ b/emails/README.md
@@ -1,0 +1,75 @@
+# Lexena Email Templates
+
+React Email-based transactional email templates for Lexena.
+
+## Phase 1 (current — delivered 2026-05-02)
+
+3 templates served by Supabase Auth:
+- `templates/MagicLink.tsx` — `Sign in to Lexena`
+- `templates/SignupConfirmation.tsx` — `Confirm your Lexena email address`
+- `templates/PasswordReset.tsx` — `Reset your Lexena password`
+
+Language: **EN only** for v3.0. FR will be added later via a Supabase Auth email-hook keyed on `user_settings.ui_language`.
+
+## Workflow
+
+### Editing a template
+
+1. Modify the `.tsx` under `templates/`.
+2. Preview live: `pnpm email:dev` → open `http://localhost:3001`.
+3. When done, build: `pnpm email:build` → produces `../dist/emails/<slug>.html`.
+4. Run tests: `pnpm test emails/` → 23 tests should pass (4 tokens + 18 templates + 5 build).
+5. Commit the `.tsx` AND the rebuilt `dist/emails/*.html` together (snapshot regression test enforces this).
+6. Follow `DEPLOY_SUPABASE.md` to paste the new HTML into Supabase Dashboard.
+
+### Adding a new template
+
+1. Create `templates/<NewTemplate>.tsx` exporting `default` (the component) and `subject` (the subject string).
+2. Register it in `build.tsx` in the `TEMPLATES` array.
+3. Add tests to `__tests__/templates.test.tsx`.
+4. Run `pnpm test emails/` and `pnpm email:build`.
+5. Commit, then deploy following `DEPLOY_SUPABASE.md`.
+
+## Architecture
+
+- `components/tokens.ts` — design tokens (colors, font stack, logo URL, spacing)
+- `components/EmailLayout.tsx` — outer shell (Html, Head, Body, Container) with Google Fonts Inter + fallbacks
+- `components/EmailHeader.tsx` — navy header with monogram (56×56)
+- `components/EmailFooter.tsx` — footer with `contextLine` slot per template
+- `components/EmailButton.tsx` — Signal Green CTA
+- `components/EmailHeading.tsx` — H1 styled (24px / 600 / navy)
+- `components/EmailText.tsx` — paragraph (default + muted variants)
+- `components/EmailSecurityNote.tsx` — bordered callout with Signal Green left-border
+- `build.tsx` — render all templates to `../dist/emails/*.html` with Liquid placeholder safety
+- `__tests__/` — vitest snapshots, regression tests, per-template content assertions
+
+## Liquid placeholder safety
+
+Supabase Auth uses Liquid templating (`{{ .ConfirmationURL }}`). React HTML-escapes braces in attribute values, which would break the substitution. The build script (`build.tsx`) post-processes the HTML via `unescapeLiquid()` to restore literal `{{ }}`. This is guarded by tests in `__tests__/build.test.ts`.
+
+If you add a template with a NEW Liquid variable (e.g., `{{ .Email }}`), verify it survives the build by checking `dist/emails/<your-template>.html` for the literal placeholder. Add a corresponding assertion in the build test.
+
+## Logo asset
+
+The header monogram is currently a placeholder loaded from GitHub raw:
+
+```
+https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png
+```
+
+This URL is centralized in `components/tokens.ts` (`logoUrl`). Migrate to a stable CDN (e.g., `lexena.app/static/email/monogram@2x.png`) once the marketing site is deployed, OR when the new monogram design lands.
+
+## Phase 2 (planned, separate spec)
+
+Edge Functions Resend templates, sharing the same components:
+- Welcome (post-signup, FR/EN by user locale)
+- New device alert (rebuilds `send-new-device-email` HTML output)
+- Account deletion request
+- Account deletion completion
+
+See `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md` section 9 (out of scope of phase 1).
+
+## Operator runbook
+
+- `DEPLOY_SUPABASE.md` — how to deploy the compiled HTML into Supabase Dashboard.
+- `COMPATIBILITY.md` — multi-client rendering matrix (filled by operator after Litmus / Email on Acid run).

--- a/emails/__tests__/build.test.ts
+++ b/emails/__tests__/build.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, beforeAll } from "vitest";
 import { promises as fs } from "node:fs";
+import { execSync } from "node:child_process";
 import path from "node:path";
 import { build } from "../build";
 
@@ -55,5 +56,30 @@ describe("build", () => {
     expect(
       reset.startsWith("<!-- Subject: Reset your Lexena password -->"),
     ).toBe(true);
+  });
+});
+
+describe("regression: dist/emails/ is in sync with templates", () => {
+  it("freshly built HTML matches committed dist/emails/", async () => {
+    // Read committed versions from git
+    const slugs = ["magic-link", "signup-confirmation", "password-reset"];
+    const committed: Record<string, string> = {};
+    for (const slug of slugs) {
+      committed[slug] = execSync(`git show HEAD:dist/emails/${slug}.html`, {
+        encoding: "utf8",
+      });
+    }
+
+    // Rebuild
+    await build();
+
+    // Compare
+    for (const slug of slugs) {
+      const fresh = await fs.readFile(
+        path.join(distDir, `${slug}.html`),
+        "utf8",
+      );
+      expect(fresh).toBe(committed[slug]);
+    }
   });
 });

--- a/emails/__tests__/build.test.ts
+++ b/emails/__tests__/build.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { build } from "../build";
+
+const distDir = path.resolve(__dirname, "../../dist/emails");
+
+describe("build", () => {
+  beforeAll(async () => {
+    await build();
+  });
+
+  it("produces magic-link.html", async () => {
+    const html = await fs.readFile(path.join(distDir, "magic-link.html"), "utf8");
+    expect(html.length).toBeGreaterThan(500);
+    expect(html).toContain("<!DOCTYPE html");
+    expect(html).toContain("Sign in to Lexena");
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;");
+  });
+
+  it("produces signup-confirmation.html", async () => {
+    const html = await fs.readFile(
+      path.join(distDir, "signup-confirmation.html"),
+      "utf8",
+    );
+    expect(html).toContain("Welcome to Lexena");
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;");
+  });
+
+  it("produces password-reset.html", async () => {
+    const html = await fs.readFile(
+      path.join(distDir, "password-reset.html"),
+      "utf8",
+    );
+    expect(html).toContain("Reset your password");
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;");
+  });
+
+  it("includes subject as HTML comment at top of each file", async () => {
+    const magicLink = await fs.readFile(path.join(distDir, "magic-link.html"), "utf8");
+    expect(magicLink.startsWith("<!-- Subject: Sign in to Lexena -->")).toBe(true);
+
+    const signup = await fs.readFile(
+      path.join(distDir, "signup-confirmation.html"),
+      "utf8",
+    );
+    expect(
+      signup.startsWith("<!-- Subject: Confirm your Lexena email address -->"),
+    ).toBe(true);
+
+    const reset = await fs.readFile(path.join(distDir, "password-reset.html"), "utf8");
+    expect(
+      reset.startsWith("<!-- Subject: Reset your Lexena password -->"),
+    ).toBe(true);
+  });
+});

--- a/emails/__tests__/templates.test.tsx
+++ b/emails/__tests__/templates.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import { render } from "@react-email/render";
 import MagicLink, { subject as magicLinkSubject } from "../templates/MagicLink";
 import SignupConfirmation, { subject as signupSubject } from "../templates/SignupConfirmation";
+import PasswordReset, { subject as resetSubject } from "../templates/PasswordReset";
 
 describe("MagicLink template", () => {
   it("exports the expected subject", () => {
@@ -71,5 +72,38 @@ describe("SignupConfirmation template", () => {
     const html = await render(<SignupConfirmation />);
     // apostrophe may be HTML-entity-encoded
     expect(html).toMatch(/didn(?:&#x27;|')?t create a Lexena account/i);
+  });
+});
+
+describe("PasswordReset template", () => {
+  it("exports the expected subject", () => {
+    expect(resetSubject).toBe("Reset your Lexena password");
+  });
+
+  it("renders the H1 'Reset your password'", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toContain("Reset your password");
+  });
+
+  it("includes the Liquid placeholder for the confirmation URL, unescaped", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;&#123;");
+  });
+
+  it("mentions the 1-hour validity", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toMatch(/valid for 1 hour/i);
+  });
+
+  it("warns about session revocation", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toMatch(/active sessions on other devices will be revoked/i);
+  });
+
+  it("includes the CTA 'Reset password'", async () => {
+    const html = await render(<PasswordReset />);
+    expect(html).toContain(">Reset password<");
+    expect(html).toContain("</a>");
   });
 });

--- a/emails/__tests__/templates.test.tsx
+++ b/emails/__tests__/templates.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { render } from "@react-email/render";
 import MagicLink, { subject as magicLinkSubject } from "../templates/MagicLink";
+import SignupConfirmation, { subject as signupSubject } from "../templates/SignupConfirmation";
 
 describe("MagicLink template", () => {
   it("exports the expected subject", () => {
@@ -35,5 +36,40 @@ describe("MagicLink template", () => {
     // @react-email Button wraps text in spans for MSO compatibility
     expect(html).toContain(">Sign in<");
     expect(html).toContain("</a>");
+  });
+});
+
+describe("SignupConfirmation template", () => {
+  it("exports the expected subject", () => {
+    expect(signupSubject).toBe("Confirm your Lexena email address");
+  });
+
+  it("renders the H1 'Welcome to Lexena'", async () => {
+    const html = await render(<SignupConfirmation />);
+    expect(html).toContain("Welcome to Lexena");
+  });
+
+  it("includes the Liquid placeholder for the confirmation URL, unescaped", async () => {
+    const html = await render(<SignupConfirmation />);
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;&#123;");
+  });
+
+  it("mentions the 24-hour validity", async () => {
+    const html = await render(<SignupConfirmation />);
+    expect(html).toMatch(/valid for 24 hours/i);
+  });
+
+  it("includes the CTA 'Confirm my email'", async () => {
+    const html = await render(<SignupConfirmation />);
+    // Button may wrap text — use the same split-assertion pattern as MagicLink test
+    expect(html).toContain(">Confirm my email<");
+    expect(html).toContain("</a>");
+  });
+
+  it("includes the security note for unsolicited signup", async () => {
+    const html = await render(<SignupConfirmation />);
+    // apostrophe may be HTML-entity-encoded
+    expect(html).toMatch(/didn(?:&#x27;|')?t create a Lexena account/i);
   });
 });

--- a/emails/__tests__/templates.test.tsx
+++ b/emails/__tests__/templates.test.tsx
@@ -1,0 +1,39 @@
+import { describe, it, expect } from "vitest";
+import { render } from "@react-email/render";
+import MagicLink, { subject as magicLinkSubject } from "../templates/MagicLink";
+
+describe("MagicLink template", () => {
+  it("exports the expected subject", () => {
+    expect(magicLinkSubject).toBe("Sign in to Lexena");
+  });
+
+  it("renders the H1 'Sign in to Lexena'", async () => {
+    const html = await render(<MagicLink />);
+    expect(html).toContain("Sign in to Lexena");
+  });
+
+  it("includes the Liquid placeholder for the confirmation URL, unescaped", async () => {
+    const html = await render(<MagicLink />);
+    expect(html).toContain("{{ .ConfirmationURL }}");
+    expect(html).not.toContain("&#123;&#123;");
+    expect(html).not.toContain("&lbrace;");
+  });
+
+  it("includes the validity duration", async () => {
+    const html = await render(<MagicLink />);
+    expect(html).toMatch(/valid for 1 hour/i);
+  });
+
+  it("includes the security note for unsolicited sign-in", async () => {
+    const html = await render(<MagicLink />);
+    // apostrophe may be rendered as &#x27; by the email renderer
+    expect(html).toMatch(/didn(?:&#x27;|')?t request this sign-in/i);
+  });
+
+  it("includes the CTA button label", async () => {
+    const html = await render(<MagicLink />);
+    // @react-email Button wraps text in spans for MSO compatibility
+    expect(html).toContain(">Sign in<");
+    expect(html).toContain("</a>");
+  });
+});

--- a/emails/__tests__/tokens.test.ts
+++ b/emails/__tests__/tokens.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from "vitest";
+import { colors, fontStack, logoUrl, spacing } from "../components/tokens";
+
+describe("tokens", () => {
+  it("exposes Lexena brand colors", () => {
+    expect(colors.navy).toBe("#0D1B2A");
+    expect(colors.signalGreen).toBe("#1D9E75");
+    expect(colors.bg).toBe("#F6F6F7");
+    expect(colors.card).toBe("#FFFFFF");
+  });
+
+  it("provides a font stack starting with Inter", () => {
+    expect(fontStack).toMatch(/^Inter,/);
+    expect(fontStack).toContain("-apple-system");
+    expect(fontStack).toContain("Segoe UI");
+  });
+
+  it("exposes a stable logo URL", () => {
+    expect(logoUrl).toMatch(/^https:\/\//);
+    expect(logoUrl).toContain("monogram");
+  });
+
+  it("provides spacing scale", () => {
+    expect(spacing.lg).toBe("32px");
+    expect(spacing.xl).toBe("40px");
+  });
+});

--- a/emails/build.tsx
+++ b/emails/build.tsx
@@ -1,0 +1,69 @@
+import { promises as fs } from "node:fs";
+import path from "node:path";
+import { fileURLToPath } from "node:url";
+import React from "react";
+import { render } from "@react-email/render";
+import type { ComponentType } from "react";
+
+import MagicLink, { subject as magicLinkSubject } from "./templates/MagicLink";
+import SignupConfirmation, {
+  subject as signupSubject,
+} from "./templates/SignupConfirmation";
+import PasswordReset, { subject as resetSubject } from "./templates/PasswordReset";
+
+interface TemplateEntry {
+  slug: string;
+  subject: string;
+  Component: ComponentType;
+}
+
+const TEMPLATES: TemplateEntry[] = [
+  { slug: "magic-link", subject: magicLinkSubject, Component: MagicLink },
+  {
+    slug: "signup-confirmation",
+    subject: signupSubject,
+    Component: SignupConfirmation,
+  },
+  { slug: "password-reset", subject: resetSubject, Component: PasswordReset },
+];
+
+/**
+ * React HTML-escapes `{` and `}` in attribute values, which would break Supabase
+ * Liquid templating. We restore the literal `{{ ... }}` placeholders post-render.
+ */
+function unescapeLiquid(html: string): string {
+  return html
+    .replace(/&#123;&#123;/g, "{{")
+    .replace(/&#125;&#125;/g, "}}")
+    .replace(/&#123;/g, "{")
+    .replace(/&#125;/g, "}")
+    .replace(/&lbrace;/g, "{")
+    .replace(/&rbrace;/g, "}");
+}
+
+export async function build(): Promise<void> {
+  const here = path.dirname(fileURLToPath(import.meta.url));
+  const outDir = path.resolve(here, "../dist/emails");
+  await fs.mkdir(outDir, { recursive: true });
+
+  for (const { slug, subject, Component } of TEMPLATES) {
+    const rawHtml = await render(React.createElement(Component), { pretty: true });
+    const safeHtml = unescapeLiquid(rawHtml);
+    const withSubject = `<!-- Subject: ${subject} -->\n${safeHtml}`;
+    const outPath = path.join(outDir, `${slug}.html`);
+    await fs.writeFile(outPath, withSubject, "utf8");
+    console.log(`✓ ${slug}.html (${withSubject.length} bytes)`);
+  }
+}
+
+// Cross-platform "is this file the script entrypoint?" check.
+const isEntrypoint =
+  process.argv[1] !== undefined &&
+  path.resolve(fileURLToPath(import.meta.url)) === path.resolve(process.argv[1]);
+
+if (isEntrypoint) {
+  build().catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });
+}

--- a/emails/components/EmailButton.tsx
+++ b/emails/components/EmailButton.tsx
@@ -1,0 +1,28 @@
+import { Button } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors } from "./tokens";
+
+interface EmailButtonProps {
+  href: string;
+  children: ReactNode;
+}
+
+export function EmailButton({ href, children }: EmailButtonProps) {
+  return (
+    <Button
+      href={href}
+      style={{
+        backgroundColor: colors.signalGreen,
+        color: "#FFFFFF",
+        padding: "14px 28px",
+        borderRadius: "8px",
+        fontSize: "16px",
+        fontWeight: 500,
+        textDecoration: "none",
+        display: "inline-block",
+      }}
+    >
+      {children}
+    </Button>
+  );
+}

--- a/emails/components/EmailFooter.tsx
+++ b/emails/components/EmailFooter.tsx
@@ -1,0 +1,34 @@
+import { Hr, Section, Text } from "@react-email/components";
+import { colors } from "./tokens";
+
+interface EmailFooterProps {
+  contextLine: string;
+}
+
+export function EmailFooter({ contextLine }: EmailFooterProps) {
+  return (
+    <Section style={{ padding: "0 40px 32px 40px" }}>
+      <Hr style={{ borderColor: colors.border, margin: "32px 0 24px 0" }} />
+      <Text
+        style={{
+          color: colors.textMuted,
+          fontSize: "12px",
+          lineHeight: "18px",
+          margin: 0,
+        }}
+      >
+        Lexena · lexena.app
+      </Text>
+      <Text
+        style={{
+          color: colors.textMuted,
+          fontSize: "12px",
+          lineHeight: "18px",
+          margin: "8px 0 0 0",
+        }}
+      >
+        {contextLine}
+      </Text>
+    </Section>
+  );
+}

--- a/emails/components/EmailHeader.tsx
+++ b/emails/components/EmailHeader.tsx
@@ -1,0 +1,26 @@
+import { Img, Section } from "@react-email/components";
+import { colors, logoUrl } from "./tokens";
+
+export function EmailHeader() {
+  return (
+    <Section
+      style={{
+        backgroundColor: colors.navy,
+        padding: "32px 0",
+        textAlign: "center",
+      }}
+    >
+      <Img
+        src={logoUrl}
+        alt="Lexena"
+        width="56"
+        height="56"
+        style={{
+          margin: "0 auto",
+          display: "block",
+          borderRadius: "8px",
+        }}
+      />
+    </Section>
+  );
+}

--- a/emails/components/EmailHeading.tsx
+++ b/emails/components/EmailHeading.tsx
@@ -1,0 +1,24 @@
+import { Heading } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors } from "./tokens";
+
+interface EmailHeadingProps {
+  children: ReactNode;
+}
+
+export function EmailHeading({ children }: EmailHeadingProps) {
+  return (
+    <Heading
+      as="h1"
+      style={{
+        color: colors.navy,
+        fontSize: "24px",
+        fontWeight: 600,
+        lineHeight: "32px",
+        margin: "0 0 16px 0",
+      }}
+    >
+      {children}
+    </Heading>
+  );
+}

--- a/emails/components/EmailLayout.tsx
+++ b/emails/components/EmailLayout.tsx
@@ -1,0 +1,49 @@
+import { Body, Container, Font, Head, Html, Preview } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors, fontStack } from "./tokens";
+
+interface EmailLayoutProps {
+  preview: string;
+  children: ReactNode;
+}
+
+export function EmailLayout({ preview, children }: EmailLayoutProps) {
+  return (
+    <Html lang="en">
+      <Head>
+        <Font
+          fontFamily="Inter"
+          fallbackFontFamily="Helvetica"
+          webFont={{
+            url: "https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&display=swap",
+            format: "woff2",
+          }}
+          fontWeight={400}
+          fontStyle="normal"
+        />
+      </Head>
+      <Preview>{preview}</Preview>
+      <Body
+        style={{
+          backgroundColor: colors.bg,
+          fontFamily: fontStack,
+          margin: 0,
+          padding: "32px 0",
+        }}
+      >
+        <Container
+          style={{
+            backgroundColor: colors.card,
+            borderRadius: "12px",
+            maxWidth: "560px",
+            margin: "0 auto",
+            overflow: "hidden",
+            boxShadow: "0 1px 3px rgba(0, 0, 0, 0.05)",
+          }}
+        >
+          {children}
+        </Container>
+      </Body>
+    </Html>
+  );
+}

--- a/emails/components/EmailSecurityNote.tsx
+++ b/emails/components/EmailSecurityNote.tsx
@@ -1,0 +1,33 @@
+import { Section, Text } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors } from "./tokens";
+
+interface EmailSecurityNoteProps {
+  children: ReactNode;
+}
+
+export function EmailSecurityNote({ children }: EmailSecurityNoteProps) {
+  return (
+    <Section
+      style={{
+        backgroundColor: colors.noteBg,
+        borderLeft: `3px solid ${colors.signalGreen}`,
+        borderRadius: "6px",
+        padding: "16px",
+        margin: "24px 0",
+      }}
+    >
+      <Text
+        style={{
+          color: colors.text,
+          fontSize: "14px",
+          lineHeight: "22px",
+          fontStyle: "italic",
+          margin: 0,
+        }}
+      >
+        {children}
+      </Text>
+    </Section>
+  );
+}

--- a/emails/components/EmailText.tsx
+++ b/emails/components/EmailText.tsx
@@ -1,0 +1,24 @@
+import { Text } from "@react-email/components";
+import type { ReactNode } from "react";
+import { colors } from "./tokens";
+
+interface EmailTextProps {
+  children: ReactNode;
+  variant?: "default" | "muted";
+}
+
+export function EmailText({ children, variant = "default" }: EmailTextProps) {
+  const isMuted = variant === "muted";
+  return (
+    <Text
+      style={{
+        color: isMuted ? colors.textMuted : colors.text,
+        fontSize: isMuted ? "14px" : "16px",
+        lineHeight: isMuted ? "22px" : "26px",
+        margin: "0 0 16px 0",
+      }}
+    >
+      {children}
+    </Text>
+  );
+}

--- a/emails/components/tokens.ts
+++ b/emails/components/tokens.ts
@@ -1,0 +1,24 @@
+export const colors = {
+  navy: "#0D1B2A",
+  signalGreen: "#1D9E75",
+  bg: "#F6F6F7",
+  card: "#FFFFFF",
+  text: "#374151",
+  textMuted: "#6B7280",
+  border: "#E5E7EB",
+  noteBg: "#F3F4F6",
+} as const;
+
+export const fontStack =
+  "Inter, -apple-system, BlinkMacSystemFont, 'Segoe UI', Helvetica, Arial, sans-serif";
+
+export const logoUrl =
+  "https://raw.githubusercontent.com/Nolyo/voice-tool/main/src-tauri/icons/monogram-512.png";
+
+export const spacing = {
+  xs: "8px",
+  sm: "16px",
+  md: "24px",
+  lg: "32px",
+  xl: "40px",
+} as const;

--- a/emails/templates/MagicLink.tsx
+++ b/emails/templates/MagicLink.tsx
@@ -1,0 +1,33 @@
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { EmailHeader } from "../components/EmailHeader";
+import { EmailFooter } from "../components/EmailFooter";
+import { EmailHeading } from "../components/EmailHeading";
+import { EmailText } from "../components/EmailText";
+import { EmailButton } from "../components/EmailButton";
+import { EmailSecurityNote } from "../components/EmailSecurityNote";
+
+export const subject = "Sign in to Lexena";
+
+export default function MagicLink() {
+  return (
+    <EmailLayout preview="Sign in to your Lexena account">
+      <EmailHeader />
+      <Section style={{ padding: "40px" }}>
+        <EmailHeading>Sign in to Lexena</EmailHeading>
+        <EmailText>Click the button below to sign in to your account.</EmailText>
+        <Section style={{ textAlign: "center", margin: "32px 0" }}>
+          <EmailButton href="{{ .ConfirmationURL }}">Sign in</EmailButton>
+        </Section>
+        <EmailText variant="muted">
+          This link is valid for 1 hour and can only be used once.
+        </EmailText>
+        <EmailSecurityNote>
+          Didn't request this sign-in? You can safely ignore this message — your account remains secure.
+        </EmailSecurityNote>
+        <EmailText variant="muted">— The Lexena team</EmailText>
+        <EmailFooter contextLine="You received this email because of a sign-in request on your Lexena account." />
+      </Section>
+    </EmailLayout>
+  );
+}

--- a/emails/templates/PasswordReset.tsx
+++ b/emails/templates/PasswordReset.tsx
@@ -1,0 +1,33 @@
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { EmailHeader } from "../components/EmailHeader";
+import { EmailFooter } from "../components/EmailFooter";
+import { EmailHeading } from "../components/EmailHeading";
+import { EmailText } from "../components/EmailText";
+import { EmailButton } from "../components/EmailButton";
+import { EmailSecurityNote } from "../components/EmailSecurityNote";
+
+export const subject = "Reset your Lexena password";
+
+export default function PasswordReset() {
+  return (
+    <EmailLayout preview="Reset your Lexena password">
+      <EmailHeader />
+      <Section style={{ padding: "40px" }}>
+        <EmailHeading>Reset your password</EmailHeading>
+        <EmailText>Click the button below to choose a new password.</EmailText>
+        <Section style={{ textAlign: "center", margin: "32px 0" }}>
+          <EmailButton href="{{ .ConfirmationURL }}">Reset password</EmailButton>
+        </Section>
+        <EmailText variant="muted">
+          This link is valid for 1 hour and can only be used once.
+        </EmailText>
+        <EmailSecurityNote>
+          If you didn't request this, ignore this message — your current password remains valid. On the next successful login after reset, all your active sessions on other devices will be revoked.
+        </EmailSecurityNote>
+        <EmailText variant="muted">— The Lexena team</EmailText>
+        <EmailFooter contextLine="You received this email because of a password reset request on your Lexena account." />
+      </Section>
+    </EmailLayout>
+  );
+}

--- a/emails/templates/SignupConfirmation.tsx
+++ b/emails/templates/SignupConfirmation.tsx
@@ -1,0 +1,33 @@
+import { Section } from "@react-email/components";
+import { EmailLayout } from "../components/EmailLayout";
+import { EmailHeader } from "../components/EmailHeader";
+import { EmailFooter } from "../components/EmailFooter";
+import { EmailHeading } from "../components/EmailHeading";
+import { EmailText } from "../components/EmailText";
+import { EmailButton } from "../components/EmailButton";
+import { EmailSecurityNote } from "../components/EmailSecurityNote";
+
+export const subject = "Confirm your Lexena email address";
+
+export default function SignupConfirmation() {
+  return (
+    <EmailLayout preview="Confirm your Lexena email to finalize your account">
+      <EmailHeader />
+      <Section style={{ padding: "40px" }}>
+        <EmailHeading>Welcome to Lexena</EmailHeading>
+        <EmailText>
+          To finalize your account creation, please confirm your email address.
+        </EmailText>
+        <Section style={{ textAlign: "center", margin: "32px 0" }}>
+          <EmailButton href="{{ .ConfirmationURL }}">Confirm my email</EmailButton>
+        </Section>
+        <EmailText variant="muted">This link is valid for 24 hours.</EmailText>
+        <EmailSecurityNote>
+          Didn't create a Lexena account? You can safely ignore this message.
+        </EmailSecurityNote>
+        <EmailText variant="muted">— The Lexena team</EmailText>
+        <EmailFooter contextLine="You received this email because someone signed up to Lexena with this address." />
+      </Section>
+    </EmailLayout>
+  );
+}

--- a/emails/tsconfig.json
+++ b/emails/tsconfig.json
@@ -1,0 +1,17 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "jsx": "react-jsx",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "allowSyntheticDefaultImports": true,
+    "isolatedModules": true,
+    "noEmit": true,
+    "types": ["node"]
+  },
+  "include": ["**/*.ts", "**/*.tsx"]
+}

--- a/package.json
+++ b/package.json
@@ -10,7 +10,9 @@
     "tauri": "tauri",
     "test": "vitest run",
     "test:watch": "vitest",
-    "gen:pwned": "tsx scripts/generate-pwned-list.ts"
+    "gen:pwned": "tsx scripts/generate-pwned-list.ts",
+    "email:dev": "cd emails && react-email dev --port 3001",
+    "email:build": "tsx emails/build.ts"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",
@@ -71,12 +73,15 @@
     "zod": "^4.3.6"
   },
   "devDependencies": {
+    "@react-email/components": "^1.0.12",
+    "@react-email/render": "^2.0.8",
     "@tauri-apps/cli": "^2",
     "@types/node": "^24.8.1",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",
     "@vitest/ui": "^4.1.5",
+    "react-email": "^6.0.5",
     "supabase": "^2.95.2",
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "gen:pwned": "tsx scripts/generate-pwned-list.ts",
-    "email:dev": "cd emails && react-email dev --port 3001",
+    "email:dev": "cd emails && pnpm exec email dev --port 3001",
     "email:build": "tsx --tsconfig emails/tsconfig.json emails/build.tsx"
   },
   "dependencies": {
@@ -75,6 +75,7 @@
   "devDependencies": {
     "@react-email/components": "^1.0.12",
     "@react-email/render": "^2.0.8",
+    "@react-email/ui": "^6.0.5",
     "@tauri-apps/cli": "^2",
     "@types/node": "^24.8.1",
     "@types/react": "^19.1.8",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "test:watch": "vitest",
     "gen:pwned": "tsx scripts/generate-pwned-list.ts",
     "email:dev": "cd emails && react-email dev --port 3001",
-    "email:build": "tsx emails/build.ts"
+    "email:build": "tsx --tsconfig emails/tsconfig.json emails/build.tsx"
   },
   "dependencies": {
     "@dnd-kit/core": "^6.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -183,6 +183,12 @@ importers:
         specifier: ^4.3.6
         version: 4.3.6
     devDependencies:
+      '@react-email/components':
+        specifier: ^1.0.12
+        version: 1.0.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-email/render':
+        specifier: ^2.0.8
+        version: 2.0.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.8.4
@@ -201,6 +207,9 @@ importers:
       '@vitest/ui':
         specifier: ^4.1.5
         version: 4.1.5(vitest@4.1.5)
+      react-email:
+        specifier: ^6.0.5
+        version: 6.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       supabase:
         specifier: ^2.95.2
         version: 2.95.2
@@ -276,6 +285,11 @@ packages:
     resolution: {integrity: sha512-HFN59MmQXGHVyYadKLVumYsA9dBFun/ldYxipEjzA4196jpLZd8UjEEBLkbEkvfYreDqJhZxYAWFPtrfhNpj4w==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/parser@7.27.0':
+    resolution: {integrity: sha512-iaepho73/2Pz7w2eMS0Q5f83+0RKI7i4xmiYeBmDzfRVbQtTOG7Ts0S4HzJVsTMGI9keU8rNfuZr8DKfSt7Yyg==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   '@babel/parser@7.28.4':
     resolution: {integrity: sha512-yZbBqeM6TkpP9du/I2pUZnJsRMGGvOuIrhjzC1AwHwW+6he4mni6Bp/m8ijn0iOuZuPI2BfkCoSRunpyjnrQKg==}
     engines: {node: '>=6.0.0'}
@@ -299,6 +313,10 @@ packages:
 
   '@babel/template@7.27.2':
     resolution: {integrity: sha512-LPDZ85aEJyYSd18/DkjNh4/y1ntkE5KwUHWTiqgRxruuZL2F1yuHligVHLvcHY2vMHXttKFpJn6LwfI7cw7ODw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/traverse@7.27.0':
+    resolution: {integrity: sha512-19lYZFzYVQkkHkl4Cy4WrAVcqBkgvV2YM2TU3xG6DIwO7O3ecbDPfW3yM3bjAGcqcQHi+CCtjMR3dIEHxsd6bA==}
     engines: {node: '>=6.9.0'}
 
   '@babel/traverse@7.28.4':
@@ -337,8 +355,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.27.7':
     resolution: {integrity: sha512-62dPZHpIXzvChfvfLJow3q5dDtiNMkwiRzPylSCfriLvZeq0a1bWChrGx/BbUbPwOrsWKMn8idSllklzBy+dgQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -349,8 +379,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.27.7':
     resolution: {integrity: sha512-x5VpMODneVDb70PYV2VQOmIUUiBtY3D3mPBG8NxVk5CogneYhkR7MmM3yR/uMdITLrC1ml/NV1rj4bMJuy9MCg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -361,8 +403,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.27.7':
     resolution: {integrity: sha512-rYnXrKcXuT7Z+WL5K980jVFdvVKhCHhUwid+dDYQpH+qu+TefcomiMAJpIiC2EM3Rjtq0sO3StMV/+3w3MyyqQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -373,8 +427,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.27.7':
     resolution: {integrity: sha512-jOBDK5XEjA4m5IJK3bpAQF9/Lelu/Z9ZcdhTRLf4cajlB+8VEhFFRjWgfy3M1O4rO2GQ/b2dLwCUGpiF/eATNQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -385,8 +451,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.27.7':
     resolution: {integrity: sha512-RkT/YXYBTSULo3+af8Ib0ykH8u2MBh57o7q/DAs3lTJlyVQkgQvlrPTnjIzzRPQyavxtPtfg0EopvDyIt0j1rA==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -397,8 +475,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.27.7':
     resolution: {integrity: sha512-a4POruNM2oWsD4WKvBSEKGIiWQF8fZOAsycHOt6JBpZ+JN2n2JH9WAv56SOyu9X5IqAjqSIPTaJkqN8F7XOQ5Q==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -409,8 +499,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.27.7':
     resolution: {integrity: sha512-gRsL4x6wsGHGRqhtI+ifpN/vpOFTQtnbsupUF5R5YTAg+y/lKelYR1hXbnBdzDjGbMYjVJLJTd2OFmMewAgwlQ==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -421,8 +523,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.27.7':
     resolution: {integrity: sha512-2k8go8Ycu1Kb46vEelhu1vqEP+UeRVj2zY1pSuPdgvbd5ykAw82Lrro28vXUrRmzEsUV0NzCf54yARIK8r0fdw==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -433,8 +547,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.27.7':
     resolution: {integrity: sha512-b6pqtrQdigZBwZxAn1UpazEisvwaIDvdbMbmrly7cDTMFnw/+3lVxxCTGOrkPVnsYIosJJXAsILG9XcQS+Yu6w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -445,8 +571,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.27.7':
     resolution: {integrity: sha512-AFuojMQTxAz75Fo8idVcqoQWEHIXFRbOc1TrVcFSgCZtQfSdc1RXgB3tjOn/krRHENUB4j00bfGjyl2mJrU37A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -457,8 +595,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.27.7':
     resolution: {integrity: sha512-+KrvYb/C8zA9CU/g0sR6w2RBw7IGc5J2BPnc3dYc5VJxHCSF1yNMxTV5LQ7GuKteQXZtspjFbiuW5/dOj7H4Yw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -469,8 +619,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.27.7':
     resolution: {integrity: sha512-7yRhbHvPqSpRUV7Q20VuDwbjW5kIMwTHpptuUzV+AA46kiPze5Z7qgt6CLCK3pWFrHeNfDd1VKgyP4O+ng17CA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -481,8 +643,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.27.7':
     resolution: {integrity: sha512-56hiAJPhwQ1R4i+21FVF7V8kSD5zZTdHcVuRFMW0hn753vVfQN8xlx4uOPT4xoGH0Z/oVATuR82AiqSTDIpaHg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -928,6 +1102,192 @@ packages:
   '@radix-ui/rect@1.1.1':
     resolution: {integrity: sha512-HPwpGIzkl28mWyZqG52jiqDJ12waP11Pa1lGoiyUkIEuMLBP0oeK/C89esbXrxsky5we7dfd8U58nm0SgAWpVw==}
 
+  '@react-email/body@0.3.0':
+    resolution: {integrity: sha512-uGo0BOOzjbMUo3lu+BIDWayvn5o6Xyfmnlla5VGf05n8gHMvO1ll7U4FtzWe3hxMLwt53pmc4iE0M+B5slG+Ug==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/button@0.2.1':
+    resolution: {integrity: sha512-qXyj7RZLE7POy9BMKSoqQ00tOXThjOZSUnI2Yu9i29IHngPlmrNayIWBoVKtElES7OWwypUcpiajwi1mUWx6/A==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/code-block@0.2.1':
+    resolution: {integrity: sha512-M3B7JpVH4ytgn83/ujRR1k1DQHvTeABiDM61OvAbjLRPhC/5KLHU5KkzIbbuGIrjWwxAbL1kSQzU8MhLEtSxyw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/code-inline@0.0.6':
+    resolution: {integrity: sha512-jfhebvv3dVsp3OdPgKXnk8+e2pBiDVZejDOBFzBa/IblrAJ9cQDkN6rBD5IyEg8hTOxwbw3iaI/yZFmDmIguIA==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/column@0.0.14':
+    resolution: {integrity: sha512-f+W+Bk2AjNO77zynE33rHuQhyqVICx4RYtGX9NKsGUg0wWjdGP0qAuIkhx9Rnmk4/hFMo1fUrtYNqca9fwJdHg==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/components@1.0.12':
+    resolution: {integrity: sha512-tH18JhPDWgE+3jnYkzyB6ZrZdfNnEsFe4PwmuXmlOw4NGIysP8wPY5aXZg++pTG9qUabXg1nzX/FGHGkObH8xQ==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/container@0.0.16':
+    resolution: {integrity: sha512-QWBB56RkkU0AJ9h+qy33gfT5iuZknPC7Un/IjZv9B0QmMIK+WWacc0cH6y2SV5Cv/b99hU94fjEMOOO4enpkbQ==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/font@0.0.10':
+    resolution: {integrity: sha512-0urVSgCmQIfx5r7Xc586miBnQUVnGp3OTYUm8m5pwtQRdTRO5XrTtEfNJ3JhYhSOruV0nD8fd+dXtKXobum6tA==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/head@0.0.13':
+    resolution: {integrity: sha512-AJg6le/08Gz4tm+6MtKXqtNNyKHzmooOCdmtqmWxD7FxoAdU1eVcizhtQ0gcnVaY6ethEyE/hnEzQxt1zu5Kog==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/heading@0.0.16':
+    resolution: {integrity: sha512-jmsKnQm1ykpBzw4hCYHwBkt5pW2jScXffPeEH5ZRF5tZeF5b1pvlFTO9han7C0pCkZYo1kEvWiRtx69yfCIwuw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/hr@0.0.12':
+    resolution: {integrity: sha512-TwmOmBDibavUQpXBxpmZYi2Iks/yeZOzFYh+di9EltMSnEabH8dMZXrl+pxNXzCgZ2XE8HY7VmUL65Lenfu5PA==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/html@0.0.12':
+    resolution: {integrity: sha512-KTShZesan+UsreU7PDUV90afrZwU5TLwYlALuCSU0OT+/U8lULNNbAUekg+tGwCnOfIKYtpDPKkAMRdYlqUznw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/img@0.0.12':
+    resolution: {integrity: sha512-sRCpEARNVTf3FQhZOC+JTvu5r6ubiYWkT0ucYXg8ctkyi4G8QG+jgYPiNUqVeTLA2STOfmPM/nrk1nb84y6CPQ==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/link@0.0.13':
+    resolution: {integrity: sha512-lkWc/NjOcefRZMkQoSDDbuKBEBDES9aXnFEOuPH845wD3TxPwh+QTf0fStuzjoRLUZWpHnio4z7qGGRYusn/sw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/markdown@0.0.18':
+    resolution: {integrity: sha512-gSuYK5fsMbGk87jDebqQ6fa2fKcWlkf2Dkva8kMONqLgGCq8/0d+ZQYMEJsdidIeBo3kmsnHZPrwdFB4HgjUXg==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/preview@0.0.14':
+    resolution: {integrity: sha512-aYK8q0IPkBXyMsbpMXgxazwHxYJxTrXrV95GFuu2HbEiIToMwSyUgb8HDFYwPqqfV03/jbwqlsXmFxsOd+VNaw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/render@2.0.6':
+    resolution: {integrity: sha512-xOzaYkH3jLZKqN5MqrTXYnmqBYUnZSVbkxdb5PGGmDcK6sKDVMliaDiSwfXajRC9JtSHTcGc2tmGLHWuCgVpog==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/render@2.0.8':
+    resolution: {integrity: sha512-5udvVr3U/WuGJZfLdLBOhkzrqRWd2Q5ZYmF7ppcy7FzWcwgshdqLMNqJOXcVzAXJXg/2bm7D+WGJzTtZOZMQnQ==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/row@0.0.13':
+    resolution: {integrity: sha512-bYnOac40vIKCId7IkwuLAAsa3fKfSfqCvv6epJKmPE0JBuu5qI4FHFCl9o9dVpIIS08s/ub+Y/txoMt0dYziGw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/section@0.0.17':
+    resolution: {integrity: sha512-qNl65ye3W0Rd5udhdORzTV9ezjb+GFqQQSae03NDzXtmJq6sqVXNWNiVolAjvJNypim+zGXmv6J9TcV5aNtE/w==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
+  '@react-email/tailwind@2.0.7':
+    resolution: {integrity: sha512-kGw80weVFXikcnCXbigTGXGWQ0MRCSYNCudcdkWxebkWYd0FG6/NPoN3V1p/u68/4+NxZwYPVi2fhnp0x23HdA==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      '@react-email/body': '>=0'
+      '@react-email/button': '>=0'
+      '@react-email/code-block': '>=0'
+      '@react-email/code-inline': '>=0'
+      '@react-email/container': '>=0'
+      '@react-email/heading': '>=0'
+      '@react-email/hr': '>=0'
+      '@react-email/img': '>=0'
+      '@react-email/link': '>=0'
+      '@react-email/preview': '>=0'
+      '@react-email/text': '>=0'
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+    peerDependenciesMeta:
+      '@react-email/body':
+        optional: true
+      '@react-email/button':
+        optional: true
+      '@react-email/code-block':
+        optional: true
+      '@react-email/code-inline':
+        optional: true
+      '@react-email/container':
+        optional: true
+      '@react-email/heading':
+        optional: true
+      '@react-email/hr':
+        optional: true
+      '@react-email/img':
+        optional: true
+      '@react-email/link':
+        optional: true
+      '@react-email/preview':
+        optional: true
+
+  '@react-email/text@0.1.6':
+    resolution: {integrity: sha512-TYqkioRS45wTR5il3dYk/SbUjjEdhSwh9BtRNB99qNH1pXAwA45H7rAuxehiu8iJQJH0IyIr+6n62gBz9ezmsw==}
+    engines: {node: '>=20.0.0'}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
@@ -1058,6 +1418,12 @@ packages:
     resolution: {integrity: sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==}
     cpu: [x64]
     os: [win32]
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    resolution: {integrity: sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ==}
+
+  '@socket.io/component-emitter@3.1.2':
+    resolution: {integrity: sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -1510,6 +1876,9 @@ packages:
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
 
+  '@types/cors@2.8.19':
+    resolution: {integrity: sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==}
+
   '@types/deep-eql@4.0.2':
     resolution: {integrity: sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==}
 
@@ -1617,9 +1986,24 @@ packages:
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
 
+  accepts@1.3.8:
+    resolution: {integrity: sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==}
+    engines: {node: '>= 0.6'}
+
   agent-base@9.0.0:
     resolution: {integrity: sha512-TQf59BsZnytt8GdJKLPfUZ54g/iaUL2OWDSFCCvMOhsHduDQxO8xC4PNeyIkVcA5KwL2phPSv0douC0fgWzmnA==}
     engines: {node: '>= 20'}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
@@ -1632,6 +2016,17 @@ packages:
     resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
     engines: {node: '>=12'}
 
+  atomically@2.1.1:
+    resolution: {integrity: sha512-P4w9o2dqARji6P7MHprklbfiArZAWvo07yW7qs3pdljb3BWr12FIB7W+p0zJiuiVsUpRO0iZn1kFFcpPegg0tQ==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  base64id@2.0.0:
+    resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
+    engines: {node: ^4.5.0 || >= 5.9}
+
   baseline-browser-mapping@2.8.17:
     resolution: {integrity: sha512-j5zJcx6golJYTG6c05LUZ3Z8Gi+M62zRT/ycz4Xq4iCOdpcxwg7ngEYD4KA0eWZC7U17qh/Smq8bYbACJ0ipBA==}
     hasBin: true
@@ -1639,6 +2034,10 @@ packages:
   bin-links@6.0.0:
     resolution: {integrity: sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  brace-expansion@5.0.5:
+    resolution: {integrity: sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==}
+    engines: {node: 18 || 20 || >=22}
 
   browserslist@4.26.3:
     resolution: {integrity: sha512-lAUU+02RFBuCKQPj/P6NgjlbCnLBMp4UtgTx7vNHd3XSIJF87s9a5rA3aH2yw3GS9DqZAUbOtZdCCiZeVRqt0w==}
@@ -1652,9 +2051,16 @@ packages:
     resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
   chownr@3.0.0:
     resolution: {integrity: sha512-+IxzY9BZOQd/XuYPRmrvEVjF/nqj5kgT4kEq7VofrDoM1MxoRjEWkrCC3EtLi59TVawxTAn+orJwFQcrqEN1+g==}
     engines: {node: '>=18'}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
@@ -1667,11 +2073,31 @@ packages:
     resolution: {integrity: sha512-Jk/BK6NCapZ58BKUxlSI+ouKRbjH1NLZCgJkYoab+vEHUY3f6OzpNBN9u7HFSv9J6TRDGs4PLOHezoKGaFRSCA==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  commander@13.1.0:
+    resolution: {integrity: sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==}
+    engines: {node: '>=18'}
+
+  conf@15.1.0:
+    resolution: {integrity: sha512-Uy5YN9KEu0WWDaZAVJ5FAmZoaJt9rdK6kH+utItPyGsCqCgaTKkrmZx3zoE0/3q6S3bcp3Ihkk+ZqPxWxFK5og==}
+    engines: {node: '>=20'}
+
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
 
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cors@2.8.6:
+    resolution: {integrity: sha512-tJtZBBHA6vjIAaF6EnIaq6laBBP9aq/Y3ouVJjEfoHbRBcHBAHYcMh/w8LDrk2PvIMMq8gmopa5D4V8RmbrxGw==}
+    engines: {node: '>= 0.10'}
+
   crelt@1.0.6:
     resolution: {integrity: sha512-VQ2MBenTq1fWZUH9DJNGti7kKv6EeAuYr3cLwxUWhIu1baTaXh4Ib5W2CqHVqib4/MqbYGJqiL3Zb8GJZr3l4g==}
+
+  css-tree@3.2.1:
+    resolution: {integrity: sha512-X7sjQzceUhu1u7Y/ylrRZFU2FS6LRiFVp6rKLPg23y3x3c3DOKAwuXGDp+PAGjh6CSnCjYeAul8pcT8bAl+lSA==}
+    engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0}
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
@@ -1679,6 +2105,14 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
+
+  debounce-fn@6.0.0:
+    resolution: {integrity: sha512-rBMW+F2TXryBwB54Q0d8drNEI+TfoS9JpNTAoVpukbWEhjXQq4rySFYLaqXMFXwdv61Zb2OHtj5bviSoimqxRQ==}
+    engines: {node: '>=18'}
+
+  debounce@2.2.0:
+    resolution: {integrity: sha512-Xks6RUDLZFdz8LIdR6q0MTH44k7FikOmnh5xkSjMig6ch45afc8sjTjRQf3P6ax8dMgcQrYO/AR2RGWURrruqw==}
+    engines: {node: '>=18'}
 
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
@@ -1688,6 +2122,10 @@ packages:
     peerDependenciesMeta:
       supports-color:
         optional: true
+
+  deepmerge@4.3.1:
+    resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
+    engines: {node: '>=0.10.0'}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1703,8 +2141,33 @@ packages:
   devlop@1.1.0:
     resolution: {integrity: sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==}
 
+  dom-serializer@2.0.0:
+    resolution: {integrity: sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg==}
+
+  domelementtype@2.3.0:
+    resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
+
+  domhandler@5.0.3:
+    resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
+    engines: {node: '>= 4'}
+
+  domutils@3.2.2:
+    resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
+
+  dot-prop@10.1.0:
+    resolution: {integrity: sha512-MVUtAugQMOff5RnBy2d9N31iG0lNwg1qAoAOn7pOK5wf94WIaE3My2p3uwTQuvS2AcqchkcR3bHByjaM0mmi7Q==}
+    engines: {node: '>=20'}
+
   electron-to-chromium@1.5.237:
     resolution: {integrity: sha512-icUt1NvfhGLar5lSWH3tHNzablaA5js3HVHacQimfP8ViEBOQv+L7DKEuHdbTZ0SKCO1ogTJTIL1Gwk9S6Qvcg==}
+
+  engine.io-parser@5.2.3:
+    resolution: {integrity: sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==}
+    engines: {node: '>=10.0.0'}
+
+  engine.io@6.6.7:
+    resolution: {integrity: sha512-DgOngfDKM2EviOH3Mr9m7ks1q8roetLy/IMmYthAYzbpInMbYc/GS+fWFA3rl1gvwKVsQrVV61fo5emD1y3OJQ==}
+    engines: {node: '>=10.2.0'}
 
   enhanced-resolve@5.18.3:
     resolution: {integrity: sha512-d4lC8xfavMeBjzGr2vECC3fsGXziXZQyJxD868h2M/mBI3PwAuODxAkLkq5HYuvrPYcUtiLzsTo8U3PgX3Ocww==}
@@ -1714,11 +2177,20 @@ packages:
     resolution: {integrity: sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==}
     engines: {node: '>=0.12'}
 
+  env-paths@3.0.0:
+    resolution: {integrity: sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==}
+    engines: {node: ^12.20.0 || ^14.13.1 || >=16.0.0}
+
   es-module-lexer@2.0.0:
     resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
 
   esbuild@0.27.7:
     resolution: {integrity: sha512-IxpibTjyVnmrIQo5aqNpCgoACA/dTKLTlhMHihVHhdkxKyPO1uBBthumT0rdHmcsk9uMonIWS0m4FljWzILh3w==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -1737,9 +2209,15 @@ packages:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
   fast-equals@5.4.0:
     resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
     engines: {node: '>=6.0.0'}
+
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
 
   fdir@6.5.0:
     resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
@@ -1780,6 +2258,14 @@ packages:
   get-tsconfig@4.14.0:
     resolution: {integrity: sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==}
 
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  globals@11.12.0:
+    resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
+    engines: {node: '>=4'}
+
   graceful-fs@4.2.11:
     resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
 
@@ -1789,6 +2275,13 @@ packages:
 
   html-parse-stringify@3.0.1:
     resolution: {integrity: sha512-KknJ50kTInJ7qIScF3jeaFRpMpE8/lfiTdzf/twXyPBLAGrLRTmkz3AdTnKeh40X8k9L2fdYwEp/42WGXIRGcg==}
+
+  html-to-text@9.0.5:
+    resolution: {integrity: sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg==}
+    engines: {node: '>=14'}
+
+  htmlparser2@8.0.2:
+    resolution: {integrity: sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA==}
 
   https-proxy-agent@9.0.0:
     resolution: {integrity: sha512-/MVmHp58WkOypgFhCLk4fzpPcFQvTJ/e6LBI7irpIO2HfxUbpmYoHF+KzipzJpxxzJu7aJNWQ0xojJ/dzV2G5g==}
@@ -1806,6 +2299,14 @@ packages:
     resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
     engines: {node: '>=20.0.0'}
 
+  is-unicode-supported@2.1.0:
+    resolution: {integrity: sha512-mE00Gnza5EEB3Ds0HfMyllZzbBrmLOX3vfWoj9A9PEnTfratQ/BcaJOuMhnkhjXvb2+FkY3VuHqtAGpTPmglFQ==}
+    engines: {node: '>=18'}
+
+  jiti@2.4.2:
+    resolution: {integrity: sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==}
+    hasBin: true
+
   jiti@2.6.1:
     resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
     hasBin: true
@@ -1818,10 +2319,23 @@ packages:
     engines: {node: '>=6'}
     hasBin: true
 
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  json-schema-typed@8.0.2:
+    resolution: {integrity: sha512-fQhoXdcvc3V28x7C7BMs4P5+kNlgUURe2jmUT1T//oBRMDrqy1QPelJimwZGo7Hg9VPV3EQV5Bnq4hbFy2vetA==}
+
   json5@2.2.3:
     resolution: {integrity: sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==}
     engines: {node: '>=6'}
     hasBin: true
+
+  kleur@3.0.3:
+    resolution: {integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==}
+    engines: {node: '>=6'}
+
+  leac@0.6.0:
+    resolution: {integrity: sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1963,8 +2477,16 @@ packages:
   linkifyjs@4.3.2:
     resolution: {integrity: sha512-NT1CJtq3hHIreOianA8aSXn6Cw0JzYOuDQbOrSPe7gqFnCpKP++MQe3ODgO3oh2GJFORkAAdqredOa60z63GbA==}
 
+  log-symbols@7.0.1:
+    resolution: {integrity: sha512-ja1E3yCr9i/0hmBVaM0bfwDjnGy8I/s6PP4DFp+yP+a+mrHO4Rm7DtmnqROTUkHIkqffC84YY7AeqX6oFk0WFg==}
+    engines: {node: '>=18'}
+
   lowlight@3.3.0:
     resolution: {integrity: sha512-0JNhgFoPvP6U6lE/UdVsSq99tn6DhjjpAj5MxG49ewd2mOBVtwWYIT8ClyABhq198aXXODMU6Ox8DrGy/CpTZQ==}
+
+  lru-cache@11.3.5:
+    resolution: {integrity: sha512-NxVFwLAnrd9i7KUBxC4DrUhmgjzOs+1Qm50D3oF1/oL+r1NpZ4gA7xvG0/zJ8evR7zIKn4vLf7qTNduWFtCrRw==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -1984,16 +2506,55 @@ packages:
     resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
     hasBin: true
 
+  marked@15.0.12:
+    resolution: {integrity: sha512-8dD6FusOQSrpv9Z1rdNMdlSgQOIP880DHqnohobOmYLElGEqAL/JvxvuxZO16r4HtjTlfPRDC1hbvxC9dPN2nA==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   marked@18.0.2:
     resolution: {integrity: sha512-NsmlUYBS/Zg57rgDWMYdnre6OTj4e+qq/JS2ot3KrYLSoHLw+sDu0Nm1ZGpRgYAq6c+b1ekaY5NzVchMCQnzcg==}
     engines: {node: '>= 20'}
     hasBin: true
 
+  mdn-data@2.27.1:
+    resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
   mdurl@2.0.0:
     resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
+  mime-db@1.54.0:
+    resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@3.0.2:
+    resolution: {integrity: sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==}
+    engines: {node: '>=18'}
+
+  mimic-function@5.0.1:
+    resolution: {integrity: sha512-VP79XUPxV2CigYP3jWwAUFSku2aKqBH7uTAapFWCBqutsbmDo96KY5o8uh6U+/YSIn5OxJnXp73beVkpqMIGhA==}
+    engines: {node: '>=18'}
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minimist@1.2.8:
+    resolution: {integrity: sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==}
+
   minipass@7.1.2:
     resolution: {integrity: sha512-qOOzS1cBTWYF4BH8fVePDBOO9iptMnGUEZwNc/cMWnTV2nVLZ7VoNWEPHkYczZA0pdoA7dl6e7FL659nX9S2aw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
     engines: {node: '>=16 || 14 >=14.17'}
 
   minizlib@3.1.0:
@@ -2012,6 +2573,10 @@ packages:
     engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
     hasBin: true
 
+  negotiator@0.6.3:
+    resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
+    engines: {node: '>= 0.6'}
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -2024,9 +2589,22 @@ packages:
   node-releases@2.0.25:
     resolution: {integrity: sha512-4auku8B/vw5psvTiiN9j1dAOsXvMoGqJuKJcR+dTdqiXEK20mMTk1UEo3HS16LeGQsVG6+qKTPM9u/qQ2LqATA==}
 
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
   npm-normalize-package-bin@5.0.0:
     resolution: {integrity: sha512-CJi3OS4JLsNMmr2u07OJlhcrPxCeOeP/4xq67aWNai6TNWWbTrlNDgl8NcFKVlcBKp18GPj+EzbNIgrBfZhsag==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  nypm@0.6.6:
+    resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
 
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
@@ -2037,8 +2615,18 @@ packages:
   otpauth@9.5.0:
     resolution: {integrity: sha512-Ldhc6UYl4baR5toGr8nfKC+L/b8/RgHKoIixAebgoNGzUUCET02g04rMEZ2ZsPfeVQhMHcuaOgb28nwMr81zCA==}
 
+  parseley@0.12.1:
+    resolution: {integrity: sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
   pathe@2.0.3:
     resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  peberminta@0.9.0:
+    resolution: {integrity: sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ==}
 
   picocolors@1.1.1:
     resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
@@ -2047,13 +2635,30 @@ packages:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
 
+  picospinner@3.0.0:
+    resolution: {integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==}
+    engines: {node: '>=18.0.0'}
+
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
     engines: {node: ^10 || ^12 || >=14}
 
+  prettier@3.8.3:
+    resolution: {integrity: sha512-7igPTM53cGHMW8xWuVTydi2KO233VFiTNyF5hLJqpilHfmn8C8gPf+PS7dUT64YcXFbiMGZxS9pCSxL/Dxm/Jw==}
+    engines: {node: '>=14'}
+    hasBin: true
+
+  prismjs@1.30.0:
+    resolution: {integrity: sha512-DEvV2ZF2r2/63V+tK8hQvrR2ZGn10srHbXviTlcv7Kpzw8jWiNTqbVgjO3IY8RxrrOUF8VPMQQFysYYYv0YZxw==}
+    engines: {node: '>=6'}
+
   proc-log@6.1.0:
     resolution: {integrity: sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  prompts@2.4.2:
+    resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
+    engines: {node: '>= 6'}
 
   prosemirror-changeset@2.4.0:
     resolution: {integrity: sha512-LvqH2v7Q2SF6yxatuPP2e8vSUKS/L+xAU7dPDC4RMyHMhZoGDfBC74mYuyYF4gLqOEG758wajtyhNnsTkuhvng==}
@@ -2122,6 +2727,14 @@ packages:
     peerDependencies:
       react: ^19.2.0
 
+  react-email@6.0.5:
+    resolution: {integrity: sha512-uQRqBcd9buZ7tbjvxprVrz1BclNWPXHtGeveZJjV1qtTczZjdWp3KddmanD5nlH1UbqHx32pC0Nh93PoMRbVGw==}
+    engines: {node: '>=20.0.0'}
+    hasBin: true
+    peerDependencies:
+      react: ^18.0 || ^19.0 || ^19.0.0-rc
+      react-dom: ^18.0 || ^19.0 || ^19.0.0-rc
+
   react-i18next@17.0.2:
     resolution: {integrity: sha512-shBftH2vaTWK2Bsp7FiL+cevx3xFJlvFxmsDFQSrJc+6twHkP0tv/bGa01VVWzpreUVVwU+3Hev5iFqRg65RwA==}
     peerDependencies:
@@ -2180,6 +2793,14 @@ packages:
     resolution: {integrity: sha512-1zM5HuOfagXCBWMN83fuFI/x+T/UhZ7k+KIzhrHXcQoeX5+7gmaDYjELQHmmzIodumBHeByBJT4QYS7ufAgs7A==}
     engines: {node: ^20.17.0 || >=22.9.0}
 
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
   resolve-pkg-maps@1.0.0:
     resolution: {integrity: sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==}
 
@@ -2194,8 +2815,16 @@ packages:
   scheduler@0.27.0:
     resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
+  selderee@0.11.0:
+    resolution: {integrity: sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA==}
+
   semver@6.3.1:
     resolution: {integrity: sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==}
+    hasBin: true
+
+  semver@7.7.4:
+    resolution: {integrity: sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==}
+    engines: {node: '>=10'}
     hasBin: true
 
   siginfo@2.0.0:
@@ -2208,6 +2837,20 @@ packages:
   sirv@3.0.2:
     resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
+
+  sisteransi@1.0.5:
+    resolution: {integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==}
+
+  socket.io-adapter@2.5.6:
+    resolution: {integrity: sha512-DkkO/dz7MGln0dHn5bmN3pPy+JmywNICWrJqVWiVOyvXjWQFIv9c2h24JrQLLFJ2aQVQf/Cvl1vblnd4r2apLQ==}
+
+  socket.io-parser@4.2.6:
+    resolution: {integrity: sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==}
+    engines: {node: '>=10.0.0'}
+
+  socket.io@4.8.3:
+    resolution: {integrity: sha512-2Dd78bqzzjE6KPkD5fHZmDAKRNe3J15q+YHDrIsy9WEkqttc7GY+kT9OBLSMaPbQaEd0x1BjcmtMtXkfpc+T5A==}
+    engines: {node: '>=10.2.0'}
 
   sonner@2.0.7:
     resolution: {integrity: sha512-W6ZN4p58k8aDKA4XPcx2hpIQXBRAgyiWVkYhT7CvK6D3iAu7xjvVyhQHg2/iaKJZ1XVJ4r7XuwGL+WGEK37i9w==}
@@ -2225,16 +2868,33 @@ packages:
   std-env@4.1.0:
     resolution: {integrity: sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==}
 
+  strip-bom@3.0.0:
+    resolution: {integrity: sha512-vavAMRXOgBVNF6nyEEmL3DBK19iRpDcoIwW+swQ+CbGiu7lju6t+JklA1MHweoWtadgt4ISVUsXLyDq34ddcwA==}
+    engines: {node: '>=4'}
+
+  stubborn-fs@2.0.0:
+    resolution: {integrity: sha512-Y0AvSwDw8y+nlSNFXMm2g6L51rBGdAQT20J3YSOqxC53Lo3bjWRtr2BKcfYoAf352WYpsZSTURrA0tqhfgudPA==}
+
+  stubborn-utils@1.0.2:
+    resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
   supabase@2.95.2:
     resolution: {integrity: sha512-/inQRAchr5ciGbqR3VEVq7boQUhcQ6QDENZgyIiPRm7UYw6+slIihFjvhisTo5Kd9NK6RJID7L2N2+ct+xAqNQ==}
     engines: {npm: '>=8'}
     hasBin: true
+
+  tagged-tag@1.0.0:
+    resolution: {integrity: sha512-yEFYrVhod+hdNyx7g5Bnkkb0G6si8HJurOoOEgC8B/O0uXLHlaey/65KRv6cuWBNhBgHKAROVpc7QyYqE5gFng==}
+    engines: {node: '>=20'}
 
   tailwind-merge@3.3.1:
     resolution: {integrity: sha512-gBXpgUm/3rp1lMZZrM/w7D8GKqshif0zAymAhbCyIt8KMe+0v9DQ7cdYLR4FHH/cKpdTXb+A/tKKU3eolfsI+g==}
 
   tailwindcss@4.1.14:
     resolution: {integrity: sha512-b7pCxjGO98LnxVkKjaZSDeNuljC4ueKUddjENJOADtubtdo8llTaJy7HwBMeLNSSo2N5QIAgklslK1+Ir8r6CA==}
+
+  tailwindcss@4.2.4:
+    resolution: {integrity: sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==}
 
   tapable@2.3.0:
     resolution: {integrity: sha512-g9ljZiwki/LfxmQADO3dEY1CbpmXT5Hm2fJ+QaGKwSXUylMybePR7/67YW7jOrrvjEgL1Fmz5kzyAjWVWLlucg==}
@@ -2267,6 +2927,10 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
+  tsconfig-paths@4.2.0:
+    resolution: {integrity: sha512-NoZ4roiN7LnbKn9QqE1amc9DJfzvZXxF4xDavcOWt1BPkdx+m+0gJuPM+S0vCe7zTJMYUP0R8pO2XMr+Y8oLIg==}
+    engines: {node: '>=6'}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -2282,6 +2946,10 @@ packages:
   tw-animate-css@1.4.0:
     resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
+  type-fest@5.6.0:
+    resolution: {integrity: sha512-8ZiHFm91orbSAe2PSAiSVBVko18pbhbiB3U9GglSzF/zCGkR+rxpHx6sEMCUm4kxY4LjDIUGgCfUMtwfZfjfUA==}
+    engines: {node: '>=20'}
+
   typescript@5.8.3:
     resolution: {integrity: sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==}
     engines: {node: '>=14.17'}
@@ -2289,6 +2957,10 @@ packages:
 
   uc.micro@2.1.0:
     resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
+
+  uint8array-extras@1.5.0:
+    resolution: {integrity: sha512-rvKSBiC5zqCCiDZ9kAOszZcDvdAHwwIKJG33Ykj43OKcWsnmcBRL09YTU4nOeHZ8Y2a7l1MgTd08SBe9A8Qj6A==}
+    engines: {node: '>=18'}
 
   undici-types@7.14.0:
     resolution: {integrity: sha512-QQiYxHuyZ9gQUIrmPo3IA+hUl4KYk8uSA7cHrcKd/l3p1OTpZcM0Tbp9x7FAtXdAYhlasd60ncPpgu6ihG6TOA==}
@@ -2323,6 +2995,10 @@ packages:
     resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  vary@1.1.2:
+    resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
+    engines: {node: '>= 0.8'}
 
   vite@7.3.2:
     resolution: {integrity: sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==}
@@ -2416,6 +3092,9 @@ packages:
     resolution: {integrity: sha512-d2JWLCivmZYTSIoge9MsgFCZrt571BikcWGYkjC1khllbTeDlGqZ2D8vD8E/lJa8WGWbb7Plm8/XJYV7IJHZZw==}
     engines: {node: '>= 8'}
 
+  when-exit@2.1.5:
+    resolution: {integrity: sha512-VGkKJ564kzt6Ms1dbgPP/yuIoQCrsFAnRbptpC5wOEsDaNsbCB2bnfnaA8i/vRs5tjUSEOtIuvl9/MyVsvQZCg==}
+
   why-is-node-running@2.3.0:
     resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
     engines: {node: '>=8'}
@@ -2424,6 +3103,18 @@ packages:
   write-file-atomic@7.0.1:
     resolution: {integrity: sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg==}
     engines: {node: ^20.17.0 || >=22.9.0}
+
+  ws@8.18.3:
+    resolution: {integrity: sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   ws@8.20.0:
     resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
@@ -2442,6 +3133,10 @@ packages:
 
   yallist@5.0.0:
     resolution: {integrity: sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw==}
+    engines: {node: '>=18'}
+
+  yoctocolors@2.1.2:
+    resolution: {integrity: sha512-CzhO+pFNo8ajLM2d2IW/R93ipy99LWjtwblvC1RsoSUMZgyLbYFr221TnSNT7GjGdYui6P459mw9JH/g/zW2ug==}
     engines: {node: '>=18'}
 
   zod@4.3.6:
@@ -2524,6 +3219,10 @@ snapshots:
       '@babel/template': 7.27.2
       '@babel/types': 7.28.4
 
+  '@babel/parser@7.27.0':
+    dependencies:
+      '@babel/types': 7.28.4
+
   '@babel/parser@7.28.4':
     dependencies:
       '@babel/types': 7.28.4
@@ -2545,6 +3244,18 @@ snapshots:
       '@babel/code-frame': 7.27.1
       '@babel/parser': 7.28.4
       '@babel/types': 7.28.4
+
+  '@babel/traverse@7.27.0':
+    dependencies:
+      '@babel/code-frame': 7.27.1
+      '@babel/generator': 7.28.3
+      '@babel/parser': 7.28.4
+      '@babel/template': 7.27.2
+      '@babel/types': 7.28.4
+      debug: 4.4.3
+      globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
 
   '@babel/traverse@7.28.4':
     dependencies:
@@ -2591,79 +3302,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
   '@esbuild/android-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
     optional: true
 
   '@esbuild/android-arm@0.27.7':
     optional: true
 
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
   '@esbuild/android-x64@0.27.7':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
     optional: true
 
   '@esbuild/darwin-arm64@0.27.7':
     optional: true
 
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
   '@esbuild/darwin-x64@0.27.7':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
     optional: true
 
   '@esbuild/freebsd-arm64@0.27.7':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
   '@esbuild/freebsd-x64@0.27.7':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
     optional: true
 
   '@esbuild/linux-arm64@0.27.7':
     optional: true
 
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
   '@esbuild/linux-arm@0.27.7':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
     optional: true
 
   '@esbuild/linux-ia32@0.27.7':
     optional: true
 
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
   '@esbuild/linux-loong64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
     optional: true
 
   '@esbuild/linux-mips64el@0.27.7':
     optional: true
 
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
   '@esbuild/linux-ppc64@0.27.7':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
     optional: true
 
   '@esbuild/linux-riscv64@0.27.7':
     optional: true
 
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
   '@esbuild/linux-s390x@0.27.7':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
     optional: true
 
   '@esbuild/linux-x64@0.27.7':
     optional: true
 
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/netbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
     optional: true
 
   '@esbuild/openbsd-x64@0.27.7':
     optional: true
 
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
     optional: true
 
   '@esbuild/sunos-x64@0.27.7':
     optional: true
 
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
   '@esbuild/win32-arm64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
     optional: true
 
   '@esbuild/win32-ia32@0.27.7':
     optional: true
 
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
   '@esbuild/win32-x64@0.27.7':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
     optional: true
 
   '@floating-ui/core@1.7.3':
@@ -3077,6 +3866,137 @@ snapshots:
 
   '@radix-ui/rect@1.1.1': {}
 
+  '@react-email/body@0.3.0(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/button@0.2.1(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/code-block@0.2.1(react@19.2.0)':
+    dependencies:
+      prismjs: 1.30.0
+      react: 19.2.0
+
+  '@react-email/code-inline@0.0.6(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/column@0.0.14(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/components@1.0.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@react-email/body': 0.3.0(react@19.2.0)
+      '@react-email/button': 0.2.1(react@19.2.0)
+      '@react-email/code-block': 0.2.1(react@19.2.0)
+      '@react-email/code-inline': 0.0.6(react@19.2.0)
+      '@react-email/column': 0.0.14(react@19.2.0)
+      '@react-email/container': 0.0.16(react@19.2.0)
+      '@react-email/font': 0.0.10(react@19.2.0)
+      '@react-email/head': 0.0.13(react@19.2.0)
+      '@react-email/heading': 0.0.16(react@19.2.0)
+      '@react-email/hr': 0.0.12(react@19.2.0)
+      '@react-email/html': 0.0.12(react@19.2.0)
+      '@react-email/img': 0.0.12(react@19.2.0)
+      '@react-email/link': 0.0.13(react@19.2.0)
+      '@react-email/markdown': 0.0.18(react@19.2.0)
+      '@react-email/preview': 0.0.14(react@19.2.0)
+      '@react-email/render': 2.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-email/row': 0.0.13(react@19.2.0)
+      '@react-email/section': 0.0.17(react@19.2.0)
+      '@react-email/tailwind': 2.0.7(@react-email/body@0.3.0(react@19.2.0))(@react-email/button@0.2.1(react@19.2.0))(@react-email/code-block@0.2.1(react@19.2.0))(@react-email/code-inline@0.0.6(react@19.2.0))(@react-email/container@0.0.16(react@19.2.0))(@react-email/heading@0.0.16(react@19.2.0))(@react-email/hr@0.0.12(react@19.2.0))(@react-email/img@0.0.12(react@19.2.0))(@react-email/link@0.0.13(react@19.2.0))(@react-email/preview@0.0.14(react@19.2.0))(@react-email/text@0.1.6(react@19.2.0))(react@19.2.0)
+      '@react-email/text': 0.1.6(react@19.2.0)
+      react: 19.2.0
+    transitivePeerDependencies:
+      - react-dom
+
+  '@react-email/container@0.0.16(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/font@0.0.10(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/head@0.0.13(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/heading@0.0.16(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/hr@0.0.12(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/html@0.0.12(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/img@0.0.12(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/link@0.0.13(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/markdown@0.0.18(react@19.2.0)':
+    dependencies:
+      marked: 15.0.12
+      react: 19.2.0
+
+  '@react-email/preview@0.0.14(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/render@2.0.6(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.3
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@react-email/render@2.0.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      html-to-text: 9.0.5
+      prettier: 3.8.3
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+
+  '@react-email/row@0.0.13(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/section@0.0.17(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
+  '@react-email/tailwind@2.0.7(@react-email/body@0.3.0(react@19.2.0))(@react-email/button@0.2.1(react@19.2.0))(@react-email/code-block@0.2.1(react@19.2.0))(@react-email/code-inline@0.0.6(react@19.2.0))(@react-email/container@0.0.16(react@19.2.0))(@react-email/heading@0.0.16(react@19.2.0))(@react-email/hr@0.0.12(react@19.2.0))(@react-email/img@0.0.12(react@19.2.0))(@react-email/link@0.0.13(react@19.2.0))(@react-email/preview@0.0.14(react@19.2.0))(@react-email/text@0.1.6(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@react-email/text': 0.1.6(react@19.2.0)
+      react: 19.2.0
+      tailwindcss: 4.2.4
+    optionalDependencies:
+      '@react-email/body': 0.3.0(react@19.2.0)
+      '@react-email/button': 0.2.1(react@19.2.0)
+      '@react-email/code-block': 0.2.1(react@19.2.0)
+      '@react-email/code-inline': 0.0.6(react@19.2.0)
+      '@react-email/container': 0.0.16(react@19.2.0)
+      '@react-email/heading': 0.0.16(react@19.2.0)
+      '@react-email/hr': 0.0.12(react@19.2.0)
+      '@react-email/img': 0.0.12(react@19.2.0)
+      '@react-email/link': 0.0.13(react@19.2.0)
+      '@react-email/preview': 0.0.14(react@19.2.0)
+
+  '@react-email/text@0.1.6(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
+
   '@remirror/core-constants@3.0.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -3155,6 +4075,13 @@ snapshots:
 
   '@rollup/rollup-win32-x64-msvc@4.60.2':
     optional: true
+
+  '@selderee/plugin-htmlparser2@0.11.0':
+    dependencies:
+      domhandler: 5.0.3
+      selderee: 0.11.0
+
+  '@socket.io/component-emitter@3.1.2': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -3603,6 +4530,10 @@ snapshots:
       '@types/deep-eql': 4.0.2
       assertion-error: 2.0.1
 
+  '@types/cors@2.8.19':
+    dependencies:
+      '@types/node': 24.8.1
+
   '@types/deep-eql@4.0.2': {}
 
   '@types/estree@1.0.8': {}
@@ -3710,7 +4641,23 @@ snapshots:
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
 
+  accepts@1.3.8:
+    dependencies:
+      mime-types: 2.1.35
+      negotiator: 0.6.3
+
   agent-base@9.0.0: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
 
   argparse@2.0.1: {}
 
@@ -3719,6 +4666,15 @@ snapshots:
       tslib: 2.8.1
 
   assertion-error@2.0.1: {}
+
+  atomically@2.1.1:
+    dependencies:
+      stubborn-fs: 2.0.0
+      when-exit: 2.1.5
+
+  balanced-match@4.0.4: {}
+
+  base64id@2.0.0: {}
 
   baseline-browser-mapping@2.8.17: {}
 
@@ -3729,6 +4685,10 @@ snapshots:
       proc-log: 6.1.0
       read-cmd-shim: 6.0.0
       write-file-atomic: 7.0.1
+
+  brace-expansion@5.0.5:
+    dependencies:
+      balanced-match: 4.0.4
 
   browserslist@4.26.3:
     dependencies:
@@ -3742,7 +4702,13 @@ snapshots:
 
   chai@6.2.2: {}
 
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
   chownr@3.0.0: {}
+
+  citty@0.2.2: {}
 
   class-variance-authority@0.7.1:
     dependencies:
@@ -3752,17 +4718,51 @@ snapshots:
 
   cmd-shim@8.0.0: {}
 
+  commander@13.1.0: {}
+
+  conf@15.1.0:
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      atomically: 2.1.1
+      debounce-fn: 6.0.0
+      dot-prop: 10.1.0
+      env-paths: 3.0.0
+      json-schema-typed: 8.0.2
+      semver: 7.7.4
+      uint8array-extras: 1.5.0
+
   convert-source-map@2.0.0: {}
 
+  cookie@0.7.2: {}
+
+  cors@2.8.6:
+    dependencies:
+      object-assign: 4.1.1
+      vary: 1.1.2
+
   crelt@1.0.6: {}
+
+  css-tree@3.2.1:
+    dependencies:
+      mdn-data: 2.27.1
+      source-map-js: 1.2.1
 
   csstype@3.1.3: {}
 
   data-uri-to-buffer@4.0.1: {}
 
+  debounce-fn@6.0.0:
+    dependencies:
+      mimic-function: 5.0.1
+
+  debounce@2.2.0: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
+
+  deepmerge@4.3.1: {}
 
   dequal@2.0.3: {}
 
@@ -3774,7 +4774,48 @@ snapshots:
     dependencies:
       dequal: 2.0.3
 
+  dom-serializer@2.0.0:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      entities: 4.5.0
+
+  domelementtype@2.3.0: {}
+
+  domhandler@5.0.3:
+    dependencies:
+      domelementtype: 2.3.0
+
+  domutils@3.2.2:
+    dependencies:
+      dom-serializer: 2.0.0
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+
+  dot-prop@10.1.0:
+    dependencies:
+      type-fest: 5.6.0
+
   electron-to-chromium@1.5.237: {}
+
+  engine.io-parser@5.2.3: {}
+
+  engine.io@6.6.7:
+    dependencies:
+      '@types/cors': 2.8.19
+      '@types/node': 24.8.1
+      '@types/ws': 8.18.1
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cookie: 0.7.2
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io-parser: 5.2.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   enhanced-resolve@5.18.3:
     dependencies:
@@ -3782,6 +4823,8 @@ snapshots:
       tapable: 2.3.0
 
   entities@4.5.0: {}
+
+  env-paths@3.0.0: {}
 
   es-module-lexer@2.0.0: {}
 
@@ -3814,6 +4857,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.27.7
       '@esbuild/win32-x64': 0.27.7
 
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
   escalade@3.2.0: {}
 
   escape-string-regexp@4.0.0: {}
@@ -3824,7 +4896,11 @@ snapshots:
 
   expect-type@1.3.0: {}
 
+  fast-deep-equal@3.1.3: {}
+
   fast-equals@5.4.0: {}
+
+  fast-uri@3.1.0: {}
 
   fdir@6.5.0(picomatch@4.0.4):
     optionalDependencies:
@@ -3854,6 +4930,14 @@ snapshots:
     dependencies:
       resolve-pkg-maps: 1.0.0
 
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  globals@11.12.0: {}
+
   graceful-fs@4.2.11: {}
 
   highlight.js@11.11.1: {}
@@ -3861,6 +4945,21 @@ snapshots:
   html-parse-stringify@3.0.1:
     dependencies:
       void-elements: 3.1.0
+
+  html-to-text@9.0.5:
+    dependencies:
+      '@selderee/plugin-htmlparser2': 0.11.0
+      deepmerge: 4.3.1
+      dom-serializer: 2.0.0
+      htmlparser2: 8.0.2
+      selderee: 0.11.0
+
+  htmlparser2@8.0.2:
+    dependencies:
+      domelementtype: 2.3.0
+      domhandler: 5.0.3
+      domutils: 3.2.2
+      entities: 4.5.0
 
   https-proxy-agent@9.0.0:
     dependencies:
@@ -3877,13 +4976,25 @@ snapshots:
 
   iceberg-js@0.8.1: {}
 
+  is-unicode-supported@2.1.0: {}
+
+  jiti@2.4.2: {}
+
   jiti@2.6.1: {}
 
   js-tokens@4.0.0: {}
 
   jsesc@3.1.0: {}
 
+  json-schema-traverse@1.0.0: {}
+
+  json-schema-typed@8.0.2: {}
+
   json5@2.2.3: {}
+
+  kleur@3.0.3: {}
+
+  leac@0.6.0: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3986,11 +5097,18 @@ snapshots:
 
   linkifyjs@4.3.2: {}
 
+  log-symbols@7.0.1:
+    dependencies:
+      is-unicode-supported: 2.1.0
+      yoctocolors: 2.1.2
+
   lowlight@3.3.0:
     dependencies:
       '@types/hast': 3.0.4
       devlop: 1.1.0
       highlight.js: 11.11.1
+
+  lru-cache@11.3.5: {}
 
   lru-cache@5.1.1:
     dependencies:
@@ -4017,11 +5135,37 @@ snapshots:
       punycode.js: 2.3.1
       uc.micro: 2.1.0
 
+  marked@15.0.12: {}
+
   marked@18.0.2: {}
+
+  mdn-data@2.27.1: {}
 
   mdurl@2.0.0: {}
 
+  mime-db@1.52.0: {}
+
+  mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
+
+  mime-types@3.0.2:
+    dependencies:
+      mime-db: 1.54.0
+
+  mimic-function@5.0.1: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.5
+
+  minimist@1.2.8: {}
+
   minipass@7.1.2: {}
+
+  minipass@7.1.3: {}
 
   minizlib@3.1.0:
     dependencies:
@@ -4033,6 +5177,8 @@ snapshots:
 
   nanoid@3.3.11: {}
 
+  negotiator@0.6.3: {}
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -4043,7 +5189,17 @@ snapshots:
 
   node-releases@2.0.25: {}
 
+  normalize-path@3.0.0: {}
+
   npm-normalize-package-bin@5.0.0: {}
+
+  nypm@0.6.6:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.1.1
+
+  object-assign@4.1.1: {}
 
   obug@2.1.1: {}
 
@@ -4053,11 +5209,25 @@ snapshots:
     dependencies:
       '@noble/hashes': 2.0.1
 
+  parseley@0.12.1:
+    dependencies:
+      leac: 0.6.0
+      peberminta: 0.9.0
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.3.5
+      minipass: 7.1.3
+
   pathe@2.0.3: {}
+
+  peberminta@0.9.0: {}
 
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  picospinner@3.0.0: {}
 
   postcss@8.5.10:
     dependencies:
@@ -4065,7 +5235,16 @@ snapshots:
       picocolors: 1.1.1
       source-map-js: 1.2.1
 
+  prettier@3.8.3: {}
+
+  prismjs@1.30.0: {}
+
   proc-log@6.1.0: {}
+
+  prompts@2.4.2:
+    dependencies:
+      kleur: 3.0.3
+      sisteransi: 1.0.5
 
   prosemirror-changeset@2.4.0:
     dependencies:
@@ -4177,6 +5356,37 @@ snapshots:
       react: 19.2.0
       scheduler: 0.27.0
 
+  react-email@6.0.5(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@babel/parser': 7.27.0
+      '@babel/traverse': 7.27.0
+      '@react-email/render': 2.0.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      chokidar: 4.0.3
+      commander: 13.1.0
+      conf: 15.1.0
+      css-tree: 3.2.1
+      debounce: 2.2.0
+      esbuild: 0.28.0
+      glob: 13.0.6
+      jiti: 2.4.2
+      log-symbols: 7.0.1
+      marked: 15.0.12
+      mime-types: 3.0.2
+      normalize-path: 3.0.0
+      nypm: 0.6.6
+      picospinner: 3.0.0
+      prismjs: 1.30.0
+      prompts: 2.4.2
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      socket.io: 4.8.3
+      tailwindcss: 4.2.4
+      tsconfig-paths: 4.2.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   react-i18next@17.0.2(i18next@26.0.4(typescript@5.8.3))(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(typescript@5.8.3):
     dependencies:
       '@babel/runtime': 7.29.2
@@ -4221,6 +5431,10 @@ snapshots:
 
   read-cmd-shim@6.0.0: {}
 
+  readdirp@4.1.2: {}
+
+  require-from-string@2.0.2: {}
+
   resolve-pkg-maps@1.0.0: {}
 
   rollup@4.60.2:
@@ -4258,7 +5472,13 @@ snapshots:
 
   scheduler@0.27.0: {}
 
+  selderee@0.11.0:
+    dependencies:
+      parseley: 0.12.1
+
   semver@6.3.1: {}
+
+  semver@7.7.4: {}
 
   siginfo@2.0.0: {}
 
@@ -4269,6 +5489,38 @@ snapshots:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
       totalist: 3.0.1
+
+  sisteransi@1.0.5: {}
+
+  socket.io-adapter@2.5.6:
+    dependencies:
+      debug: 4.4.3
+      ws: 8.18.3
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
+  socket.io-parser@4.2.6:
+    dependencies:
+      '@socket.io/component-emitter': 3.1.2
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  socket.io@4.8.3:
+    dependencies:
+      accepts: 1.3.8
+      base64id: 2.0.0
+      cors: 2.8.6
+      debug: 4.4.3
+      engine.io: 6.6.7
+      socket.io-adapter: 2.5.6
+      socket.io-parser: 4.2.6
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
 
   sonner@2.0.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
     dependencies:
@@ -4281,6 +5533,14 @@ snapshots:
 
   std-env@4.1.0: {}
 
+  strip-bom@3.0.0: {}
+
+  stubborn-fs@2.0.0:
+    dependencies:
+      stubborn-utils: 1.0.2
+
+  stubborn-utils@1.0.2: {}
+
   supabase@2.95.2:
     dependencies:
       bin-links: 6.0.0
@@ -4290,9 +5550,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  tagged-tag@1.0.0: {}
+
   tailwind-merge@3.3.1: {}
 
   tailwindcss@4.1.14: {}
+
+  tailwindcss@4.2.4: {}
 
   tapable@2.3.0: {}
 
@@ -4322,6 +5586,12 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tsconfig-paths@4.2.0:
+    dependencies:
+      json5: 2.2.3
+      minimist: 1.2.8
+      strip-bom: 3.0.0
+
   tslib@2.8.1: {}
 
   tsx@4.21.0:
@@ -4337,9 +5607,15 @@ snapshots:
 
   tw-animate-css@1.4.0: {}
 
+  type-fest@5.6.0:
+    dependencies:
+      tagged-tag: 1.0.0
+
   typescript@5.8.3: {}
 
   uc.micro@2.1.0: {}
+
+  uint8array-extras@1.5.0: {}
 
   undici-types@7.14.0: {}
 
@@ -4367,6 +5643,8 @@ snapshots:
   use-sync-external-store@1.6.0(react@19.2.0):
     dependencies:
       react: 19.2.0
+
+  vary@1.1.2: {}
 
   vite@7.3.2(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0):
     dependencies:
@@ -4417,6 +5695,8 @@ snapshots:
 
   web-streams-polyfill@3.3.3: {}
 
+  when-exit@2.1.5: {}
+
   why-is-node-running@2.3.0:
     dependencies:
       siginfo: 2.0.0
@@ -4426,10 +5706,14 @@ snapshots:
     dependencies:
       signal-exit: 4.1.0
 
+  ws@8.18.3: {}
+
   ws@8.20.0: {}
 
   yallist@3.1.1: {}
 
   yallist@5.0.0: {}
+
+  yoctocolors@2.1.2: {}
 
   zod@4.3.6: {}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,7 +133,7 @@ importers:
         version: 5.0.6
       '@vercel/analytics':
         specifier: ^1.5.0
-        version: 1.5.0(react@19.2.0)
+        version: 1.5.0(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -189,6 +189,9 @@ importers:
       '@react-email/render':
         specifier: ^2.0.8
         version: 2.0.8(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@react-email/ui':
+        specifier: ^6.0.5
+        version: 6.0.5(@babel/core@7.28.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tauri-apps/cli':
         specifier: ^2
         version: 2.8.4
@@ -348,6 +351,9 @@ packages:
     resolution: {integrity: sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg==}
     peerDependencies:
       react: '>=16.8.0'
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
 
   '@esbuild/aix-ppc64@0.27.7':
     resolution: {integrity: sha512-EKX3Qwmhz1eMdEJokhALr0YiD0lhQNwDqkPYyPhiSwKrh7/4KRjQc04sZ8db+5DVVnZ1LmbNDI1uAMPEUBnQPg==}
@@ -679,6 +685,143 @@ packages:
   '@fontsource/inter@5.2.8':
     resolution: {integrity: sha512-P6r5WnJoKiNVV+zvW2xM13gNdFhAEpQ9dQJHt3naLvfg+LkF2ldgSLiF4T41lf1SQCM9QmkqPTn4TH568IRagg==}
 
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
   '@isaacs/fs-minipass@4.0.1':
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
@@ -707,6 +850,57 @@ packages:
 
   '@mixmark-io/domino@2.2.0':
     resolution: {integrity: sha512-Y28PR25bHXUg88kCV7nivXrP2Nj2RueZ3/l/jdx6J9f8J4nsEGcgX0Qe6lt7Pa+J79+kPiJU3LguR6O/6zrLOw==}
+
+  '@next/env@16.2.3':
+    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
+
+  '@next/swc-darwin-arm64@16.2.3':
+    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.2.3':
+    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.2.3':
+    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-arm64-musl@16.2.3':
+    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@next/swc-linux-x64-gnu@16.2.3':
+    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-linux-x64-musl@16.2.3':
+    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+
+  '@next/swc-win32-arm64-msvc@16.2.3':
+    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.3':
+    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
 
   '@noble/hashes@2.0.1':
     resolution: {integrity: sha512-XlOlEbQcE9fmuXxrVTXCTlG2nlRXa9Rj3rr5Ue/+tX+nmkgbX720YHh0VR3hBF9xDvwnb8D2shVGOwNx+ulArw==}
@@ -1288,6 +1482,9 @@ packages:
     peerDependencies:
       react: ^18.0 || ^19.0 || ^19.0.0-rc
 
+  '@react-email/ui@6.0.5':
+    resolution: {integrity: sha512-5XvP8CxSJH1CxOCYUEubYFiTaOPjtxJqMBsN69+hHVYHGR9psYgIBnRA2MDDfK5LdoC9r+QovN0ZgBrLd+tduQ==}
+
   '@remirror/core-constants@3.0.0':
     resolution: {integrity: sha512-42aWfPrimMfDKDi4YegyS7x+/0tlzaqwPQCULLanv3DMIlu96KTJR0fM5isWX2UViOqlGnX6YFgqWepcX+XMNg==}
 
@@ -1454,6 +1651,9 @@ packages:
   '@supabase/supabase-js@2.104.1':
     resolution: {integrity: sha512-E0H/CtVmaGjiAy+ieZ5ZB/1EqxXcGdaFaAc23AE5zaYfz6NtCNDcmaEdoGPYMPFH5pE6drGG6e3ljPmkFoGVxQ==}
     engines: {node: '>=20.0.0'}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
   '@tailwindcss/node@4.1.14':
     resolution: {integrity: sha512-hpz+8vFk3Ic2xssIA3e01R6jkmsAhvkQdXlEbRTk6S10xDAtiQiM3FyvZVGsucefq764euO/b8WUW9ysLdThHw==}
@@ -2027,6 +2227,11 @@ packages:
     resolution: {integrity: sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==}
     engines: {node: ^4.5.0 || >= 5.9}
 
+  baseline-browser-mapping@2.10.25:
+    resolution: {integrity: sha512-QO/VHsXCQdnzADMfmkeOPvHdIAkoB7i0/rGjINPJEetLx75hNttVWGQ/jycHUDP9zZ9rupbm60WRxcwViB0MiA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
   baseline-browser-mapping@2.8.17:
     resolution: {integrity: sha512-j5zJcx6golJYTG6c05LUZ3Z8Gi+M62zRT/ycz4Xq4iCOdpcxwg7ngEYD4KA0eWZC7U17qh/Smq8bYbACJ0ipBA==}
     hasBin: true
@@ -2064,6 +2269,9 @@ packages:
 
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
   clsx@2.1.1:
     resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
@@ -2577,6 +2785,27 @@ packages:
     resolution: {integrity: sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==}
     engines: {node: '>= 0.6'}
 
+  next@16.2.3:
+    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
   node-domexception@1.0.0:
     resolution: {integrity: sha512-/jKZoMpw0F8GRwl4/eLROPA3cfcXtLApP0QzLmUT/HuPCZWyB7IY9ZrMeKw2O/nFIqPQB3PVM9aYm0F312AXDQ==}
     engines: {node: '>=10.5.0'}
@@ -2638,6 +2867,10 @@ packages:
   picospinner@3.0.0:
     resolution: {integrity: sha512-lGA1TNsmy2bxvRsTI2cV01kfTwKzZjnZSDmF9llYNyMHMrU4sP87lQ5taiIKm88L3cbswjl008nwyGc3WpNvzg==}
     engines: {node: '>=18.0.0'}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
 
   postcss@8.5.10:
     resolution: {integrity: sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==}
@@ -2827,6 +3060,10 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
@@ -2877,6 +3114,19 @@ packages:
 
   stubborn-utils@1.0.2:
     resolution: {integrity: sha512-zOh9jPYI+xrNOyisSelgym4tolKTJCQd5GBhK0+0xJvcYDcwlOoxF/rnFKQ2KRZknXSG9jWAp66fwP6AxN9STg==}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
 
   supabase@2.95.2:
     resolution: {integrity: sha512-/inQRAchr5ciGbqR3VEVq7boQUhcQ6QDENZgyIiPRm7UYw6+slIihFjvhisTo5Kd9NK6RJID7L2N2+ct+xAqNQ==}
@@ -3299,6 +3549,11 @@ snapshots:
       react: 19.2.0
       tslib: 2.8.1
 
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@esbuild/aix-ppc64@0.27.7':
     optional: true
 
@@ -3474,6 +3729,103 @@ snapshots:
 
   '@fontsource/inter@5.2.8': {}
 
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
   '@isaacs/fs-minipass@4.0.1':
     dependencies:
       minipass: 7.1.2
@@ -3503,6 +3855,32 @@ snapshots:
       react-dom: 19.2.0(react@19.2.0)
 
   '@mixmark-io/domino@2.2.0': {}
+
+  '@next/env@16.2.3': {}
+
+  '@next/swc-darwin-arm64@16.2.3':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.3':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.2.3':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.3':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.2.3':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.3':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.2.3':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.3':
+    optional: true
 
   '@noble/hashes@2.0.1': {}
 
@@ -3997,6 +4375,20 @@ snapshots:
     dependencies:
       react: 19.2.0
 
+  '@react-email/ui@6.0.5(@babel/core@7.28.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      esbuild: 0.28.0
+      next: 16.2.3(@babel/core@7.28.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+    transitivePeerDependencies:
+      - '@babel/core'
+      - '@opentelemetry/api'
+      - '@playwright/test'
+      - babel-plugin-macros
+      - babel-plugin-react-compiler
+      - react
+      - react-dom
+      - sass
+
   '@remirror/core-constants@3.0.0': {}
 
   '@rolldown/pluginutils@1.0.0-beta.27': {}
@@ -4124,6 +4516,10 @@ snapshots:
     transitivePeerDependencies:
       - bufferutil
       - utf-8-validate
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
 
   '@tailwindcss/node@4.1.14':
     dependencies:
@@ -4573,8 +4969,9 @@ snapshots:
     dependencies:
       '@types/node': 24.8.1
 
-  '@vercel/analytics@1.5.0(react@19.2.0)':
+  '@vercel/analytics@1.5.0(next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0))(react@19.2.0)':
     optionalDependencies:
+      next: 16.2.3(@babel/core@7.28.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       react: 19.2.0
 
   '@vitejs/plugin-react@4.7.0(vite@7.3.2(@types/node@24.8.1)(jiti@2.6.1)(lightningcss@1.32.0)(tsx@4.21.0))':
@@ -4676,6 +5073,8 @@ snapshots:
 
   base64id@2.0.0: {}
 
+  baseline-browser-mapping@2.10.25: {}
+
   baseline-browser-mapping@2.8.17: {}
 
   bin-links@6.0.0:
@@ -4713,6 +5112,8 @@ snapshots:
   class-variance-authority@0.7.1:
     dependencies:
       clsx: 2.1.1
+
+  client-only@0.0.1: {}
 
   clsx@2.1.1: {}
 
@@ -5179,6 +5580,30 @@ snapshots:
 
   negotiator@0.6.3: {}
 
+  next@16.2.3(@babel/core@7.28.4)(react-dom@19.2.0(react@19.2.0))(react@19.2.0):
+    dependencies:
+      '@next/env': 16.2.3
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.25
+      caniuse-lite: 1.0.30001751
+      postcss: 8.4.31
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      styled-jsx: 5.1.6(@babel/core@7.28.4)(react@19.2.0)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.3
+      '@next/swc-darwin-x64': 16.2.3
+      '@next/swc-linux-arm64-gnu': 16.2.3
+      '@next/swc-linux-arm64-musl': 16.2.3
+      '@next/swc-linux-x64-gnu': 16.2.3
+      '@next/swc-linux-x64-musl': 16.2.3
+      '@next/swc-win32-arm64-msvc': 16.2.3
+      '@next/swc-win32-x64-msvc': 16.2.3
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
   node-domexception@1.0.0: {}
 
   node-fetch@3.3.2:
@@ -5228,6 +5653,12 @@ snapshots:
   picomatch@4.0.4: {}
 
   picospinner@3.0.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
 
   postcss@8.5.10:
     dependencies:
@@ -5480,6 +5911,38 @@ snapshots:
 
   semver@7.7.4: {}
 
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.7.4
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
   siginfo@2.0.0: {}
 
   signal-exit@4.1.0: {}
@@ -5540,6 +6003,13 @@ snapshots:
       stubborn-utils: 1.0.2
 
   stubborn-utils@1.0.2: {}
+
+  styled-jsx@5.1.6(@babel/core@7.28.4)(react@19.2.0):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.0
+    optionalDependencies:
+      '@babel/core': 7.28.4
 
   supabase@2.95.2:
     dependencies:

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -7,6 +7,6 @@ export default defineConfig({
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts"],
+    include: ["src/**/*.test.ts", "emails/**/*.test.ts"],
   },
 });

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,12 +1,19 @@
 import { defineConfig } from "vitest/config";
+import react from "@vitejs/plugin-react";
 import path from "node:path";
 
 export default defineConfig({
+  plugins: [react()],
   resolve: {
     alias: { "@": path.resolve(__dirname, "./src") },
   },
   test: {
     environment: "node",
-    include: ["src/**/*.test.ts", "emails/**/*.test.ts"],
+    include: [
+      "src/**/*.test.ts",
+      "src/**/*.test.tsx",
+      "emails/**/*.test.ts",
+      "emails/**/*.test.tsx",
+    ],
   },
 });


### PR DESCRIPTION
## Summary

Replaces the default Supabase Auth email templates with branded Lexena HTML, built via React Email.

- **3 templates** (EN only for v3.0): Magic Link, Signup Confirmation, Password Reset
- **`emails/` subproject** at repo root with reusable components (`Layout`, `Header`, `Footer`, `Button`, `Heading`, `Text`, `SecurityNote`, `tokens`)
- **Build pipeline**: `pnpm email:build` renders `.tsx` → `dist/emails/*.html` with Liquid placeholder safety (`unescapeLiquid()` post-processing)
- **Live preview**: `pnpm email:dev` → `localhost:3001` (smoke-tested ✅)
- **Snapshot regression test** guards against `dist/emails/*.html` drifting from `.tsx` sources (uses `git show HEAD:dist/...` for true drift detection, sanity-checked)
- **Logo**: temporary placeholder via GitHub raw (monogram-512.png), centralized URL for easy migration to `lexena.app/static/email/...` once marketing site lands
- 117/117 tests passing (23 new email tests + 94 existing)

## Spec / Plan

- Spec: `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md`
- Plan: `docs/superpowers/plans/2026-05-02-email-templates-supabase-auth.md`

## Manual follow-ups (operator-required)

These are documented inline in `emails/` and tracked here:

- [ ] **Multi-client compatibility test** — run via Email on Acid or Litmus free trial, fill in `emails/COMPATIBILITY.md` matrix (Gmail web/iOS/Android, Outlook desktop/web, Apple Mail macOS/iOS)
- [ ] **Deploy to Supabase Dashboard** — paste each `dist/emails/*.html` into Supabase → Authentication → Email Templates per `emails/DEPLOY_SUPABASE.md`. Set subjects from the `<!-- Subject: ... -->` comments on line 1 of each file.
  - [ ] Magic Link template deployed and tested
  - [ ] Signup Confirmation template deployed and tested
  - [ ] Password Reset template deployed and tested

## Test plan

- [x] `pnpm test` → 117/117 pass (23 new email tests)
- [x] `pnpm email:build` produces 3 HTML files with Liquid placeholders intact (no `&#123;`)
- [x] `pnpm email:dev` → `localhost:3001` serves all 3 template previews (HTTP 200)
- [x] Snapshot regression test catches drift (verified by intentionally perturbing a template, then reverting)
- [ ] **Multi-client preview** (Litmus / Email on Acid) — operator follow-up
- [ ] **Live test emails from Supabase Dashboard** — operator follow-up

## What's NOT in this PR (phase 2)

Tracked in spec section 9. To be addressed in a separate spec/plan:
- 4 emails via Edge Functions Resend: welcome, new-device alert (HTML refactor), deletion request, deletion completion
- FR/EN per-user locale (Edge Function `auth-email-hook`)
- Migration to a stable CDN-hosted logo asset (`lexena.app/static/email/...`)
- DMARC/SPF/BIMI deliverability hardening

## Plan execution notes

- Followed `superpowers:subagent-driven-development` (19 tasks, fresh subagent per task, two-stage review where applicable)
- One in-flight fix: `email:dev` script was originally `cd emails && react-email dev` per plan, but the binary is named `email` (not `react-email`) and `pnpm exec` is needed to find it. Also `@react-email/ui` had to be added as a devDep for the preview UI. Fixed and committed as `a4e352b`.
- One implementer-driven adjustment: tests file extension `.tsx` (not `.ts`) since vitest needs JSX support, vitest config extended to discover both. Verified clean by spec reviewer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)