### PR TITLE
feat(cloud): guard LexenaCloud recording when ineligible

### DIFF
--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -3,7 +3,7 @@ use tauri::{AppHandle, Emitter, State};
 use tauri_plugin_store::StoreBuilder;
 
 use crate::hotkeys::{apply_hotkeys, normalize_hotkey_value};
-use crate::state::AppState;
+use crate::state::{AppState, CloudGate};
 
 /// Check if autostart is currently enabled
 #[tauri::command]
@@ -186,5 +186,25 @@ pub fn set_post_process_enabled(app: AppHandle, enabled: bool) -> Result<(), Str
     let _ = app.emit("post-process-enabled-changed", enabled);
 
     tracing::info!("Post-process enabled set to: {}", enabled);
+    Ok(())
+}
+
+/// Push the cloud routing snapshot from the renderer's `CloudContext` into
+/// `AppState.cloud_gate`. Hotkey-triggered `start_recording` reads this to
+/// refuse capture when `provider == "LexenaCloud"` and the user is not
+/// eligible — instead of recording 20s of audio that the renderer would
+/// reject post-capture.
+#[tauri::command]
+pub fn set_cloud_gate(
+    state: State<AppState>,
+    provider: String,
+    eligible: bool,
+) -> Result<(), String> {
+    let mut guard = state
+        .inner()
+        .cloud_gate
+        .lock()
+        .map_err(|e| format!("cloud_gate lock poisoned: {}", e))?;
+    *guard = CloudGate { provider, eligible };
     Ok(())
 }

--- a/src-tauri/src/hotkeys.rs
+++ b/src-tauri/src/hotkeys.rs
@@ -116,6 +116,22 @@ fn is_recorder_active<R: Runtime>(app_handle: &AppHandle<R>) -> bool {
 
 fn start_recording_shortcut<R: Runtime>(app_handle: &AppHandle<R>) -> bool {
     let state: State<AppState> = app_handle.state();
+
+    // Refuse hotkey-triggered capture when the user picked "LexenaCloud" but
+    // is not eligible (not signed-in / no active trial / no active sub). The
+    // renderer pushes this snapshot via the `set_cloud_gate` command from
+    // CloudContext. We emit `cloud-gate-blocked` so the renderer can surface
+    // a toast (instead of letting the user speak for 20s before we tell them).
+    if let Ok(gate) = state.inner().cloud_gate.lock() {
+        if gate.provider == "LexenaCloud" && !gate.eligible {
+            tracing::info!(
+                "Hotkey start_recording refused: LexenaCloud selected but user not eligible"
+            );
+            let _ = app_handle.emit("cloud-gate-blocked", ());
+            return false;
+        }
+    }
+
     if let Ok(mut recorder) = state.inner().audio_recorder.lock() {
         if recorder.is_recording() {
             return true;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -119,6 +119,7 @@ pub fn run() {
             commands::settings::set_update_channel,
             commands::settings::set_translate_mode,
             commands::settings::set_post_process_enabled,
+            commands::settings::set_cloud_gate,
             commands::model::download_local_model,
             commands::model::check_local_model_exists,
             commands::model::any_local_model_exists,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -29,6 +29,22 @@ pub struct WhisperState {
     pub cache: Arc<TokioMutex<WhisperCache>>,
 }
 
+/// Snapshot of cloud eligibility pushed by the renderer's CloudContext.
+///
+/// Used by hotkey-triggered `start_recording` to refuse capture when the user
+/// picked "LexenaCloud" but isn't signed-in / eligible — otherwise the user
+/// records 20s of audio that will be rejected post-capture by the renderer.
+#[derive(Clone, Default)]
+pub(crate) struct CloudGate {
+    /// Last known `transcription_provider` from settings (`"Local"` or
+    /// `"LexenaCloud"`). Defaults to empty until the renderer pushes its first
+    /// snapshot, which leaves the gate open (no block).
+    pub(crate) provider: String,
+    /// Whether the signed-in user is server-side eligible for cloud
+    /// (active trial or active subscription).
+    pub(crate) eligible: bool,
+}
+
 /// Application state that holds the audio recorder and active hotkeys
 pub struct AppState {
     pub(crate) audio_recorder: Mutex<AudioRecorder>,
@@ -38,6 +54,9 @@ pub struct AppState {
     pub active_profile_id: Mutex<String>,
     /// Auth state: pending OAuth nonces, memory-fallback refresh token, keyring flag
     pub auth: Mutex<crate::auth::AuthState>,
+    /// Cloud routing snapshot pushed by the renderer; used by hotkey handlers
+    /// to refuse `start_recording` when LexenaCloud is selected but ineligible.
+    pub(crate) cloud_gate: Mutex<CloudGate>,
 }
 
 pub(crate) fn create_app_state() -> AppState {
@@ -55,5 +74,6 @@ pub(crate) fn create_app_state() -> AppState {
         },
         active_profile_id: Mutex::new(String::new()),
         auth: Mutex::new(crate::auth::AuthState::new()),
+        cloud_gate: Mutex::new(CloudGate::default()),
     }
 }

--- a/src/components/settings/SettingTabs.tsx
+++ b/src/components/settings/SettingTabs.tsx
@@ -38,7 +38,9 @@ export function SettingTabs({ activeSection, onSectionChange }: SettingTabsProps
 
   return (
     <div className="vt-app mx-auto max-w-5xl px-3 py-6 sm:px-4 md:px-6">
-      {activeSection === "section-transcription" && <TranscriptionSection />}
+      {activeSection === "section-transcription" && (
+        <TranscriptionSection onSectionChange={onSectionChange} />
+      )}
       {activeSection === "section-post-process" && <PostProcessSection />}
       {activeSection === "section-audio" && <AudioSection />}
       {activeSection === "section-vocabulaire" && <VocabularySection />}

--- a/src/components/settings/sections/TranscriptionSection.tsx
+++ b/src/components/settings/sections/TranscriptionSection.tsx
@@ -2,6 +2,9 @@ import type { ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 import { useSettings } from "@/hooks/useSettings";
 import { useModelDownload } from "@/hooks/useModelDownload";
+import { useCloud } from "@/hooks/useCloud";
+import { useAuth } from "@/hooks/useAuth";
+import type { SettingsSectionId } from "../common/SettingsNav";
 import {
   PickerCardGrid,
   Row,
@@ -25,11 +28,73 @@ type LocalModel =
   | "large-v3-turbo"
   | "large-v3-turbo-q5_0";
 
-export function TranscriptionSection() {
+interface TranscriptionSectionProps {
+  onSectionChange?: (id: SettingsSectionId) => void;
+}
+
+/**
+ * Computes the cloud-eligibility chip displayed on the LexenaCloud provider
+ * card so the user sees, at a glance, why picking cloud might or might not
+ * work. Mirrors the gating logic in `useRecordingWorkflow` and the Rust
+ * `cloud_gate` so the UI signal is consistent with what would happen on
+ * record.
+ */
+function cloudStatusVariant({
+  isSignedIn,
+  isCloudEligible,
+  trialActive,
+  planName,
+}: {
+  isSignedIn: boolean;
+  isCloudEligible: boolean;
+  trialActive: boolean;
+  planName: string | null;
+}): { kind: "signin" | "trial" | "plan" | "none"; planName?: string } {
+  if (!isSignedIn) return { kind: "signin" };
+  if (isCloudEligible) {
+    if (planName) return { kind: "plan", planName };
+    if (trialActive) return { kind: "trial" };
+  }
+  return { kind: "none" };
+}
+
+export function TranscriptionSection({ onSectionChange }: TranscriptionSectionProps) {
   const { t } = useTranslation();
   const { settings, updateSetting } = useSettings();
   const { isDownloading, progress, isDownloaded, isChecking, download, remove } =
     useModelDownload(settings.transcription_provider, settings.local_model_size);
+  const { isCloudEligible, trial, plan } = useCloud();
+  const { user, openAuthModal } = useAuth();
+
+  const isSignedIn = Boolean(user);
+  const planName = plan?.plan ?? null;
+  const status = cloudStatusVariant({
+    isSignedIn,
+    isCloudEligible,
+    trialActive: trial.is_active,
+    planName,
+  });
+
+  const cloudStatusBadge =
+    status.kind === "signin" ? (
+      <ProviderBadge color="var(--vt-danger)">
+        {t("settings.transcription.cloudStatus.signinRequired")}
+      </ProviderBadge>
+    ) : status.kind === "plan" ? (
+      <ProviderBadge color="var(--vt-ok)">
+        {t("settings.transcription.cloudStatus.planActive", {
+          plan: status.planName,
+        })}
+      </ProviderBadge>
+    ) : status.kind === "trial" ? (
+      <ProviderBadge color="var(--vt-ok)">
+        {t("settings.transcription.cloudStatus.trialActive")}
+      </ProviderBadge>
+    ) : (
+      <ProviderBadge color="var(--vt-warn)">
+        {t("settings.transcription.cloudStatus.noActivePlan")}
+      </ProviderBadge>
+    );
 
   const providerOptions = [
     {
@@ -44,12 +109,18 @@ export function TranscriptionSection() {
       sub: t("settings.transcription.providerLexenaCloudSub"),
       dot: "var(--vt-accent)",
       badge: (
-        <ProviderBadge color="var(--vt-accent)">
-          {t("settings.transcription.providerBetaBadge")}
-        </ProviderBadge>
+        <div className="flex items-center gap-1.5">
+          <ProviderBadge color="var(--vt-accent)">
+            {t("settings.transcription.providerBetaBadge")}
+          </ProviderBadge>
+          {cloudStatusBadge}
+        </div>
       ),
     },
   ];
+
+  const cloudSelected = settings.transcription_provider === "LexenaCloud";
+  const showCloudBanner = cloudSelected && !isCloudEligible;
 
   return (
     <div className="vt-anim-fade-up space-y-5">
@@ -65,12 +136,22 @@ export function TranscriptionSection() {
           label={t("settings.transcription.provider")}
           hint={t("settings.transcription.providerHint")}
         >
-          <PickerCardGrid
-            value={settings.transcription_provider}
-            onChange={(v) => updateSetting("transcription_provider", v)}
-            options={providerOptions}
-            columns={2}
-          />
+          <div className="flex flex-col gap-2">
+            <PickerCardGrid
+              value={settings.transcription_provider}
+              onChange={(v) => updateSetting("transcription_provider", v)}
+              options={providerOptions}
+              columns={2}
+            />
+            {showCloudBanner && (
+              <CloudEligibilityBanner
+                isSignedIn={isSignedIn}
+                onSignIn={() => openAuthModal()}
+                onManagePlan={() => onSectionChange?.("section-cloud")}
+                t={t}
+              />
+            )}
+          </div>
         </Row>
 
         <Row
@@ -261,5 +342,62 @@ function ProviderBadge({ color, children }: ProviderBadgeProps) {
     >
       {children}
     </span>
+  );
+}
+
+interface CloudEligibilityBannerProps {
+  isSignedIn: boolean;
+  onSignIn: () => void;
+  onManagePlan: () => void;
+  t: (key: string, opts?: Record<string, unknown>) => string;
+}
+
+function CloudEligibilityBanner({
+  isSignedIn,
+  onSignIn,
+  onManagePlan,
+  t,
+}: CloudEligibilityBannerProps) {
+  const titleKey = isSignedIn
+    ? "settings.transcription.cloudBanner.noPlanTitle"
+    : "settings.transcription.cloudBanner.signinRequiredTitle";
+  const bodyKey = isSignedIn
+    ? "settings.transcription.cloudBanner.noPlanBody"
+    : "settings.transcription.cloudBanner.signinRequiredBody";
+
+  return (
+    <div
+      className="rounded-lg px-3 py-2.5 flex items-start gap-3"
+      style={{
+        background: "oklch(from var(--vt-warn) l c h / 0.10)",
+        border: "1px solid oklch(from var(--vt-warn) l c h / 0.32)",
+      }}
+    >
+      <span
+        className="mt-0.5 shrink-0"
+        style={{ color: "var(--vt-warn)" }}
+      >
+        <VtIcon.alert />
+      </span>
+      <div className="flex-1 min-w-0">
+        <div className="text-[12.5px] font-semibold">{t(titleKey)}</div>
+        <div
+          className="text-[12px] mt-0.5 leading-relaxed"
+          style={{ color: "var(--vt-fg-3)" }}
+        >
+          {t(bodyKey)}
+        </div>
+      </div>
+      <button
+        type="button"
+        onClick={isSignedIn ? onManagePlan : onSignIn}
+        className="vt-btn-primary shrink-0"
+        style={{ height: 30 }}
+      >
+        {isSignedIn
+          ? t("settings.transcription.cloudBanner.managePlanCta")
+          : t("settings.transcription.cloudBanner.signinCta")}
+      </button>
+    </div>
   );
 }

--- a/src/contexts/CloudContext.tsx
+++ b/src/contexts/CloudContext.tsx
@@ -1,4 +1,5 @@
 import { createContext, useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
+import { invoke } from "@tauri-apps/api/core";
 import { listen } from "@tauri-apps/api/event";
 import { supabase } from "@/lib/supabase";
 import { useAuth } from "@/hooks/useAuth";
@@ -165,6 +166,23 @@ export function CloudProvider({ children }: { children: ReactNode }) {
       unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
     };
   }, [refreshUsage]);
+
+  // Push the cloud routing snapshot to Rust so hotkey-triggered start_recording
+  // can refuse capture when LexenaCloud is selected but the user isn't eligible
+  // (instead of capturing 20s of audio that the renderer would reject post-hoc).
+  // The Rust side stores this in `AppState.cloud_gate` and emits
+  // `cloud-gate-blocked` when a hotkey is refused — listened to in
+  // useRecordingWorkflow which surfaces the i18n toast.
+  useEffect(() => {
+    void invoke("set_cloud_gate", {
+      provider: transcription_provider,
+      eligible,
+    }).catch(() => {
+      // Non-fatal: the renderer-side check in useRecordingWorkflow still
+      // refuses the call. Worst case, hotkey path captures audio then we
+      // reject in transcribeAudio (the pre-PR behavior).
+    });
+  }, [transcription_provider, eligible]);
 
   const mode: CloudMode = useMemo(() => {
     if (!user) return "local";

--- a/src/hooks/useRecordingWorkflow.ts
+++ b/src/hooks/useRecordingWorkflow.ts
@@ -606,6 +606,22 @@ export function useRecordingWorkflow({
           await transcribeAudio(result.audio_data, result.sample_rate);
         }
       } else {
+        // Refuse capture before recording when LexenaCloud is selected but the
+        // user isn't eligible — otherwise they speak for 20s only to get a
+        // generic post-capture error. Mirrors the Rust-side gate in
+        // start_recording_shortcut for the hotkey path.
+        if (hasCloudSelectedRef.current && cloudModeRef.current !== "cloud") {
+          const { data } = await supabase.auth.getSession();
+          const hasSession = Boolean(data.session?.access_token);
+          const key = !hasSession
+            ? "errors.signin_required"
+            : "errors.not_eligible";
+          toast.error(tRef.current(`cloud:${key}`));
+          await emit("transcription-error", {
+            error: tRef.current(`cloud:${key}`),
+          });
+          return;
+        }
         await invoke("start_recording", {
           deviceIndex: settings.input_device_index,
         });
@@ -623,6 +639,43 @@ export function useRecordingWorkflow({
     settings.input_device_index,
     transcribeAudio,
   ]);
+
+  // Listener for the Rust-side cloud gate: when a hotkey press is refused
+  // (LexenaCloud selected + ineligible), Rust emits `cloud-gate-blocked` and
+  // we surface the same i18n toast the UI button would show.
+  useEffect(() => {
+    let unlisten: UnlistenFn | null = null;
+    let disposed = false;
+
+    const setup = async () => {
+      try {
+        const handle = await listen("cloud-gate-blocked", async () => {
+          const { data } = await supabase.auth.getSession();
+          const hasSession = Boolean(data.session?.access_token);
+          const key = !hasSession
+            ? "errors.signin_required"
+            : "errors.not_eligible";
+          toast.error(tRef.current(`cloud:${key}`));
+          await emit("transcription-error", {
+            error: tRef.current(`cloud:${key}`),
+          });
+        });
+        if (disposed) handle();
+        else unlisten = handle;
+      } catch (err) {
+        console.error("Failed to register cloud-gate-blocked listener:", err);
+      }
+    };
+    setup();
+
+    return () => {
+      disposed = true;
+      if (unlisten) {
+        unlisten();
+        unlisten = null;
+      }
+    };
+  }, []);
 
   return {
     isRecording,

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -326,7 +326,21 @@
       "whisperModelHint": "The bigger the model, the more accurate but slower and heavier.",
       "providerLocalSub": "offline · CPU/GPU",
       "smartFormatting": "Smart formatting (punctuation, capitals, spaces)",
-      "smartFormattingHint": "Fixes capitalization, punctuation and spaces on the Whisper output."
+      "smartFormattingHint": "Fixes capitalization, punctuation and spaces on the Whisper output.",
+      "cloudStatus": {
+        "signinRequired": "Sign-in required",
+        "trialActive": "Trial active",
+        "planActive": "{{plan}} plan active",
+        "noActivePlan": "No active plan"
+      },
+      "cloudBanner": {
+        "signinRequiredTitle": "You're not signed in",
+        "signinRequiredBody": "Lexena Cloud requires an account. Sign in to start your free trial, or pick Local in the meantime.",
+        "signinCta": "Sign in",
+        "noPlanTitle": "No active trial or subscription",
+        "noPlanBody": "You can still pick Lexena Cloud, but recording will be refused until a plan or trial is active.",
+        "managePlanCta": "Manage subscription"
+      }
     },
     "audio": {
       "title": "Audio",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -326,7 +326,21 @@
       "whisperModelHint": "Plus le modèle est grand, plus il est précis mais lent et lourd.",
       "providerLocalSub": "hors-ligne · CPU/GPU",
       "smartFormatting": "Formatage intelligent (ponctuation, majuscules, espaces)",
-      "smartFormattingHint": "Corrige majuscules, ponctuation et espaces sur la sortie Whisper."
+      "smartFormattingHint": "Corrige majuscules, ponctuation et espaces sur la sortie Whisper.",
+      "cloudStatus": {
+        "signinRequired": "Connexion requise",
+        "trialActive": "Essai actif",
+        "planActive": "Plan {{plan}} actif",
+        "noActivePlan": "Aucun plan actif"
+      },
+      "cloudBanner": {
+        "signinRequiredTitle": "Tu n'es pas connecté",
+        "signinRequiredBody": "Lexena Cloud nécessite un compte. Connecte-toi pour lancer ton essai gratuit ou choisis Local en attendant.",
+        "signinCta": "Se connecter",
+        "noPlanTitle": "Aucun essai ni abonnement actif",
+        "noPlanBody": "Tu peux toujours choisir Lexena Cloud, mais l'enregistrement sera refusé tant qu'un plan ou un essai n'est pas actif.",
+        "managePlanCta": "Gérer mon abonnement"
+      }
     },
     "audio": {
       "title": "Audio",


### PR DESCRIPTION
## Summary

- **Problem**: users could pick **Lexena Cloud** as transcription provider while signed-out (or without an active plan), then speak for 20 s before the renderer rejected the capture post-hoc. Frustrating in tests.
- **Fix**: refuse `start_recording` *before* the user speaks, at both the hotkey path (Rust) and the UI-button path (renderer). Surface eligibility in Settings via a dynamic badge + inline banner with contextual CTA.

### How it works

- New `CloudGate { provider, eligible }` lives in Rust `AppState`. `CloudContext` pushes a snapshot via `set_cloud_gate` every time `(transcription_provider, eligible)` changes.
- Hotkey `start_recording_shortcut` reads the gate and emits `cloud-gate-blocked` when refusing — the renderer listens and shows the same i18n toast the UI button would.
- `TranscriptionSection`:
  - dynamic status chip on the Lexena Cloud card: *Sign-in required* / *Trial active* / *Plan X active* / *No active plan*
  - inline banner under the picker grid when cloud-selected + ineligible:
    - signed-out → CTA "Sign in" (opens AuthModal)
    - signed-in / no plan → CTA "Manage subscription" (navigates to `section-cloud`)

### Result matrix

| Case | Before | After |
|---|---|---|
| Signed-out + Cloud picked, hit Record button | 20 s capture then error | Immediate toast, no capture |
| Signed-out + Cloud picked, press hotkey | 20 s capture then error | Rust refuses, immediate toast |
| Signed-in but no plan + Cloud picked | Same | Same (badge + banner explain why) |
| User signs out mid-session | Silent fallback | Gate updates, next attempt refused |

## Test plan

- [ ] Settings → Transcription while signed-out shows red `SIGN-IN REQUIRED` chip on the Lexena Cloud card
- [ ] Selecting Lexena Cloud while signed-out shows the orange banner with "Sign in" CTA
- [ ] Click record button while signed-out + Cloud selected → toast, no recording starts
- [ ] Press record hotkey while signed-out + Cloud selected → toast, no recording starts
- [ ] Sign in with active trial → chip flips to green `TRIAL ACTIVE`, banner disappears, recording works in cloud mode
- [ ] Sign in with active Pro plan → chip shows `PRO PLAN ACTIVE`
- [ ] Sign in without trial or plan → chip shows `NO ACTIVE PLAN`, banner CTA navigates to Cloud section
- [ ] Sign out mid-session → next record attempt refused
- [ ] Switching back to Local provider clears the banner immediately
- [ ] `pnpm test` green (151 tests)
- [ ] `cargo test --lib --no-default-features` green (30 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)