### PR TITLE
fix(onboarding): align local model wizard with vt-app design system

### DIFF
--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -148,10 +148,10 @@ export function OnboardingWizard({
     <DialogPrimitive.Root open>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay
-          className="dark fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=open]:fade-in-0"
+          className="vt-app fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0"
         />
         <DialogPrimitive.Content
-          className="dark fixed left-[50%] top-[50%] z-50 grid w-full max-w-2xl translate-x-[-50%] translate-y-[-50%] gap-6 border bg-background p-8 text-foreground shadow-lg sm:rounded-lg data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
+          className="vt-app fixed left-[50%] top-[50%] z-50 grid w-full max-w-2xl translate-x-[-50%] translate-y-[-50%] gap-6 border bg-background p-8 text-foreground shadow-lg sm:rounded-lg data-[state=open]:animate-in data-[state=open]:fade-in-0 data-[state=open]:zoom-in-95"
           onInteractOutside={(e) => e.preventDefault()}
           onEscapeKeyDown={(e) => e.preventDefault()}
         >


### PR DESCRIPTION
## Summary
- Swap `dark` legacy scope → `vt-app` on `OnboardingWizard` overlay + content so OKLCH tokens (vt-violet recommendation card, vt-warn detection failure, etc.) render correctly
- Align overlay backdrop with `WelcomeScreen` (`bg-black/60 backdrop-blur-sm` instead of opaque `bg-black/80`) so the cloud-vs-local → local-wizard transition is visually seamless

## Test plan
- [ ] `pnpm tauri dev`, first-run welcome screen → click "Continuer avec local"
- [ ] Local wizard modal opens with same blurred backdrop as the welcome screen
- [ ] Click "Détecter automatiquement le meilleur modèle" → recommendation card uses violet OKLCH token (was raw blue/grey before)
- [ ] Trigger detection failure path (offline) → warn card uses vt-warn OKLCH token
- [ ] No regression on the download flow / progress bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)