### PR TITLE
fix(post-process): restore strict auto prompt and unify to single mode

### DIFF
--- a/src/components/settings/sections/PostProcessSection.tsx
+++ b/src/components/settings/sections/PostProcessSection.tsx
@@ -11,33 +11,10 @@ import {
 
 const ACCENT = "var(--vt-pin)";
 
-type PostProcessMode =
-  | "auto"
-  | "list"
-  | "email"
-  | "formal"
-  | "casual"
-  | "summary"
-  | "grammar";
-
 export function PostProcessSection() {
   const { t } = useTranslation();
   const { settings, updateSetting } = useSettings();
   const { isCloudEligible } = useCloud();
-
-  const modes: PostProcessMode[] = [
-    "auto",
-    "list",
-    "email",
-    "formal",
-    "casual",
-    "summary",
-    "grammar",
-  ];
-  const recommendedLabel = t("common.recommended", { defaultValue: "Recommandé" });
-  const activeModeDesc = t(
-    `settings.postProcess.modes.${settings.post_process_mode}.desc`,
-  );
 
   return (
     <div className="vt-anim-fade-up space-y-5">
@@ -120,41 +97,17 @@ export function PostProcessSection() {
               </Callout>
             </div>
 
-            <Row
-              label={t("settings.postProcess.mode")}
-              hint={t("settings.postProcess.modeHint", {
-                defaultValue: "Détermine le style appliqué à la sortie.",
-              })}
-              align="start"
-            >
-              <div className="flex flex-col gap-2" style={{ maxWidth: 360 }}>
-                <select
-                  className="vt-select"
-                  value={settings.post_process_mode}
-                  onChange={(e) =>
-                    updateSetting(
-                      "post_process_mode",
-                      e.target.value as PostProcessMode,
-                    )
-                  }
-                >
-                  {modes.map((m) => {
-                    const label = t(`settings.postProcess.modes.${m}.label`);
-                    return (
-                      <option key={m} value={m}>
-                        {m === "auto" ? `${label} — ${recommendedLabel}` : label}
-                      </option>
-                    );
-                  })}
-                </select>
-                <span
-                  className="text-[12px] leading-snug"
-                  style={{ color: "var(--vt-fg-3)" }}
-                >
-                  {activeModeDesc}
-                </span>
-              </div>
-            </Row>
+            <div className="vt-row">
+              <Callout
+                kind="info"
+                icon={<VtIcon.wand />}
+                title={t("settings.postProcess.autoTitle", {
+                  defaultValue: "Mode automatique",
+                })}
+              >
+                {t("settings.postProcess.autoBody")}
+              </Callout>
+            </div>
           </>
         )}
       </div>

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -122,10 +122,6 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
             console.info("[settings migration] %s → Local", legacyProvider);
             migrated = true;
           }
-          if (rawSettings.post_process_mode === "custom") {
-            merged.settings.post_process_mode = "auto";
-            migrated = true;
-          }
           for (const k of [
             "openai_api_key",
             "groq_api_key",
@@ -133,6 +129,9 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
             "groq_model",
             "post_process_provider",
             "post_process_custom_prompt",
+            // Post-process is now a single auto mode — the legacy per-mode
+            // selector was removed, so any stored value is dead weight.
+            "post_process_mode",
           ] as const) {
             if (k in rawSettings) {
               delete (merged.settings as Record<string, unknown>)[k];

--- a/src/hooks/useRecordingWorkflow.ts
+++ b/src/hooks/useRecordingWorkflow.ts
@@ -23,7 +23,6 @@ import { useCloud } from "@/hooks/useCloud";
 import { supabase } from "@/lib/supabase";
 import { transcribeCloud, postProcessCloud } from "@/lib/cloud/api";
 import { CloudApiError } from "@/lib/cloud/errors";
-import type { PostProcessTask } from "@/lib/cloud/types";
 
 type AddTranscription = (
   text: string,
@@ -42,8 +41,6 @@ interface PostProcessOutcome {
   text: string;
   /** Original Whisper text — set only when post-process actually modified it. */
   originalText?: string;
-  /** Mode applied — same condition as `originalText`. */
-  mode?: string;
   /** USD cost of the post-process LLM call — set only when post-process ran. */
   cost?: number;
 }
@@ -63,26 +60,6 @@ function shouldPostProcess(
   return true;
 }
 
-/**
- * Maps the local UI's post-process mode to the cloud worker's task taxonomy.
- */
-function mapModeToCloudTask(mode: string): PostProcessTask {
-  switch (mode) {
-    case "grammar":
-      return "correct";
-    case "email":
-      return "email";
-    case "summary":
-    case "list":
-      return "summarize";
-    case "auto":
-    case "formal":
-    case "casual":
-    default:
-      return "reformulate";
-  }
-}
-
 async function maybePostProcessCloud(
   originalText: string,
   settings: AppSettings["settings"],
@@ -94,13 +71,10 @@ async function maybePostProcessCloud(
   const trimmed = originalText.trim();
   if (!trimmed) return { text: originalText };
 
-  const task = mapModeToCloudTask(settings.post_process_mode);
-
   try {
     const result = await postProcessCloud({
-      task,
+      task: "auto",
       text: trimmed,
-      language: settings.language,
       jwt,
     });
     const cleaned = result.text?.trim();
@@ -110,7 +84,6 @@ async function maybePostProcessCloud(
     return {
       text: cleaned,
       originalText: trimmed,
-      mode: settings.post_process_mode,
       // Cloud post-process is billed in tokens against the user's plan / trial,
       // not in USD against their API key — no apiCost passthrough.
       cost: 0,
@@ -458,7 +431,7 @@ export function useRecordingWorkflow({
           result.audioPath,
           apiCost,
           processed.originalText,
-          processed.mode,
+          undefined,
           processed.cost,
           durationSeconds,
           effectiveProviderLabel,

--- a/src/lib/cloud/api.test.ts
+++ b/src/lib/cloud/api.test.ts
@@ -113,7 +113,7 @@ describe("postProcessCloud", () => {
       source: "trial",
     });
     await postProcessCloud({
-      task: "reformulate",
+      task: "auto",
       text: "in",
       language: "fr",
       modelTier: "mini",
@@ -122,7 +122,7 @@ describe("postProcessCloud", () => {
     expect(invoke).toHaveBeenCalledWith(
       "post_process_cloud",
       expect.objectContaining({
-        task: "reformulate",
+        task: "auto",
         text: "in",
         language: "fr",
         modelTier: "mini",

--- a/src/lib/cloud/types.ts
+++ b/src/lib/cloud/types.ts
@@ -23,7 +23,7 @@ export interface NotesAssistResult {
   source: CloudUsageSource;
 }
 
-export type PostProcessTask = "reformulate" | "correct" | "email" | "summarize";
+export type PostProcessTask = "auto";
 export type ModelTier = "mini" | "full";
 
 export interface CloudApiErrorBody {

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -70,14 +70,6 @@ export interface AppSettings {
 
     // Post-process (AI reformatting after transcription, cloud-only)
     post_process_enabled: boolean;
-    post_process_mode:
-      | "auto"
-      | "list"
-      | "email"
-      | "formal"
-      | "casual"
-      | "summary"
-      | "grammar";
   };
 }
 
@@ -149,7 +141,6 @@ export const DEFAULT_SETTINGS: AppSettings = {
 
     // Post-process
     post_process_enabled: false,
-    post_process_mode: "auto",
   },
 };
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -372,44 +372,14 @@
       "title": "Post Process",
       "subtitle": "Reformat the transcription with Lexena Cloud AI",
       "enable": "Enable AI post-processing",
-      "enableDesc": "After each transcription, the text goes through our AI using the selected mode.",
+      "enableDesc": "After each transcription, the text goes through our AI in automatic mode.",
       "delayWarning": "An AI call adds 1 to 3 seconds before the text is inserted.",
-      "mode": "Reformatting mode",
       "delayWarningTitle": "Extra latency",
-      "modeHint": "Determines the style applied to the output.",
+      "autoTitle": "Automatic mode",
+      "autoBody": "Dictate an instruction up front (\"translate to English\", \"write this as an email\", \"turn this into a list\"…): the AI applies it and strips it from the output. Without an instruction, it just fixes punctuation, casing, and readability.",
       "cloudUpsellTitle": "Available with Lexena Cloud",
       "cloudUpsellBody": "AI post-processing is included in paid plans (active trial or subscription).",
-      "cloudUpsellCta": "View plans",
-      "modes": {
-        "auto": {
-          "label": "Auto (context detection)",
-          "desc": "Detects list, email, or free text and reformats automatically."
-        },
-        "list": {
-          "label": "Bullet list",
-          "desc": "Converts the dictated enumeration into a Markdown bullet list."
-        },
-        "email": {
-          "label": "Email",
-          "desc": "Restructures the dictation into an email (greeting, body, closing)."
-        },
-        "formal": {
-          "label": "Formal tone",
-          "desc": "Rewrites in a professional tone, without filler words."
-        },
-        "casual": {
-          "label": "Casual tone",
-          "desc": "Rewrites in a fluid, natural tone without formality."
-        },
-        "summary": {
-          "label": "Summary",
-          "desc": "Condenses the dictation into 2 to 3 essential sentences."
-        },
-        "grammar": {
-          "label": "Grammar correction",
-          "desc": "Corrects spelling and grammar without reformulating the content."
-        }
-      }
+      "cloudUpsellCta": "View plans"
     },
     "vocabulary": {
       "title": "Vocabulary",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -372,44 +372,14 @@
       "title": "Post Process",
       "subtitle": "Reformate la transcription avec l'IA Lexena Cloud",
       "enable": "Activer le post-traitement IA",
-      "enableDesc": "Après chaque transcription, le texte est repassé par notre IA selon le mode choisi.",
+      "enableDesc": "Après chaque transcription, le texte est repassé par notre IA en mode automatique.",
       "delayWarning": "Un appel IA ajoute 1 à 3 secondes avant que le texte soit inséré.",
-      "mode": "Mode de reformatage",
       "delayWarningTitle": "Latence supplémentaire",
-      "modeHint": "Détermine le style appliqué à la sortie.",
+      "autoTitle": "Mode automatique",
+      "autoBody": "Dicte une consigne en tête (« traduis en anglais », « rédige ça comme un mail », « mets ça en liste »…) : l'IA l'applique et la retire du texte. Sans consigne, elle se contente de corriger ponctuation, casse et lisibilité.",
       "cloudUpsellTitle": "Disponible avec Lexena Cloud",
       "cloudUpsellBody": "Le post-traitement IA est inclus dans les offres payantes (essai ou abonnement actif).",
-      "cloudUpsellCta": "Voir les offres",
-      "modes": {
-        "auto": {
-          "label": "Auto (détection contextuelle)",
-          "desc": "Détecte liste, email ou texte libre et reformate automatiquement."
-        },
-        "list": {
-          "label": "Liste à puces",
-          "desc": "Convertit l'énumération dictée en liste Markdown à puces."
-        },
-        "email": {
-          "label": "Email",
-          "desc": "Restructure la dictée en email (salutation, corps, formule de politesse)."
-        },
-        "formal": {
-          "label": "Ton formel",
-          "desc": "Réécrit dans un ton professionnel, sans tics de langage."
-        },
-        "casual": {
-          "label": "Ton décontracté",
-          "desc": "Réécrit dans un ton fluide et naturel, sans formalisme."
-        },
-        "summary": {
-          "label": "Résumé",
-          "desc": "Condense la dictée en 2 à 3 phrases essentielles."
-        },
-        "grammar": {
-          "label": "Correction grammaticale",
-          "desc": "Corrige l'orthographe et la grammaire sans reformuler le fond."
-        }
-      }
+      "cloudUpsellCta": "Voir les offres"
     },
     "vocabulary": {
       "title": "Vocabulaire",

--- a/workers/transcription-api/src/post-process.test.ts
+++ b/workers/transcription-api/src/post-process.test.ts
@@ -55,7 +55,7 @@ describe("handlePostProcess OpenAIError mapping", () => {
       new OpenAIError("openai 400: content policy", 400, false),
     );
     const res = await handlePostProcess(
-      makeRequest({ task: "reformulate", text: "Bonjour" }),
+      makeRequest({ task: "auto", text: "Bonjour" }),
       ENV,
       USER,
     );
@@ -70,7 +70,7 @@ describe("handlePostProcess OpenAIError mapping", () => {
       new OpenAIError("openai 503: down", 503, true),
     );
     const res = await handlePostProcess(
-      makeRequest({ task: "reformulate", text: "Bonjour" }),
+      makeRequest({ task: "auto", text: "Bonjour" }),
       ENV,
       USER,
     );
@@ -85,7 +85,7 @@ describe("handlePostProcess OpenAIError mapping", () => {
       new OpenAIError("openai 429: rate limit", 429, true),
     );
     const res = await handlePostProcess(
-      makeRequest({ task: "reformulate", text: "Bonjour" }),
+      makeRequest({ task: "auto", text: "Bonjour" }),
       ENV,
       USER,
     );

--- a/workers/transcription-api/src/prompts.test.ts
+++ b/workers/transcription-api/src/prompts.test.ts
@@ -2,11 +2,15 @@ import { describe, it, expect } from "vitest";
 import { isValidTask, getPromptTemplate } from "./prompts";
 
 describe("isValidTask", () => {
-  it("accepts the four documented tasks", () => {
-    expect(isValidTask("reformulate")).toBe(true);
-    expect(isValidTask("correct")).toBe(true);
-    expect(isValidTask("email")).toBe(true);
-    expect(isValidTask("summarize")).toBe(true);
+  it("accepts the auto task", () => {
+    expect(isValidTask("auto")).toBe(true);
+  });
+
+  it("rejects the legacy 4-task taxonomy", () => {
+    expect(isValidTask("reformulate")).toBe(false);
+    expect(isValidTask("correct")).toBe(false);
+    expect(isValidTask("email")).toBe(false);
+    expect(isValidTask("summarize")).toBe(false);
   });
 
   it("rejects Object.prototype keys", () => {
@@ -29,13 +33,44 @@ describe("isValidTask", () => {
   });
 });
 
-describe("getPromptTemplate", () => {
-  it("returns a template with system + buildUser for every valid task", () => {
-    for (const task of ["reformulate", "correct", "email", "summarize"] as const) {
-      const tpl = getPromptTemplate(task);
-      expect(typeof tpl.system).toBe("string");
-      expect(tpl.system.length).toBeGreaterThan(0);
-      expect(typeof tpl.buildUser).toBe("function");
-    }
+describe("getPromptTemplate auto", () => {
+  const tpl = getPromptTemplate("auto");
+
+  it("returns a non-empty system prompt and a buildUser function", () => {
+    expect(typeof tpl.system).toBe("string");
+    expect(tpl.system.length).toBeGreaterThan(0);
+    expect(typeof tpl.buildUser).toBe("function");
+  });
+
+  it("system prompt encodes the absolute anti-answer rule", () => {
+    expect(tpl.system).toMatch(/RÈGLE ABSOLUE/);
+    expect(tpl.system).toMatch(/tu ne réponds JAMAIS/);
+  });
+
+  it("system prompt encodes the two-step meta-instruction detection", () => {
+    expect(tpl.system).toMatch(/ÉTAPE 1/);
+    expect(tpl.system).toMatch(/meta-instruction/);
+    expect(tpl.system).toMatch(/ÉTAPE 2/);
+  });
+
+  it("system prompt carries the translation few-shot", () => {
+    // Load-bearing example: confirms the LLM sees a concrete translate
+    // meta-instruction and the expected stripped+translated output.
+    expect(tpl.system).toMatch(
+      /<dictation>Traduis en anglais bonjour comment ça va<\/dictation>/,
+    );
+    expect(tpl.system).toMatch(/Hello, how are you\?/);
+  });
+
+  it("buildUser wraps input in <dictation>...</dictation>", () => {
+    const out = tpl.buildUser("Traduis en anglais bonjour");
+    expect(out).toBe("<dictation>\nTraduis en anglais bonjour\n</dictation>");
+  });
+
+  it("buildUser ignores the language hint", () => {
+    // language is irrelevant for auto — the prompt instructs the model to
+    // preserve the source language unless a meta-instruction overrides it.
+    const out = tpl.buildUser("Bonjour", "fr");
+    expect(out).toBe("<dictation>\nBonjour\n</dictation>");
   });
 });

--- a/workers/transcription-api/src/prompts.ts
+++ b/workers/transcription-api/src/prompts.ts
@@ -1,43 +1,59 @@
-export type PostProcessTask = "reformulate" | "correct" | "email" | "summarize";
+export type PostProcessTask = "auto";
 
 export interface PromptTemplate {
   system: string;
   buildUser: (input: string, language?: string) => string;
 }
 
-const langClause = (lang?: string) =>
-  lang ? `\n\nLangue de réponse : ${lang}.` : "";
+// Ported from the legacy local AUTO_PROMPT (src-tauri/src/commands/ai.rs before
+// the cloud migration). The strict structure — absolute rule, two-step decision
+// tree (meta-instruction vs. reformat), four few-shots, <dictation> wrapping —
+// is load-bearing: it's what keeps the LLM from answering dictated questions
+// or ignoring meta-instructions like "traduis en anglais …".
+const AUTO_SYSTEM = `Tu es un assistant de mise en forme de texte dicté à la voix.
+Tu reçois une dictée brute encadrée par <dictation>...</dictation>.
+
+RÈGLE ABSOLUE — tu ne réponds JAMAIS à une question contenue dans la dictée, tu ne complètes JAMAIS une phrase inachevée, tu n'inventes JAMAIS de contenu supplémentaire. Ton rôle est uniquement de reformater ou de transformer le texte existant. Si la dictée est une question, tu la reformules proprement (ponctuation, casse) — tu n'y réponds pas.
+
+ÉTAPE 1 — détecter une meta-instruction en tête de dictée (un ordre adressé à toi du type « traduis en anglais », « rédige ça comme un mail », « mets ça en liste », « résume », « reformule en formel ») :
+- si OUI : applique l'instruction au reste de la dictée, et retire l'instruction elle-même de la sortie
+- si NON : passe à l'étape 2
+
+ÉTAPE 2 — mettre en forme la dictée :
+- si c'est une énumération, transforme en liste Markdown (« - item »)
+- si c'est clairement un email, restructure avec salutation, corps court et formule de politesse
+- sinon, corrige ponctuation, casse et lisibilité sans changer le sens ni ajouter de contenu
+
+SORTIE — retourne uniquement le texte final, prêt à être collé. Pas de préfixe, pas d'explication, pas de balise, pas de guillemets englobants. Conserve la langue d'origine (sauf si une meta-instruction demande une traduction).
+
+Exemples :
+
+<dictation>Pourquoi le raccourci Ctrl Windows ne marche pas</dictation>
+→ Pourquoi le raccourci Ctrl+Windows ne marche pas ?
+
+<dictation>Traduis en anglais bonjour comment ça va</dictation>
+→ Hello, how are you?
+
+<dictation>Rédige ça comme un mail je voulais te dire que le projet avance bien et qu'on tient les délais</dictation>
+→ Bonjour,
+
+Je voulais te dire que le projet avance bien et que nous tenons les délais.
+
+Cordialement,
+
+<dictation>Donc je pense qu'on pourrait</dictation>
+→ Donc je pense qu'on pourrait.`;
 
 const TEMPLATES: Record<PostProcessTask, PromptTemplate> = {
-  reformulate: {
-    system:
-      "Tu es un assistant qui reformule un texte pour le rendre plus clair, concis et naturel, en conservant strictement le sens et l'intention de l'auteur. Tu ne rajoutes ni ne retires d'information. Réponds avec uniquement le texte reformulé, sans préambule.",
-    buildUser: (input, lang) =>
-      `Texte à reformuler :\n\n${input}${langClause(lang)}`,
-  },
-  correct: {
-    system:
-      "Tu es un correcteur orthographique et grammatical. Tu corriges les fautes sans modifier le style ni le sens. Réponds avec uniquement le texte corrigé.",
-    buildUser: (input, lang) =>
-      `Texte à corriger :\n\n${input}${langClause(lang)}`,
-  },
-  email: {
-    system:
-      "Tu transformes une note dictée en un email professionnel concis et bien structuré. Tu inclus un objet pertinent, une formule d'appel adaptée et une formule de politesse. Réponds avec uniquement l'email final, format texte brut.",
-    buildUser: (input, lang) =>
-      `Note à transformer en email :\n\n${input}${langClause(lang)}`,
-  },
-  summarize: {
-    system:
-      "Tu résumes un texte en gardant l'essentiel, en 3-5 puces. Réponds avec uniquement les puces, format texte brut.",
-    buildUser: (input, lang) =>
-      `Texte à résumer :\n\n${input}${langClause(lang)}`,
+  auto: {
+    system: AUTO_SYSTEM,
+    // The <dictation>...</dictation> wrapping is what lets the system prompt
+    // refer to a well-known delimiter when distinguishing meta-instructions
+    // from regular speech. Don't strip it.
+    buildUser: (input) => `<dictation>\n${input}\n</dictation>`,
   },
 };
 
-// Set lookup, not `in` operator: avoids prototype-chain hits like "toString".
-// Derive from TEMPLATES so adding a 5th task can never silently desync the validator
-// (Object.keys returns own enumerable props only — no prototype chain).
 const VALID_TASKS = new Set<PostProcessTask>(
   Object.keys(TEMPLATES) as PostProcessTask[],
 );


### PR DESCRIPTION
## Summary

- Cloud post-process regressed when the v3 worker shipped 4 minimal prompts (`reformulate`/`correct`/`email`/`summarize`) that dropped the anti-answer rule and meta-instruction detection from the legacy local `AUTO_PROMPT`. Dictations like *"translate this to English: …"* either kept the instruction in the output or translated it wholesale (system prompt vs. user input tug-of-war on `gpt-4o-mini`).
- Worker now exposes a single `auto` task carrying the full legacy prompt: absolute anti-answer rule, two-step decision tree (meta-instruction vs. reformat), four few-shots (including the translation case), and `<dictation>…</dictation>` wrapping done in `buildUser`.
- Frontend collapses to a single-mode UX: the per-mode selector is gone, `PostProcessSection` is toggle-only with an inline help callout explaining the meta-instruction pattern. `post_process_mode` is removed from the settings type/default and purged from stored settings via the existing migration. The optional column in the transcription history is kept for back-compat with older entries.

## Deployment note

The worker on `api.lexena.app` still validates against the legacy 4-task taxonomy. **The worker MUST be redeployed (`wrangler deploy` in `workers/transcription-api/`) before this PR is rolled out to users**, otherwise the desktop app will receive `bad_request: unknown task: auto` on every post-process call.

## Test plan

- [x] `pnpm --filter @lexena/transcription-api test` — 37/37 ✅
- [x] `pnpm test` (frontend) — 154/154 ✅
- [x] `tsc --noEmit` (frontend + worker) ✅
- [x] `cargo check --no-default-features` ✅
- [ ] Manual smoke test (`pnpm tauri dev`):
  - [x] Dictate *"Traduis-moi en anglais : bonjour comment ça va"* → output is `Hello, how are you?` (no leading meta-instruction)
  - [x] Dictate *"Rédige ça comme un mail je voulais te dire que le projet avance bien"* → email body, no "Rédige ça comme un mail" prefix
  - [x] Dictate a plain sentence → just punctuation/casing cleanup, no answer
  - [x] Dictate a question (*"Pourquoi le raccourci ne marche pas ?"*) → question is reformatted, not answered

🤖 Generated with [Claude Code](https://claude.com/claude-code)