### PR TITLE
feat(updater): move update notification to sidebar and redesign modal

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,3 +4,7 @@ VITE_SUPABASE_PUBLISHABLE_KEY=sb_publishable_<your-key>
 
 # Optional: override auth callback URL (default = prod auth.lexena.app)
 # VITE_AUTH_CALLBACK_URL=https://auth.lexena.app
+
+# Dev-only: force the "update available" UI (sidebar banner + modal) without
+# a real release. Tree-shaken in prod builds.
+# VITE_MOCK_UPDATE_AVAILABLE=true

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -54,7 +54,7 @@ export default function Dashboard() {
     settings,
     settingsLoaded,
   );
-  const { updateAvailable, showUpdateModal, setShowUpdateModal } =
+  const { updateAvailable, updateInfo, showUpdateModal, setShowUpdateModal } =
     useUpdaterContext();
   const {
     transcriptions,
@@ -260,6 +260,9 @@ export default function Dashboard() {
         sourceFilter={logsSourceFilter}
         onSourceFilterChange={setLogsSourceFilter}
         developerMode={settings.developer_mode}
+        updateAvailable={updateAvailable}
+        updateVersion={updateInfo?.version ?? null}
+        onOpenUpdateModal={() => setShowUpdateModal(true)}
       />
 
       {/* Main area */}
@@ -268,8 +271,6 @@ export default function Dashboard() {
           isRecording={isRecording}
           isTranscribing={isTranscribing}
           onToggleRecording={handleToggleRecording}
-          updateAvailable={updateAvailable}
-          onUpdateClick={() => setShowUpdateModal(true)}
           activeTab={activeTab}
           sidebarCollapsed={sidebarCollapsed}
         />
@@ -354,7 +355,10 @@ export default function Dashboard() {
       <UpdateModal
         open={showUpdateModal}
         onOpenChange={setShowUpdateModal}
-        onViewDetails={() => setActiveTab("parametres")}
+        onViewDetails={() => {
+          setActiveTab("parametres");
+          setActiveSettingsSection("section-mises-a-jour");
+        }}
       />
 
       {showOnboarding && <OnboardingWizard onComplete={recheckOnboarding} />}

--- a/src/components/common/DashboardHeader.tsx
+++ b/src/components/common/DashboardHeader.tsx
@@ -4,7 +4,6 @@ import { useEffect, useState } from "react"
 import { useTranslation } from "react-i18next"
 import {
   Mic,
-  Download,
   FileText,
   History,
   ScrollText,
@@ -12,8 +11,6 @@ import {
   BarChart3,
   type LucideIcon,
 } from "lucide-react"
-import { Button } from "@/components/ui/button"
-import { Badge } from "@/components/ui/badge"
 import { AudioVisualizer } from "./AudioVisualizer"
 import { LexenaWordmark } from "./LexenaWordmark"
 import { SyncStatusIndicator } from "@/components/SyncStatusIndicator"
@@ -24,8 +21,6 @@ interface DashboardHeaderProps {
   isRecording: boolean;
   isTranscribing?: boolean;
   onToggleRecording: () => void;
-  updateAvailable?: boolean;
-  onUpdateClick?: () => void;
   activeTab: DashboardTabId;
   sidebarCollapsed?: boolean;
 }
@@ -42,8 +37,6 @@ export function DashboardHeader({
   isRecording,
   isTranscribing = false,
   onToggleRecording,
-  updateAvailable,
-  onUpdateClick,
   activeTab,
   sidebarCollapsed = false,
 }: DashboardHeaderProps) {
@@ -147,22 +140,6 @@ export function DashboardHeader({
             </div>
 
             <SyncStatusIndicator />
-
-            {updateAvailable && (
-              <Button
-                variant="default"
-                size="sm"
-                onClick={onUpdateClick}
-                className="gap-2 shadow-[var(--vt-shadow-primary-glow)]"
-              >
-                <Download className="w-4 h-4" />
-                <span>{t('header.newVersion')}</span>
-                <Badge variant="secondary" className="ml-1 bg-white/20 text-white border-0">
-                  {t('common.new')}
-                </Badge>
-              </Button>
-            )}
-
           </div>
         </div>
       </div>

--- a/src/components/common/UpdateModal.tsx
+++ b/src/components/common/UpdateModal.tsx
@@ -2,12 +2,10 @@
 
 import { useTranslation } from "react-i18next";
 import { Download, ExternalLink } from "lucide-react";
-import { Button } from "@/components/ui/button";
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
@@ -41,68 +39,116 @@ export function UpdateModal({ open, onOpenChange, onViewDetails }: UpdateModalPr
     onViewDetails();
   };
 
-  // Format date if available
-  const locale = i18n.language === 'en' ? 'en-US' : 'fr-FR';
+  const locale = i18n.language === "en" ? "en-US" : "fr-FR";
   const formattedDate = updateInfo.date
     ? new Date(updateInfo.date).toLocaleDateString(locale, {
-        year: 'numeric',
-        month: 'long',
-        day: 'numeric'
+        year: "numeric",
+        month: "long",
+        day: "numeric",
       })
     : null;
 
+  const bodyLines = updateInfo.body ? updateInfo.body.split("\n") : [];
+  const bodyPreview = bodyLines.slice(0, 10).join("\n");
+  const hasMoreLines = bodyLines.length > 10;
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
-      <DialogContent className="sm:max-w-[500px]">
-        <DialogHeader>
-          <DialogTitle className="flex items-center gap-2">
-            <Download className="w-5 h-5 text-primary" />
-            {t('updater.updateModal.title')}
-          </DialogTitle>
-          <DialogDescription className="text-left">
-            {t('updater.updateModal.versionReady', { version: updateInfo.version })}
-            {formattedDate && (
-              <span className="block mt-1 text-xs text-muted-foreground">
-                {t('updater.updateModal.publishedOn')} {formattedDate}
-              </span>
-            )}
-          </DialogDescription>
-        </DialogHeader>
-
-        {updateInfo.body && (
-          <div className="max-h-[200px] overflow-y-auto rounded-md border border-border bg-muted/30 p-3">
-            <p className="vt-eyebrow mb-2">
-              {t('updater.updateModal.releaseNotes')}
-            </p>
-            <div className="text-sm text-foreground whitespace-pre-wrap">
-              {updateInfo.body.split('\n').slice(0, 10).join('\n')}
-              {updateInfo.body.split('\n').length > 10 && (
-                <span className="block mt-2 text-xs text-muted-foreground italic">
-                  {t('updater.updateModal.viewFullDetails')}
-                </span>
-              )}
-            </div>
+      <DialogContent className="vt-app sm:max-w-[520px] border-0 bg-transparent p-0 shadow-none">
+        <div
+          className="rounded-2xl overflow-hidden"
+          style={{
+            background: "var(--vt-bg)",
+            border: "1px solid var(--vt-border)",
+            boxShadow: "var(--vt-shadow-elevated)",
+          }}
+        >
+          <div className="px-6 pt-6 pb-2">
+            <DialogHeader>
+              <DialogTitle
+                className="vt-display text-[16px] font-semibold flex items-center gap-2"
+                style={{ color: "var(--vt-fg)" }}
+              >
+                <Download
+                  className="w-4 h-4"
+                  style={{ color: "var(--vt-accent)" }}
+                />
+                {t("updater.updateModal.title")}
+              </DialogTitle>
+              <DialogDescription
+                className="text-[12.5px] text-left"
+                style={{ color: "var(--vt-fg-3)" }}
+              >
+                {t("updater.updateModal.versionReady", {
+                  version: updateInfo.version,
+                })}
+                {formattedDate && (
+                  <span
+                    className="block mt-1 text-[11.5px]"
+                    style={{ color: "var(--vt-fg-4)" }}
+                  >
+                    {t("updater.updateModal.publishedOn")} {formattedDate}
+                  </span>
+                )}
+              </DialogDescription>
+            </DialogHeader>
           </div>
-        )}
 
-        <DialogFooter className="gap-2 sm:gap-0">
-          <Button
-            variant="outline"
-            onClick={handleViewDetails}
-            className="gap-2"
-          >
-            <ExternalLink className="w-4 h-4" />
-            {t('updater.updateModal.viewDetails')}
-          </Button>
-          <Button
-            onClick={handleInstall}
-            disabled={isDownloading}
-            className="gap-2 bg-primary hover:bg-primary/90"
-          >
-            <Download className="w-4 h-4" />
-            {isDownloading ? t('updater.updateModal.downloading') : t('updater.updateModal.installNow')}
-          </Button>
-        </DialogFooter>
+          {updateInfo.body && (
+            <div className="px-6 pb-2">
+              <div
+                className="rounded-xl p-3 max-h-[200px] overflow-y-auto"
+                style={{
+                  background: "var(--vt-panel)",
+                  border: "1px solid var(--vt-border)",
+                }}
+              >
+                <p
+                  className="text-[10.5px] uppercase tracking-wide font-medium mb-2"
+                  style={{ color: "var(--vt-fg-3)" }}
+                >
+                  {t("updater.updateModal.releaseNotes")}
+                </p>
+                <div
+                  className="text-[12.5px] whitespace-pre-wrap"
+                  style={{ color: "var(--vt-fg-2)" }}
+                >
+                  {bodyPreview}
+                  {hasMoreLines && (
+                    <span
+                      className="block mt-2 text-[11px] italic"
+                      style={{ color: "var(--vt-fg-3)" }}
+                    >
+                      {t("updater.updateModal.viewFullDetails")}
+                    </span>
+                  )}
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div className="flex justify-end gap-2 px-6 py-4">
+            <button
+              type="button"
+              onClick={handleViewDetails}
+              className="vt-btn vt-btn-sm"
+            >
+              <ExternalLink className="w-3.5 h-3.5" />
+              {t("updater.updateModal.viewDetails")}
+            </button>
+            <button
+              type="button"
+              onClick={handleInstall}
+              disabled={isDownloading}
+              className="vt-btn vt-btn-sm vt-btn-primary"
+            >
+              <Download className="w-3.5 h-3.5" />
+              {isDownloading
+                ? t("updater.updateModal.downloading")
+                : t("updater.updateModal.installNow")}
+            </button>
+          </div>
+        </div>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -25,6 +25,7 @@ import { ProfileSwitcher } from "./ProfileSwitcher";
 import { HistoriqueSidebarSection } from "./HistoriqueSidebarSection";
 import { StatistiquesSidebarSection } from "./StatistiquesSidebarSection";
 import { LogsSidebarSection } from "./LogsSidebarSection";
+import { UpdateAvailableBanner } from "./UpdateAvailableBanner";
 
 export const DASHBOARD_NAV_ITEMS = [
   {
@@ -100,6 +101,9 @@ interface DashboardSidebarProps {
   sourceFilter: string | null;
   onSourceFilterChange: (next: string | null) => void;
   developerMode: boolean;
+  updateAvailable: boolean;
+  updateVersion: string | null;
+  onOpenUpdateModal: () => void;
 }
 
 export function DashboardSidebar({
@@ -132,6 +136,9 @@ export function DashboardSidebar({
   sourceFilter,
   onSourceFilterChange,
   developerMode,
+  updateAvailable,
+  updateVersion,
+  onOpenUpdateModal,
 }: DashboardSidebarProps) {
   const { t } = useTranslation();
   const { settings } = useSettings();
@@ -274,6 +281,17 @@ export function DashboardSidebar({
         !(activeTab === "logs" && !collapsed) && (
           <div className="flex-1" />
         )}
+
+      {/* Update banner — sits just above the profile switcher when an update is available */}
+      {updateAvailable && updateVersion && (
+        <div className="shrink-0 px-2 pb-2">
+          <UpdateAvailableBanner
+            collapsed={collapsed}
+            version={updateVersion}
+            onClick={onOpenUpdateModal}
+          />
+        </div>
+      )}
 
       {/* Profile switcher — always at the very bottom */}
       <div className="border-t border-border shrink-0 p-2">

--- a/src/components/dashboard/UpdateAvailableBanner.tsx
+++ b/src/components/dashboard/UpdateAvailableBanner.tsx
@@ -1,0 +1,78 @@
+import { ChevronRight, Download } from "lucide-react";
+import { useTranslation } from "react-i18next";
+
+interface UpdateAvailableBannerProps {
+  collapsed: boolean;
+  version: string;
+  onClick: () => void;
+}
+
+export function UpdateAvailableBanner({
+  collapsed,
+  version,
+  onClick,
+}: UpdateAvailableBannerProps) {
+  const { t } = useTranslation();
+  const tooltip = t("sidebar.updateAvailableTooltip", { version });
+
+  if (collapsed) {
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        title={tooltip}
+        aria-label={tooltip}
+        className="relative flex items-center justify-center p-1.5 rounded-md transition-colors cursor-pointer hover:opacity-90"
+        style={{ background: "var(--vt-accent-soft)" }}
+      >
+        <div
+          className="w-7 h-7 rounded-md flex items-center justify-center shrink-0"
+          style={{ background: "var(--vt-accent-soft)" }}
+        >
+          <Download className="w-3.5 h-3.5" style={{ color: "var(--vt-accent)" }} />
+        </div>
+        <span
+          className="absolute top-1 right-1 w-2 h-2 rounded-full animate-pulse"
+          style={{ background: "var(--vt-accent)" }}
+          aria-hidden="true"
+        />
+      </button>
+    );
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={tooltip}
+      className="w-full flex items-center gap-2.5 rounded-md px-2 py-1.5 transition-colors cursor-pointer hover:opacity-90"
+      style={{ background: "var(--vt-accent-soft)" }}
+    >
+      <div
+        className="w-7 h-7 rounded-md flex items-center justify-center shrink-0"
+        style={{ background: "var(--vt-accent-soft)" }}
+      >
+        <Download className="w-3.5 h-3.5" style={{ color: "var(--vt-accent)" }} />
+      </div>
+      <div className="flex-1 min-w-0 text-left">
+        <div
+          className="text-sm font-medium truncate"
+          style={{ color: "var(--vt-fg)" }}
+        >
+          {t("sidebar.updateAvailable")}
+        </div>
+        <div
+          className="text-[11px] truncate vt-mono"
+          style={{ color: "var(--vt-fg-3)" }}
+        >
+          {version}
+        </div>
+      </div>
+      <ChevronRight
+        className="w-3.5 h-3.5 shrink-0"
+        style={{ color: "var(--vt-fg-3)" }}
+        aria-hidden="true"
+      />
+    </button>
+  );
+}

--- a/src/contexts/UpdaterContext.tsx
+++ b/src/contexts/UpdaterContext.tsx
@@ -27,6 +27,23 @@ interface UpdaterContextType {
 
 const UpdaterContext = createContext<UpdaterContextType | undefined>(undefined);
 
+// Dev-only mock: set VITE_MOCK_UPDATE_AVAILABLE=true in .env.local to force
+// the "update available" UI without a real release. Tree-shaken in prod.
+const MOCK_UPDATE =
+  import.meta.env.DEV &&
+  import.meta.env.VITE_MOCK_UPDATE_AVAILABLE === "true";
+
+const MOCK_UPDATE_INFO: UpdateInfo = {
+  version: "99.0.0-mock",
+  date: new Date().toISOString(),
+  body:
+    "## Mocked release notes\n" +
+    "- This is a fake update used to preview the sidebar banner and modal.\n" +
+    "- Set VITE_MOCK_UPDATE_AVAILABLE=false (or remove the var) to disable.\n" +
+    "- Clicking 'Install now' will be a no-op in this mode.",
+  available: true,
+};
+
 export function UpdaterProvider({ children }: { children: ReactNode }) {
   const updater = useUpdater();
   const { settings, isLoaded } = useSettings();
@@ -95,13 +112,25 @@ export function UpdaterProvider({ children }: { children: ReactNode }) {
     return info;
   }, [updater]);
 
+  const effectiveUpdateAvailable = MOCK_UPDATE ? true : updateAvailable;
+  const effectiveUpdateInfo = MOCK_UPDATE
+    ? MOCK_UPDATE_INFO
+    : updater.updateInfo;
+  const effectiveDownloadAndInstall = MOCK_UPDATE
+    ? async () => {
+        console.warn(
+          "[UpdaterContext] Mock mode — downloadAndInstall is a no-op.",
+        );
+      }
+    : updater.downloadAndInstall;
+
   return (
     <UpdaterContext.Provider
       value={{
-        updateAvailable,
-        updateInfo: updater.updateInfo,
+        updateAvailable: effectiveUpdateAvailable,
+        updateInfo: effectiveUpdateInfo,
         checkForUpdates,
-        downloadAndInstall: updater.downloadAndInstall,
+        downloadAndInstall: effectiveDownloadAndInstall,
         isChecking: updater.isChecking,
         isDownloading: updater.isDownloading,
         downloadProgress: updater.downloadProgress,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -46,7 +46,9 @@
     "settings": "Settings",
     "logs": "Logs",
     "expandMenu": "Expand menu",
-    "collapseMenu": "Collapse menu"
+    "collapseMenu": "Collapse menu",
+    "updateAvailable": "Update available",
+    "updateAvailableTooltip": "Update {{version}} available"
   },
   "statistics": {
     "heroEyebrow": "Dashboard",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -46,7 +46,9 @@
     "settings": "Paramètres",
     "logs": "Logs",
     "expandMenu": "Déplier le menu",
-    "collapseMenu": "Replier le menu"
+    "collapseMenu": "Replier le menu",
+    "updateAvailable": "Mise à jour disponible",
+    "updateAvailableTooltip": "Mise à jour {{version}} disponible"
   },
   "statistics": {
     "heroEyebrow": "Tableau de bord",


### PR DESCRIPTION
## Summary

- Move the "update available" CTA from the dashboard header to a compact banner above the profile switcher in the sidebar (VS Code-style). The header zone "Click to start" recovers its primary-action prominence.
- Banner adapts to the collapsed sidebar: icon-only + pulsing teal dot + native tooltip carrying the version.
- Migrate `UpdateModal` from shadcn v2 primitives to the v3 design system (`.vt-app` scope, OKLCH tokens, `rounded-2xl` card, `vt-btn-primary`), matching `ExportDialog`.
- Fix: "View details" used to land on the first Settings tab. It now opens directly on the Updates section.
- Add `VITE_MOCK_UPDATE_AVAILABLE` (dev-only, tree-shaken in prod) so the update UI can be previewed without a real release.

## Notes

- Release notes (`updateInfo.body`) currently come from a hardcoded GitHub link in `scripts/release.ps1:186`, not the parsed CHANGELOG. Improving that is out-of-scope here.
- All existing i18n keys preserved (`updater.updateModal.*`); two new keys added under `sidebar.*` for FR + EN.

## Test plan

- [x] Set `VITE_MOCK_UPDATE_AVAILABLE=true` in `.env.local`, run `pnpm tauri dev`.
- [x] Sidebar expanded — banner shows above the profile switcher with version + chevron.
- [x] Sidebar collapsed — only the Download icon + pulsing dot + tooltip on hover.
- [x] Click the banner → v3 modal opens (rounded card, accent icon, vt-fg colors).
- [x] "View details" closes the modal and opens Settings on the Updates section.
- [x] Toggle FR ↔ EN, banner + tooltip + modal stay localised.
- [x] Header no longer shows the blue "New version available" button.
- [x] Build prod (`pnpm tauri build`) — mock is tree-shaken, no banner unless a real update is available.

🤖 Generated with [Claude Code](https://claude.com/claude-code)