### PR TITLE
fix(sync): full pull on (re)activation — fixes notes not pulling on 2nd device

### DIFF
--- a/src/contexts/SyncContext.activation.test.tsx
+++ b/src/contexts/SyncContext.activation.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useContext } from "react";
+import { DEFAULT_SETTINGS } from "@/lib/settings";
+
+// ── Hoisted spies / shared state (vi.mock factories are hoisted) ─────────────
+const h = vi.hoisted(() => ({
+  storeData: {} as Record<string, unknown>,
+  pullAllSpy: vi.fn(),
+  pushSpy: vi.fn(),
+}));
+
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: async (cmd: string) => {
+    if (cmd === "get_active_profile_sync_meta_path") return "meta.json";
+    if (cmd === "get_or_create_device_id") return "device-B";
+    return undefined;
+  },
+}));
+
+vi.mock("@tauri-apps/plugin-store", () => ({
+  Store: {
+    load: async () => ({
+      get: async (k: string) => h.storeData[k] ?? null,
+      set: async (k: string, v: unknown) => {
+        h.storeData[k] = v;
+      },
+      save: async () => {},
+    }),
+  },
+}));
+
+vi.mock("@tauri-apps/api/window", () => ({
+  getCurrentWindow: () => ({ onFocusChanged: async () => () => {} }),
+}));
+
+vi.mock("@/hooks/useAuth", () => ({
+  useAuth: () => ({ status: "signed-in" }),
+}));
+
+vi.mock("@/hooks/useSettings", () => ({
+  useSettings: () => ({
+    settings: DEFAULT_SETTINGS.settings,
+    updateSettings: vi.fn(async () => {}),
+    subscribeToChanges: () => () => {},
+  }),
+}));
+
+vi.mock("@/lib/flog", () => ({ flog: () => {} }));
+
+vi.mock("@/lib/sync/client", () => ({
+  pullAll: (...a: unknown[]) => h.pullAllSpy(...a),
+  pushOperations: (...a: unknown[]) => h.pushSpy(...a),
+}));
+
+// Queue: empty / inert.
+vi.mock("@/lib/sync/queue", () => ({
+  enqueue: async () => {},
+  peekAll: async () => [],
+  peekReadyHead: async () => null,
+  markRetry: async () => {},
+  moveToDeadLetter: async () => {},
+  getDeadLetters: async () => [],
+  MAX_RETRIES_BEFORE_DLQ: 5,
+  size: async () => 0,
+}));
+
+vi.mock("@/lib/sync/apply-batch-results", () => ({
+  applyBatchResults: async () => ({ failedCount: 0 }),
+}));
+
+vi.mock("@/lib/sync/snippets-store", () => ({
+  loadSnippets: async () => [],
+  applyRemoteSnippet: async () => {},
+  migrateLegacySnippetsOnce: async () => {},
+}));
+
+vi.mock("@/lib/sync/notes-store", () => ({
+  applyRemoteNote: async () => {},
+  flushPendingNoteUpdates: async () => {},
+  listNotes: async () => [],
+  readNote: async () => ({ meta: {}, content: "" }),
+}));
+
+vi.mock("@/lib/sync/folders-store", () => ({
+  applyRemoteFolder: async () => {},
+  listFolders: async () => [],
+}));
+
+vi.mock("@/lib/sync/dictionary-store", () => ({
+  loadDictionary: async () => ({ words: [] }),
+  applyRemoteWord: async () => {},
+  migrateLegacyDictionaryOnce: async () => {},
+}));
+
+import { SyncContext, SyncProvider } from "./SyncContext";
+
+const EMPTY_PULL = {
+  settings: null,
+  dictionary: [],
+  snippets: [],
+  notes: [],
+  folders: [],
+  invalid: { settings: false, dictionary: 0, snippets: 0, notes: 0, folders: 0 },
+};
+
+beforeEach(() => {
+  Object.keys(h.storeData).forEach((k) => delete h.storeData[k]);
+  h.pullAllSpy.mockReset().mockResolvedValue(EMPTY_PULL);
+  h.pushSpy.mockReset().mockResolvedValue({ ok: true, results: [], server_time: "2026-06-25T00:00:00Z" });
+});
+
+describe("SyncContext — activation forces a full reconcile", () => {
+  it("enableSync pulls with since=null even when a stale cursor is stored", async () => {
+    // Simulate a device that synced before: a residual incremental cursor.
+    h.storeData["enabled"] = false;
+    h.storeData["last_pull_at"] = "2020-01-01T00:00:00Z";
+
+    const { result } = renderHook(() => useContext(SyncContext), {
+      wrapper: SyncProvider,
+    });
+
+    await act(async () => {
+      await result.current!.enableSync();
+    });
+
+    // Activation MUST pull with since=null (full reconcile). A stale cursor
+    // would otherwise make it incremental and miss the older notes.
+    expect(h.pullAllSpy).toHaveBeenCalled();
+    const sinceArgs = h.pullAllSpy.mock.calls.map((c) => c[0]);
+    expect(sinceArgs).toContain(null);
+    expect(sinceArgs).not.toContain("2020-01-01T00:00:00Z");
+  });
+
+  it("disableSync clears the stored pull cursor", async () => {
+    // Mount disabled (stable, no activation pull) — disableSync clears the
+    // cursor unconditionally so a later re-enable always full-reconciles.
+    h.storeData["enabled"] = false;
+    h.storeData["last_pull_at"] = "2026-06-01T00:00:00Z";
+
+    const { result } = renderHook(() => useContext(SyncContext), {
+      wrapper: SyncProvider,
+    });
+
+    await act(async () => {
+      await result.current!.disableSync();
+    });
+
+    expect(h.storeData["last_pull_at"]).toBeNull();
+  });
+});

--- a/src/contexts/SyncContext.tsx
+++ b/src/contexts/SyncContext.tsx
@@ -225,11 +225,17 @@ export function SyncProvider({ children }: { children: ReactNode }) {
     [enabled, flushQueue]
   );
 
-  const pullAndApply = useCallback(async () => {
-    if (!enabled || auth.status !== "signed-in") return;
+  const pullAndApply = useCallback(async (opts?: { forceFull?: boolean }) => {
+    // `forceFull` is used by enableSync: it bypasses the stale `enabled` closure
+    // (enableSync sets enabled=true but this callback still captured false) AND
+    // ignores any residual cursor, so activating sync always does a COMPLETE
+    // reconcile instead of an incremental pull that would miss older notes.
+    if ((!enabled && !opts?.forceFull) || auth.status !== "signed-in") return;
     setStatus("syncing");
     try {
-      const since = await getMeta<string | null>(KEY_LAST_PULL_AT, null);
+      const since = opts?.forceFull
+        ? null
+        : await getMeta<string | null>(KEY_LAST_PULL_AT, null);
       const result = await pullAll(since);
 
       // Settings : LWW → écrire la diff syncable dans le SettingsContext
@@ -379,7 +385,7 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       flog(`[sync] legacy migration failed: ${String(e)}`, "warn");
     }
 
-    await pullAndApply();
+    await pullAndApply({ forceFull: true });
 
     // Full push initial : settings + dico + snippets + folders + notes.
     // ORDRE CRITIQUE — folders DOIVENT précéder notes dans le tableau d'ops.
@@ -472,6 +478,10 @@ export function SyncProvider({ children }: { children: ReactNode }) {
       flog(`[sync] flushPendingNoteUpdates failed on disable: ${String(e)}`, "warn");
     }
     await setMeta(KEY_ENABLED, false);
+    // Clear the incremental cursor so a later re-enable always full-reconciles
+    // (re-activation must never resume an incremental pull from a stale cursor).
+    await setMeta(KEY_LAST_PULL_AT, null);
+    setLastPullAt(null);
     setEnabled(false);
     setSyncActive(false);
     setStatus("disabled");


### PR DESCRIPTION
## Symptôme

34 notes synchronisées depuis PC A, mais activer la sync sur PC B n''en ramène qu''**une**.

## Cause racine (confirmée par les données)

Requête cloud : `user_notes` contient bien **34 notes actives** pour le compte → le push de PC A a tout envoyé. Le problème est 100 % côté **pull**.

PC B avait un **curseur incrémental résiduel** (`last_pull_at`) dans son sync-meta par profil. À l''activation, `enableSync` appelait `pullAndApply()` qui relisait ce curseur et faisait un pull **incrémental** (`.gt("updated_at", curseur)`) → il ne ramenait que la note modifiée après le curseur.

Deux problèmes cumulés :
1. Le `await pullAndApply()` dans `enableSync` était du **code mort** : la closure capturait `enabled=false` (mis à `true` juste avant) → early-return. Le premier vrai pull était piloté par l''effet `enabled`, avec le curseur périmé.
2. Ni l''activation ni la désactivation ne réinitialisaient le curseur → basculer la sync ne re-réconciliait jamais.

## Fix

- `pullAndApply({ forceFull })` : ignore la closure `enabled` périmée **et** le curseur stocké (`since=null`) → l''activation fait toujours une **réconciliation complète**.
- `disableSync` purge `last_pull_at` → toute réactivation ultérieure full-reconcilie aussi.

## Tests (TDD, rouge → vert)

Tests d''intégration `SyncProvider` (première couverture du contexte) :
- `enableSync` pull avec `since=null` malgré un curseur résiduel
- `disableSync` efface le curseur

**Suite complète : 292/292**, `tsc` clean.

## Note

Complète la PR #56 (curseur serveur + anti-clobber settings). Les deux doivent être dans la prochaine bêta pour le test cross-device.

🤖 Generated with [Claude Code](https://claude.com/claude-code)