### PR TITLE
fix(sync): pull cursor (server-based) + stop settings clobber

### DIFF
--- a/src/contexts/SettingsContext.test.tsx
+++ b/src/contexts/SettingsContext.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+
+// In-memory fake Tauri Store backing the settings persistence.
+const storeData = new Map<string, unknown>();
+const fakeStore = {
+  get: vi.fn(async (k: string) => storeData.get(k)),
+  set: vi.fn(async (k: string, v: unknown) => {
+    storeData.set(k, v);
+  }),
+  save: vi.fn(async () => {}),
+};
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  Store: { load: vi.fn(async () => fakeStore) },
+}));
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(async () => "settings.json"),
+}));
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: vi.fn(async () => {}),
+  listen: vi.fn(async () => () => {}),
+}));
+vi.mock("@/i18n", () => ({ changeLanguage: vi.fn(async () => {}) }));
+vi.mock("@/lib/theme", () => ({ applyTheme: vi.fn() }));
+
+import { SettingsProvider, useSettingsContext } from "./SettingsContext";
+
+beforeEach(() => {
+  storeData.clear();
+});
+
+describe("SettingsContext callback stability", () => {
+  // Regression: unstable `updateSetting`/`updateSettings`/`subscribeToChanges`
+  // identities made SyncContext's `pullAndApply` re-create on every settings
+  // render, which re-fired the pull effect and clobbered the just-edited value
+  // (the "transcription cloud → local in a microsecond" bug).
+  it("updateSetting keeps a stable identity across settings changes", async () => {
+    const { result } = renderHook(() => useSettingsContext(), {
+      wrapper: SettingsProvider,
+    });
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    const first = result.current.updateSetting;
+    await act(async () => {
+      await result.current.updateSetting("theme", "light");
+    });
+
+    // A real re-render happened (state changed)…
+    expect(result.current.settings.theme).toBe("light");
+    // …yet the callback identity is unchanged.
+    expect(result.current.updateSetting).toBe(first);
+  });
+
+  it("updateSettings and subscribeToChanges are also stable across changes", async () => {
+    const { result } = renderHook(() => useSettingsContext(), {
+      wrapper: SettingsProvider,
+    });
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    const firstUpdateSettings = result.current.updateSettings;
+    const firstSubscribe = result.current.subscribeToChanges;
+    await act(async () => {
+      await result.current.updateSettings({ theme: "light" });
+    });
+
+    expect(result.current.settings.theme).toBe("light");
+    expect(result.current.updateSettings).toBe(firstUpdateSettings);
+    expect(result.current.subscribeToChanges).toBe(firstSubscribe);
+  });
+});

--- a/src/contexts/SettingsContext.tsx
+++ b/src/contexts/SettingsContext.tsx
@@ -257,14 +257,14 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
   /**
    * Update a specific setting value
    */
-  const updateSetting = async <K extends keyof AppSettings["settings"]>(
+  const updateSetting = useCallback(async <K extends keyof AppSettings["settings"]>(
     key: K,
     value: AppSettings["settings"][K]
   ) => {
     try {
       const storeInstance = await getStore();
       const current = await storeInstance.get<AppSettings>("settings");
-      const base = current ? mergeSettings(current) : settings;
+      const base = current ? mergeSettings(current) : settingsRef.current;
 
       const newSettings: AppSettings = {
         ...base,
@@ -325,18 +325,18 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     } catch (error) {
       console.error("Failed to save setting:", error);
     }
-  };
+  }, [fireObservers]);
 
   /**
    * Update multiple settings at once
    */
-  const updateSettings = async (
+  const updateSettings = useCallback(async (
     updates: Partial<AppSettings["settings"]>
   ) => {
     try {
       const storeInstance = await getStore();
       const current = await storeInstance.get<AppSettings>("settings");
-      const base = current ? mergeSettings(current) : settings;
+      const base = current ? mergeSettings(current) : settingsRef.current;
 
       const newSettings: AppSettings = {
         ...base,
@@ -354,12 +354,12 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     } catch (error) {
       console.error("Failed to save settings:", error);
     }
-  };
+  }, [fireObservers]);
 
   /**
    * Reset all settings to defaults
    */
-  const resetSettings = async () => {
+  const resetSettings = useCallback(async () => {
     const newSettings = {
       ...DEFAULT_SETTINGS,
       created: new Date().toISOString().replace("T", " ").substring(0, 19),
@@ -376,7 +376,7 @@ export function SettingsProvider({ children }: { children: ReactNode }) {
     } catch (error) {
       console.error("Failed to reset settings:", error);
     }
-  };
+  }, [fireObservers]);
 
   const value: SettingsContextType = {
     settings: settings.settings,

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -48,7 +48,8 @@ import {
   applyRemoteWord,
   migrateLegacyDictionaryOnce,
 } from "@/lib/sync/dictionary-store";
-import { mergeSettingsLWW } from "@/lib/sync/merge";
+import { mergeSettingsLWW, shouldApplyCloudSettings } from "@/lib/sync/merge";
+import { computeNextPullCursor } from "@/lib/sync/pull-cursor";
 import { setSyncActive } from "@/lib/sync/sync-gate";
 import type { AppSettings } from "@/lib/settings";
 import type { SyncOperation, SyncState, SyncStatus } from "@/lib/sync/types";
@@ -242,7 +243,13 @@ export function SyncProvider({ children }: { children: ReactNode }) {
           lastPushedAt,
           result.settings
         );
-        if (merged.action === "apply-cloud") {
+        // A queued local settings push means the user just edited settings on
+        // this device — don't let the pulled (stale) cloud value revert it.
+        const pendingOps = await peekAll();
+        const settingsPushPending = pendingOps.some(
+          (e) => e.operation.kind === "settings-upsert"
+        );
+        if (shouldApplyCloudSettings(merged.action, settingsPushPending)) {
           await updateSettings({
             theme: merged.settings.theme,
             ui_language: merged.settings.ui_language,
@@ -340,8 +347,13 @@ export function SyncProvider({ children }: { children: ReactNode }) {
         }
       }
 
+      // Cursor for the next incremental pull MUST come from server `updated_at`
+      // values, never the client wall-clock — a client clock ahead of the server
+      // would push the cursor past rows written on another device and hide them
+      // permanently. Display timestamps below stay wall-clock (cosmetic only).
+      const nextCursor = computeNextPullCursor(since, result);
+      await setMeta(KEY_LAST_PULL_AT, nextCursor);
       const nowIso = new Date().toISOString();
-      await setMeta(KEY_LAST_PULL_AT, nowIso);
       setLastPullAt(nowIso);
       setLastSyncAt(nowIso);
       setStatus("idle");

--- a/src/lib/sync/merge.test.ts
+++ b/src/lib/sync/merge.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { mergeSnippetLWW, mergeSettingsLWW, mergeNoteLWW, mergeFolderLWW } from "./merge";
+import {
+  mergeSnippetLWW,
+  mergeSettingsLWW,
+  mergeNoteLWW,
+  mergeFolderLWW,
+  shouldApplyCloudSettings,
+} from "./merge";
 import type {
   LocalSnippet,
   CloudSnippetRow,
@@ -110,6 +116,27 @@ describe("merge LWW settings", () => {
   it("cloud null → push-local", () => {
     const merged = mergeSettingsLWW(DEFAULT_SETTINGS.settings, null, null);
     expect(merged.action).toBe("push-local");
+  });
+});
+
+describe("shouldApplyCloudSettings", () => {
+  it("apply-cloud + no pending local push → apply", () => {
+    expect(shouldApplyCloudSettings("apply-cloud", false)).toBe(true);
+  });
+
+  it("apply-cloud BUT a local settings push is still queued → do NOT apply", () => {
+    // The user just toggled a setting on this device; the push hasn't reached
+    // the server yet. Applying the (stale) cloud value here reverts the edit.
+    expect(shouldApplyCloudSettings("apply-cloud", true)).toBe(false);
+  });
+
+  it("push-local action → never apply cloud regardless of queue", () => {
+    expect(shouldApplyCloudSettings("push-local", false)).toBe(false);
+    expect(shouldApplyCloudSettings("push-local", true)).toBe(false);
+  });
+
+  it("no-op action → never apply cloud", () => {
+    expect(shouldApplyCloudSettings("no-op", false)).toBe(false);
   });
 });
 

--- a/src/lib/sync/merge.ts
+++ b/src/lib/sync/merge.ts
@@ -67,6 +67,21 @@ export function mergeSettingsLWW(
   return { settings: local, action: "push-local" };
 }
 
+/** Whether a pulled cloud-settings row should overwrite local state.
+ *
+ *  Even when LWW resolves to `apply-cloud`, a still-queued local settings push
+ *  means the user just edited settings on THIS device and the change hasn't
+ *  reached the server yet. Applying the (now-stale) cloud value would revert
+ *  that edit — the "cloud → local in a microsecond" lost-update. In that case we
+ *  keep local and let the pending push win.
+ */
+export function shouldApplyCloudSettings(
+  action: SettingsMergeAction,
+  hasPendingLocalSettingsPush: boolean
+): boolean {
+  return action === "apply-cloud" && !hasPendingLocalSettingsPush;
+}
+
 /** LWW merge for a single note (meta + content).
  *  - `local === null` → adopt remote unconditionally.
  *  - Tied or remote-newer timestamps → remote wins (deterministic).

--- a/src/lib/sync/pull-cursor.test.ts
+++ b/src/lib/sync/pull-cursor.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import { computeNextPullCursor } from "./pull-cursor";
+import type { PullResult } from "./client";
+
+function emptyResult(partial: Partial<PullResult> = {}): PullResult {
+  return {
+    settings: null,
+    dictionary: [],
+    snippets: [],
+    notes: [],
+    folders: [],
+    invalid: { settings: false, dictionary: 0, snippets: 0, notes: 0, folders: 0 },
+    ...partial,
+  };
+}
+
+// Minimal row factories — only `updated_at` matters for the cursor.
+function note(updated_at: string) {
+  return { updated_at } as PullResult["notes"][number];
+}
+function folder(updated_at: string) {
+  return { updated_at } as PullResult["folders"][number];
+}
+function settingsRow(updated_at: string) {
+  return { updated_at } as NonNullable<PullResult["settings"]>;
+}
+
+describe("computeNextPullCursor", () => {
+  it("full pull (prev null) → max updated_at across all rows", () => {
+    const result = emptyResult({
+      notes: [note("2026-01-01T10:00:00Z"), note("2026-01-01T12:00:00Z")],
+      folders: [folder("2026-01-01T11:00:00Z")],
+    });
+    expect(computeNextPullCursor(null, result)).toBe("2026-01-01T12:00:00Z");
+  });
+
+  it("includes the settings row updated_at in the high-water mark", () => {
+    const result = emptyResult({
+      settings: settingsRow("2026-01-02T00:00:00Z"),
+      notes: [note("2026-01-01T10:00:00Z")],
+    });
+    expect(computeNextPullCursor(null, result)).toBe("2026-01-02T00:00:00Z");
+  });
+
+  it("never regresses below prev when all rows are older (clock-skew guard)", () => {
+    // The bug: a client-clock cursor could jump AHEAD of the newest server row,
+    // permanently hiding remote changes. The server-derived cursor must stay at
+    // the newest row actually seen and never use wall-clock time.
+    const prev = "2026-01-01T12:00:00Z";
+    const result = emptyResult({
+      notes: [note("2026-01-01T09:00:00Z")],
+    });
+    expect(computeNextPullCursor(prev, result)).toBe(prev);
+  });
+
+  it("advances to the newest row when newer than prev", () => {
+    const prev = "2026-01-01T12:00:00Z";
+    const result = emptyResult({
+      notes: [note("2026-01-01T15:00:00Z")],
+    });
+    expect(computeNextPullCursor(prev, result)).toBe("2026-01-01T15:00:00Z");
+  });
+
+  it("empty incremental pull → cursor unchanged", () => {
+    const prev = "2026-01-01T12:00:00Z";
+    expect(computeNextPullCursor(prev, emptyResult())).toBe(prev);
+  });
+
+  it("empty full pull (no data, no prev) → null", () => {
+    expect(computeNextPullCursor(null, emptyResult())).toBeNull();
+  });
+});

--- a/src/lib/sync/pull-cursor.ts
+++ b/src/lib/sync/pull-cursor.ts
@@ -1,0 +1,36 @@
+import type { PullResult } from "./client";
+
+/**
+ * Computes the next incremental-pull cursor from a pull result.
+ *
+ * CRITICAL: the cursor is derived purely from SERVER `updated_at` values, never
+ * from the client wall-clock. The previous implementation stored
+ * `new Date().toISOString()` as the cursor and then filtered the next pull with
+ * `.gt("updated_at", cursor)` against server timestamps. Any client clock ahead
+ * of the server (a few seconds is common) pushed the cursor past the real
+ * `updated_at` of rows written on another device, permanently hiding them.
+ *
+ * By taking the high-water mark of the rows we actually received — and never
+ * regressing below `prev` — the cursor stays exactly at the newest change we
+ * have seen, so the next `.gt(cursor)` pull skips nothing and re-pulls nothing.
+ */
+export function computeNextPullCursor(
+  prev: string | null,
+  result: PullResult
+): string | null {
+  let max = prev;
+  const consider = (ts: string | null | undefined) => {
+    if (!ts) return;
+    if (max === null || new Date(ts).getTime() > new Date(max).getTime()) {
+      max = ts;
+    }
+  };
+
+  consider(result.settings?.updated_at);
+  for (const r of result.dictionary) consider(r.updated_at);
+  for (const r of result.snippets) consider(r.updated_at);
+  for (const r of result.notes) consider(r.updated_at);
+  for (const r of result.folders) consider(r.updated_at);
+
+  return max;
+}


### PR DESCRIPTION
## Contexte

Deux bugs cross-device remontés en test sur 2 PC, même sous-système (pull/merge) :

1. **Réglage transcription `local → cloud` qui revient sur `local` "dans la microseconde"**
2. **Notes jamais "pull" sur le 2ᵉ PC**

## Bug B — settings qui revert (lost update)

`updateSetting`/`updateSettings` dans `SettingsContext` n'étaient pas mémoïsés → identité instable à chaque render → `pullAndApply` (SyncContext) devenait instable → l'effet de pull se redéclenchait à **chaque** édition de réglage, et le pull réappliquait la valeur cloud (périmée) par-dessus le changement local avant que le push (debounce) ne l'ait propagé.

**Fix :** `useCallback` sur `updateSetting`/`updateSettings`/`resetSettings` (lecture via `settingsRef` au lieu de `settings`). Le pull ne se déclenche plus qu'aux vraies transitions auth/enabled.

## Bug A — notes pas pull (décalage d'horloge)

Le curseur de pull incrémental était `new Date().toISOString()` (horloge **client**), mais le pull suivant filtre `.gt("updated_at", curseur)` contre l'horloge **serveur**. Un client en avance de quelques secondes poussait le curseur au-delà du `updated_at` réel des lignes écrites sur l'autre device → masquées définitivement.

**Fix :** `computeNextPullCursor()` dérive le curseur du `max(updated_at)` serveur des lignes reçues, sans jamais régresser sous le curseur précédent.

## Ceinture + bretelles

`shouldApplyCloudSettings()` : même si le LWW dit `apply-cloud`, on n'applique pas le cloud tant qu'un `settings-upsert` local est dans la queue (édition locale en vol jamais revertée par un pull concurrent).

## Tests (TDD, rouge → vert)

- `pull-cursor` : 6 cas (full/incrémental, garde anti-skew, vide)
- `SettingsContext` stabilité d'identité : 2 cas
- `shouldApplyCloudSettings` : 4 cas
- **Suite complète : 290/290**, `tsc` clean.

## Validation restante

Logique prouvée en unitaire. Le comportement cross-device (pull réel + non-revert) reste à confirmer sur 2 appareils — c'est le test bloquant avant un nouveau tag bêta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)