### PR TITLE
feat(home): nouvelle page d'accueil (dashboard de démarrage)

### DIFF
--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -7,6 +7,7 @@ import {
   DashboardSidebar,
   type DashboardTabId,
 } from "./dashboard/DashboardSidebar";
+import { AccueilTab } from "./dashboard/tabs/AccueilTab";
 import { HistoriqueTab } from "./dashboard/tabs/HistoriqueTab";
 import { StatistiquesTab } from "./dashboard/tabs/StatistiquesTab";
 import { SettingTabs } from "./settings/SettingTabs";
@@ -42,7 +43,7 @@ export default function Dashboard() {
   const [selectedTranscription, setSelectedTranscription] =
     useState<Transcription | null>(null);
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
-  const [activeTab, setActiveTab] = useState<DashboardTabId>("historique");
+  const [activeTab, setActiveTab] = useState<DashboardTabId>("accueil");
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeSettingsSection, setActiveSettingsSection] =
     useState<SettingsSectionId>("section-transcription");
@@ -226,7 +227,7 @@ export default function Dashboard() {
 
   useEffect(() => {
     if (activeTab === "logs" && !settings.developer_mode) {
-      setActiveTab("historique");
+      setActiveTab("accueil");
     }
   }, [activeTab, settings.developer_mode]);
 
@@ -349,6 +350,19 @@ export default function Dashboard() {
                 />
               ) : (
                 <div className="container mx-auto px-6 py-8">
+                  {activeTab === "accueil" && (
+                    <AccueilTab
+                      notes={notes}
+                      onOpenNote={handleOpenNoteFromSidebar}
+                      onCreateNote={() => handleCreateNoteFromSidebar(null)}
+                      onViewHistory={() => setActiveTab("historique")}
+                      onViewNotes={() => setActiveTab("notes")}
+                      onOpenAccountPage={() => {
+                        setActiveTab("parametres");
+                        setActiveSettingsSection("section-compte");
+                      }}
+                    />
+                  )}
                   {activeTab === "historique" && (
                     <HistoriqueTab
                       transcriptions={transcriptions}

--- a/src/components/common/DashboardHeader.tsx
+++ b/src/components/common/DashboardHeader.tsx
@@ -6,6 +6,7 @@ import {
   Mic,
   FileText,
   History,
+  Home,
   ScrollText,
   Settings2,
   BarChart3,
@@ -27,6 +28,7 @@ interface DashboardHeaderProps {
 }
 
 const TAB_ICONS: Record<DashboardTabId, LucideIcon> = {
+  accueil: Home,
   historique: History,
   statistiques: BarChart3,
   notes: FileText,

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -2,6 +2,7 @@ import {
   BarChart3,
   FileText,
   History,
+  Home,
   PanelLeftClose,
   PanelLeftOpen,
   ScrollText,
@@ -28,6 +29,13 @@ import { LogsSidebarSection } from "./LogsSidebarSection";
 import { UpdateAvailableBanner } from "./UpdateAvailableBanner";
 
 export const DASHBOARD_NAV_ITEMS = [
+  {
+    id: "accueil",
+    labelKey: "sidebar.home",
+    icon: Home,
+    iconColor: "text-vt-fg-3",
+    iconBg: "bg-vt-surface",
+  },
   {
     id: "historique",
     labelKey: "sidebar.history",

--- a/src/components/dashboard/home/QuickActionsCard.tsx
+++ b/src/components/dashboard/home/QuickActionsCard.tsx
@@ -1,0 +1,95 @@
+import { Fragment } from "react";
+import { History, Mic, Plus, Zap } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useSettings } from "@/hooks/useSettings";
+import { KeyBadge } from "@/components/settings/common/KeyBadge";
+
+interface QuickActionsCardProps {
+  onCreateNote: () => void;
+  onViewHistory: () => void;
+}
+
+/** Renders a hotkey string ("Ctrl+F11") as a row of key badges. */
+function HotkeyTokens({ shortcut }: { shortcut: string }) {
+  const tokens = shortcut.split("+").map((s) => s.trim()).filter(Boolean);
+  return (
+    <span className="inline-flex items-center gap-0.5">
+      {tokens.map((tok, i) => (
+        <Fragment key={`${tok}-${i}`}>
+          {i > 0 && <span className="text-[var(--vt-fg-3)] text-[11px]">+</span>}
+          <KeyBadge token={tok} />
+        </Fragment>
+      ))}
+    </span>
+  );
+}
+
+/**
+ * Quick-access actions for the home screen: create a note, jump to the
+ * transcription history, and a reminder of the recording hotkeys.
+ */
+export function QuickActionsCard({
+  onCreateNote,
+  onViewHistory,
+}: QuickActionsCardProps) {
+  const { t } = useTranslation();
+  const { settings } = useSettings();
+
+  const recordHotkey = settings.record_hotkey || "Ctrl+F11";
+  const pttHotkey = settings.ptt_hotkey || "Ctrl+F12";
+
+  return (
+    <div className="vt-card-elevated p-5">
+      <div className="flex items-center gap-2">
+        <Zap className="w-4 h-4 text-[var(--vt-fg-3)]" />
+        <h3 className="vt-display text-[15px] font-semibold text-[var(--vt-fg)]">
+          {t("home.quickActions.title")}
+        </h3>
+      </div>
+
+      <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+        <button
+          type="button"
+          onClick={onCreateNote}
+          className="flex items-center gap-3 text-left px-3 py-2.5 rounded-lg bg-foreground/[0.03] hover:bg-foreground/[0.06] transition-colors cursor-pointer"
+        >
+          <div className="flex items-center justify-center w-8 h-8 rounded-md bg-[var(--vt-accent-soft)] text-[var(--vt-accent)] shrink-0">
+            <Plus className="w-4 h-4" />
+          </div>
+          <span className="text-[13px] font-medium text-[var(--vt-fg)]">
+            {t("home.quickActions.newNote")}
+          </span>
+        </button>
+
+        <button
+          type="button"
+          onClick={onViewHistory}
+          className="flex items-center gap-3 text-left px-3 py-2.5 rounded-lg bg-foreground/[0.03] hover:bg-foreground/[0.06] transition-colors cursor-pointer"
+        >
+          <div className="flex items-center justify-center w-8 h-8 rounded-md bg-[var(--vt-surface)] text-[var(--vt-fg-3)] shrink-0">
+            <History className="w-4 h-4" />
+          </div>
+          <span className="text-[13px] font-medium text-[var(--vt-fg)]">
+            {t("home.quickActions.viewHistory")}
+          </span>
+        </button>
+      </div>
+
+      <div className="mt-3 flex flex-col gap-2 rounded-lg bg-foreground/[0.03] px-3 py-2.5">
+        <div className="flex items-center justify-between gap-3">
+          <span className="flex items-center gap-1.5 text-[12.5px] text-[var(--vt-fg-2)]">
+            <Mic className="w-3.5 h-3.5 text-[var(--vt-fg-3)]" />
+            {t("home.quickActions.recordHint")}
+          </span>
+          <HotkeyTokens shortcut={recordHotkey} />
+        </div>
+        <div className="flex items-center justify-between gap-3">
+          <span className="text-[12.5px] text-[var(--vt-fg-2)] pl-5">
+            {t("home.quickActions.pttHint")}
+          </span>
+          <HotkeyTokens shortcut={pttHotkey} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/home/RecentNotesCard.tsx
+++ b/src/components/dashboard/home/RecentNotesCard.tsx
@@ -1,0 +1,105 @@
+import { useMemo } from "react";
+import { ArrowRight, FileText, Plus, Star } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { useDateFormatters } from "@/lib/date-format";
+import type { NoteMeta } from "@/hooks/useNotes";
+
+interface RecentNotesCardProps {
+  notes: NoteMeta[];
+  onOpenNote: (note: NoteMeta) => void;
+  onCreateNote: () => void;
+  onViewAllNotes: () => void;
+}
+
+const MAX_RECENT = 5;
+
+/**
+ * Compact list of the most recently edited notes on the home screen. Renders
+ * small clickable cards (title + relative date), not the note bodies. Sorted
+ * by updatedAt desc. Empty state offers a create-note CTA.
+ */
+export function RecentNotesCard({
+  notes,
+  onOpenNote,
+  onCreateNote,
+  onViewAllNotes,
+}: RecentNotesCardProps) {
+  const { t } = useTranslation();
+  const { dayLabel } = useDateFormatters();
+
+  const recent = useMemo(
+    () =>
+      [...notes]
+        .sort(
+          (a, b) =>
+            new Date(b.updatedAt).getTime() - new Date(a.updatedAt).getTime(),
+        )
+        .slice(0, MAX_RECENT),
+    [notes],
+  );
+
+  return (
+    <div className="vt-card-elevated p-5">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <FileText className="w-4 h-4 text-[var(--vt-fg-3)]" />
+          <h3 className="vt-display text-[15px] font-semibold text-[var(--vt-fg)]">
+            {t("home.recentNotes.title")}
+          </h3>
+        </div>
+        {recent.length > 0 && (
+          <button
+            type="button"
+            onClick={onViewAllNotes}
+            className="inline-flex items-center gap-1 text-[12px] font-medium text-[var(--vt-accent)] hover:underline cursor-pointer"
+          >
+            {t("home.recentNotes.viewAll")}
+            <ArrowRight className="w-3.5 h-3.5" />
+          </button>
+        )}
+      </div>
+
+      {recent.length === 0 ? (
+        <div className="mt-4 flex flex-col items-center text-center py-6">
+          <p className="text-[13px] text-[var(--vt-fg-3)]">
+            {t("home.recentNotes.empty")}
+          </p>
+          <Button className="mt-3" size="sm" variant="outline" onClick={onCreateNote}>
+            <Plus className="w-4 h-4" />
+            {t("home.recentNotes.createCta")}
+          </Button>
+        </div>
+      ) : (
+        <div className="mt-3 grid grid-cols-1 sm:grid-cols-2 gap-2">
+          {recent.map((note) => (
+            <button
+              key={note.id}
+              type="button"
+              onClick={() => onOpenNote(note)}
+              className="group flex items-center gap-3 text-left px-3 py-2.5 rounded-lg bg-foreground/[0.03] hover:bg-foreground/[0.06] transition-colors cursor-pointer min-w-0"
+            >
+              <div className="flex items-center justify-center w-8 h-8 rounded-md bg-[var(--vt-surface)] shrink-0">
+                <FileText className="w-3.5 h-3.5 text-[var(--vt-fg-3)]" />
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex items-center gap-1.5 min-w-0">
+                  <span className="truncate text-[13px] font-medium text-[var(--vt-fg)]">
+                    {note.title?.trim() || t("notes.editor.untitled")}
+                  </span>
+                  {note.favorite && (
+                    <Star className="w-3 h-3 shrink-0 fill-[var(--vt-warn)] text-[var(--vt-warn)]" />
+                  )}
+                </div>
+                <span className="text-[11.5px] text-[var(--vt-fg-3)]">
+                  {note.updatedAt ? dayLabel(new Date(note.updatedAt)) : ""}
+                </span>
+              </div>
+              <ArrowRight className="w-3.5 h-3.5 text-[var(--vt-fg-3)] opacity-0 group-hover:opacity-100 transition-opacity shrink-0" />
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/dashboard/home/SyncReminderCard.tsx
+++ b/src/components/dashboard/home/SyncReminderCard.tsx
@@ -1,0 +1,76 @@
+import { ArrowRight, Check, RefreshCw } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+
+interface SyncReminderCardProps {
+  onOpenAccountPage: () => void;
+}
+
+/**
+ * Reminder shown on the home screen when the user is signed in but has not
+ * enabled sync for the current profile. Explains the benefits and routes to
+ * the account section (which hosts the sync activation flow). Visibility is
+ * decided by the parent (AccueilTab) so the grid layout stays clean.
+ */
+export function SyncReminderCard({ onOpenAccountPage }: SyncReminderCardProps) {
+  const { t } = useTranslation();
+
+  const tint = "var(--vt-violet)";
+  const tintSoft = `oklch(from ${tint} l c h / 0.18)`;
+  const tintBg = `oklch(from ${tint} l c h / 0.14)`;
+
+  const benefits = [
+    t("home.sync.benefit1"),
+    t("home.sync.benefit2"),
+    t("home.sync.benefit3"),
+  ];
+
+  return (
+    <div
+      className="vt-card-elevated relative overflow-hidden p-5 h-full"
+      style={{
+        background: `
+          radial-gradient(circle at 100% 0%, ${tintSoft} 0, transparent 55%),
+          var(--vt-panel-2)
+        `,
+      }}
+    >
+      <div className="flex items-center justify-between gap-3">
+        <span className="vt-eyebrow">{t("home.sync.eyebrow")}</span>
+        <div
+          className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
+          style={{ background: tintBg, color: tint }}
+        >
+          <RefreshCw className="w-4 h-4" />
+        </div>
+      </div>
+
+      <h3 className="mt-3 vt-display text-[17px] font-semibold text-[var(--vt-fg)]">
+        {t("home.sync.title")}
+      </h3>
+      <p className="mt-1.5 text-[13px] text-[var(--vt-fg-3)] leading-relaxed">
+        {t("home.sync.desc")}
+      </p>
+
+      <ul className="mt-3 space-y-1.5">
+        {benefits.map((b) => (
+          <li
+            key={b}
+            className="flex items-start gap-2 text-[12.5px] text-[var(--vt-fg-2)]"
+          >
+            <Check
+              className="w-3.5 h-3.5 mt-0.5 shrink-0"
+              style={{ color: tint }}
+            />
+            <span>{b}</span>
+          </li>
+        ))}
+      </ul>
+
+      <Button className="mt-4" size="sm" variant="outline" onClick={onOpenAccountPage}>
+        {t("home.sync.cta")}
+        <ArrowRight className="w-4 h-4" />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/dashboard/home/TrialAccountCard.tsx
+++ b/src/components/dashboard/home/TrialAccountCard.tsx
@@ -1,0 +1,208 @@
+import { ArrowRight, BadgeCheck, Clock, Sparkles, UserPlus } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { useAuth } from "@/hooks/useAuth";
+import { useUsage } from "@/hooks/useUsage";
+import { useDateFormatters } from "@/lib/date-format";
+
+interface TrialAccountCardProps {
+  onOpenAccountPage: () => void;
+}
+
+/**
+ * Adaptive account/trial card for the home screen. Renders one of four states:
+ * signed-out (create-account CTA), active subscription (plan + monthly usage),
+ * active trial (minutes left + expiry), or signed-in without an active plan
+ * (manage-account CTA). Branches on useAuth + useUsage.
+ */
+export function TrialAccountCard({ onOpenAccountPage }: TrialAccountCardProps) {
+  const { t } = useTranslation();
+  const { status, openAuthModal } = useAuth();
+  const { trial, plan, monthly_minutes_used, loading } = useUsage();
+  const { formatLongDate } = useDateFormatters();
+
+  const tint = "var(--vt-accent)";
+  const tintSoft = `oklch(from ${tint} l c h / 0.18)`;
+  const tintBg = `oklch(from ${tint} l c h / 0.14)`;
+
+  // --- Signed-out: invite to create an account ----------------------------
+  if (status === "signed-out") {
+    return (
+      <Shell tintSoft={tintSoft}>
+        <Head
+          icon={<UserPlus className="w-4 h-4" />}
+          tint={tint}
+          tintBg={tintBg}
+          eyebrow={t("home.account.eyebrowSignedOut")}
+        />
+        <h3 className="mt-3 vt-display text-[17px] font-semibold text-[var(--vt-fg)]">
+          {t("home.account.titleSignedOut")}
+        </h3>
+        <p className="mt-1.5 text-[13px] text-[var(--vt-fg-3)] leading-relaxed">
+          {t("home.account.descSignedOut")}
+        </p>
+        <Button className="mt-4" size="sm" onClick={openAuthModal}>
+          {t("home.account.ctaSignedOut")}
+          <ArrowRight className="w-4 h-4" />
+        </Button>
+      </Shell>
+    );
+  }
+
+  // While loading usage for a signed-in user, show a light skeleton.
+  if (loading && !plan && !trial.is_active) {
+    return (
+      <Shell tintSoft={tintSoft}>
+        <Head
+          icon={<BadgeCheck className="w-4 h-4" />}
+          tint={tint}
+          tintBg={tintBg}
+          eyebrow={t("home.account.eyebrowPlan")}
+        />
+        <div className="mt-4 h-7 w-32 rounded-md bg-foreground/[0.06] animate-pulse" />
+        <div className="mt-2 h-4 w-44 rounded-md bg-foreground/[0.04] animate-pulse" />
+      </Shell>
+    );
+  }
+
+  // --- Active subscription -------------------------------------------------
+  if (plan) {
+    const planLabel = t(`home.account.plan_${plan.plan}`);
+    return (
+      <Shell tintSoft={tintSoft}>
+        <Head
+          icon={<BadgeCheck className="w-4 h-4" />}
+          tint={tint}
+          tintBg={tintBg}
+          eyebrow={t("home.account.eyebrowPlan")}
+        />
+        <div className="mt-3 flex items-baseline gap-2">
+          <span className="vt-display text-[22px] font-semibold text-[var(--vt-fg)]">
+            {planLabel}
+          </span>
+        </div>
+        <p className="mt-1.5 text-[13px] text-[var(--vt-fg-3)]">
+          {t("home.account.minutesUsed", {
+            used: Math.round(monthly_minutes_used),
+            quota: plan.quota_minutes,
+          })}
+        </p>
+        <button
+          type="button"
+          onClick={onOpenAccountPage}
+          className="mt-3 inline-flex items-center gap-1 text-[12.5px] font-medium text-[var(--vt-accent)] hover:underline cursor-pointer"
+        >
+          {t("home.account.manage")}
+          <ArrowRight className="w-3.5 h-3.5" />
+        </button>
+      </Shell>
+    );
+  }
+
+  // --- Active trial --------------------------------------------------------
+  if (trial.is_active) {
+    const minutesLeft = Math.max(0, Math.round(trial.minutes_remaining));
+    return (
+      <Shell tintSoft={tintSoft}>
+        <Head
+          icon={<Sparkles className="w-4 h-4" />}
+          tint={tint}
+          tintBg={tintBg}
+          eyebrow={t("home.account.eyebrowTrial")}
+        />
+        <div className="mt-3 flex items-baseline gap-1.5">
+          <span className="vt-display text-[28px] leading-none font-semibold text-[var(--vt-fg)] vt-mono">
+            {minutesLeft}
+          </span>
+          <span className="text-[13px] text-[var(--vt-fg-3)]">
+            {t("home.account.minutesUnit")}
+          </span>
+        </div>
+        {trial.expires_at && (
+          <p className="mt-2 flex items-center gap-1.5 text-[12.5px] text-[var(--vt-fg-3)]">
+            <Clock className="w-3.5 h-3.5" />
+            {t("home.account.trialExpires", {
+              date: formatLongDate(new Date(trial.expires_at)),
+            })}
+          </p>
+        )}
+        <button
+          type="button"
+          onClick={onOpenAccountPage}
+          className="mt-3 inline-flex items-center gap-1 text-[12.5px] font-medium text-[var(--vt-accent)] hover:underline cursor-pointer"
+        >
+          {t("home.account.manage")}
+          <ArrowRight className="w-3.5 h-3.5" />
+        </button>
+      </Shell>
+    );
+  }
+
+  // --- Signed-in, no active plan or trial ---------------------------------
+  return (
+    <Shell tintSoft={tintSoft}>
+      <Head
+        icon={<Sparkles className="w-4 h-4" />}
+        tint={tint}
+        tintBg={tintBg}
+        eyebrow={t("home.account.eyebrowInactive")}
+      />
+      <h3 className="mt-3 vt-display text-[17px] font-semibold text-[var(--vt-fg)]">
+        {t("home.account.titleInactive")}
+      </h3>
+      <p className="mt-1.5 text-[13px] text-[var(--vt-fg-3)] leading-relaxed">
+        {t("home.account.descInactive")}
+      </p>
+      <Button className="mt-4" size="sm" onClick={onOpenAccountPage}>
+        {t("home.account.ctaInactive")}
+        <ArrowRight className="w-4 h-4" />
+      </Button>
+    </Shell>
+  );
+}
+
+function Shell({
+  tintSoft,
+  children,
+}: {
+  tintSoft: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div
+      className="vt-card-elevated relative overflow-hidden p-5 h-full"
+      style={{
+        background: `
+          radial-gradient(circle at 100% 0%, ${tintSoft} 0, transparent 55%),
+          var(--vt-panel-2)
+        `,
+      }}
+    >
+      {children}
+    </div>
+  );
+}
+
+function Head({
+  icon,
+  tint,
+  tintBg,
+  eyebrow,
+}: {
+  icon: React.ReactNode;
+  tint: string;
+  tintBg: string;
+  eyebrow: string;
+}) {
+  return (
+    <div className="flex items-center justify-between gap-3">
+      <span className="vt-eyebrow">{eyebrow}</span>
+      <div
+        className="flex items-center justify-center w-8 h-8 rounded-lg shrink-0"
+        style={{ background: tintBg, color: tint }}
+      >
+        {icon}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/tabs/AccueilTab.tsx
+++ b/src/components/dashboard/tabs/AccueilTab.tsx
@@ -1,0 +1,85 @@
+import { Sparkles } from "lucide-react";
+import { useTranslation } from "react-i18next";
+import { useAuth } from "@/hooks/useAuth";
+import { useSync } from "@/hooks/useSync";
+import type { NoteMeta } from "@/hooks/useNotes";
+import { TrialAccountCard } from "@/components/dashboard/home/TrialAccountCard";
+import { SyncReminderCard } from "@/components/dashboard/home/SyncReminderCard";
+import { RecentNotesCard } from "@/components/dashboard/home/RecentNotesCard";
+import { QuickActionsCard } from "@/components/dashboard/home/QuickActionsCard";
+
+interface AccueilTabProps {
+  notes: NoteMeta[];
+  onOpenNote: (note: NoteMeta) => void;
+  onCreateNote: () => void;
+  onViewHistory: () => void;
+  onViewNotes: () => void;
+  onOpenAccountPage: () => void;
+}
+
+/**
+ * Home screen: the default landing tab. Assembles autonomous cards (account /
+ * trial, sync reminder, recent notes, quick actions). The sync reminder only
+ * appears when signed in with sync disabled for the current profile — the
+ * layout adapts so the account card spans the row when it is hidden.
+ */
+export function AccueilTab({
+  notes,
+  onOpenNote,
+  onCreateNote,
+  onViewHistory,
+  onViewNotes,
+  onOpenAccountPage,
+}: AccueilTabProps) {
+  const { t } = useTranslation();
+  const { status } = useAuth();
+  const { enabled: syncEnabled } = useSync();
+
+  const showSyncReminder = status === "signed-in" && !syncEnabled;
+
+  return (
+    <div className="vt-app space-y-5 max-w-5xl mx-auto">
+      {/* Hero */}
+      <div className="vt-anim-fade-up">
+        <div className="flex items-center gap-2 mb-1">
+          <Sparkles className="w-4 h-4 text-[var(--vt-accent)]" />
+          <span className="vt-eyebrow text-[var(--vt-accent)]">
+            {t("home.heroEyebrow")}
+          </span>
+        </div>
+        <h2 className="vt-display text-[22px] font-semibold tracking-tight text-[var(--vt-fg)]">
+          {t("home.heroTitle")}
+        </h2>
+        <p className="text-[13.5px] text-[var(--vt-fg-3)] mt-1 max-w-2xl">
+          {t("home.heroSubtitle")}
+        </p>
+      </div>
+
+      {/* Account + sync row */}
+      <div
+        className={
+          showSyncReminder ? "grid grid-cols-1 lg:grid-cols-2 gap-4" : ""
+        }
+      >
+        <TrialAccountCard onOpenAccountPage={onOpenAccountPage} />
+        {showSyncReminder && (
+          <SyncReminderCard onOpenAccountPage={onOpenAccountPage} />
+        )}
+      </div>
+
+      {/* Recent notes */}
+      <RecentNotesCard
+        notes={notes}
+        onOpenNote={onOpenNote}
+        onCreateNote={onCreateNote}
+        onViewAllNotes={onViewNotes}
+      />
+
+      {/* Quick actions */}
+      <QuickActionsCard
+        onCreateNote={onCreateNote}
+        onViewHistory={onViewHistory}
+      />
+    </div>
+  );
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,6 +25,7 @@
   "header": {
     "title": "Lexena",
     "subtitle": {
+      "accueil": "Overview",
       "historique": "Dictations history",
       "statistiques": "Usage statistics",
       "notes": "Notes & organized dictations",
@@ -38,6 +39,7 @@
     "error": "AI post-processing failed: {{error}}"
   },
   "sidebar": {
+    "home": "Home",
     "history": "History",
     "statistics": "Statistics",
     "notes": "Notes",
@@ -47,6 +49,51 @@
     "collapseMenu": "Collapse menu",
     "updateAvailable": "Update available",
     "updateAvailableTooltip": "Update {{version}} available"
+  },
+  "home": {
+    "heroEyebrow": "Home",
+    "heroTitle": "Welcome to Lexena",
+    "heroSubtitle": "A glance at your account, your sync status and your latest notes.",
+    "account": {
+      "eyebrowSignedOut": "Account",
+      "titleSignedOut": "Create a Lexena account",
+      "descSignedOut": "Back up your notes to the cloud, sync your devices and unlock managed transcription.",
+      "ctaSignedOut": "Create an account",
+      "eyebrowTrial": "Trial",
+      "minutesUnit": "min left",
+      "trialExpires": "Expires on {{date}}",
+      "eyebrowPlan": "Subscription",
+      "plan_starter": "Starter",
+      "plan_pro": "Pro",
+      "minutesUsed": "{{used}} / {{quota}} min used this month",
+      "manage": "Manage my account",
+      "eyebrowInactive": "Account",
+      "titleInactive": "Switch to cloud transcription",
+      "descInactive": "Your trial has ended. Pick a plan to keep using managed transcription and sync.",
+      "ctaInactive": "See plans"
+    },
+    "sync": {
+      "eyebrow": "Sync",
+      "title": "Turn on sync",
+      "desc": "You have an account but sync is not enabled on this profile.",
+      "benefit1": "Your notes and settings backed up to the cloud",
+      "benefit2": "Pick up where you left off on your other devices",
+      "benefit3": "Protection against data loss",
+      "cta": "Turn on sync"
+    },
+    "recentNotes": {
+      "title": "Recently edited notes",
+      "empty": "You don't have any notes yet.",
+      "createCta": "Create a note",
+      "viewAll": "All notes"
+    },
+    "quickActions": {
+      "title": "Quick actions",
+      "newNote": "New note",
+      "viewHistory": "View history",
+      "recordHint": "Start a dictation",
+      "pttHint": "Hold to dictate"
+    }
   },
   "statistics": {
     "heroEyebrow": "Dashboard",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -25,6 +25,7 @@
   "header": {
     "title": "Lexena",
     "subtitle": {
+      "accueil": "Vue d'ensemble",
       "historique": "Historique des dictées",
       "statistiques": "Statistiques d'utilisation",
       "notes": "Notes & dictées organisées",
@@ -38,6 +39,7 @@
     "error": "Post-traitement IA échoué : {{error}}"
   },
   "sidebar": {
+    "home": "Accueil",
     "history": "Historique",
     "statistics": "Statistiques",
     "notes": "Notes",
@@ -47,6 +49,51 @@
     "collapseMenu": "Replier le menu",
     "updateAvailable": "Mise à jour disponible",
     "updateAvailableTooltip": "Mise à jour {{version}} disponible"
+  },
+  "home": {
+    "heroEyebrow": "Accueil",
+    "heroTitle": "Bienvenue sur Lexena",
+    "heroSubtitle": "Un coup d'œil sur ton compte, ta synchronisation et tes dernières notes.",
+    "account": {
+      "eyebrowSignedOut": "Compte",
+      "titleSignedOut": "Crée un compte Lexena",
+      "descSignedOut": "Sauvegarde tes notes dans le cloud, synchronise tes appareils et débloque la transcription managée.",
+      "ctaSignedOut": "Créer un compte",
+      "eyebrowTrial": "Période d'essai",
+      "minutesUnit": "min restantes",
+      "trialExpires": "Expire le {{date}}",
+      "eyebrowPlan": "Abonnement",
+      "plan_starter": "Starter",
+      "plan_pro": "Pro",
+      "minutesUsed": "{{used}} / {{quota}} min utilisées ce mois-ci",
+      "manage": "Gérer mon compte",
+      "eyebrowInactive": "Compte",
+      "titleInactive": "Passe à la transcription cloud",
+      "descInactive": "Ton essai est terminé. Choisis un plan pour continuer à utiliser la transcription managée et la synchronisation.",
+      "ctaInactive": "Voir les plans"
+    },
+    "sync": {
+      "eyebrow": "Synchronisation",
+      "title": "Active la synchronisation",
+      "desc": "Tu as un compte mais la synchronisation n'est pas activée sur ce profil.",
+      "benefit1": "Tes notes et réglages sauvegardés dans le cloud",
+      "benefit2": "Retrouve tout sur tes autres appareils",
+      "benefit3": "Une protection contre la perte de données",
+      "cta": "Activer la synchronisation"
+    },
+    "recentNotes": {
+      "title": "Dernières notes éditées",
+      "empty": "Tu n'as pas encore de note.",
+      "createCta": "Créer une note",
+      "viewAll": "Toutes les notes"
+    },
+    "quickActions": {
+      "title": "Accès rapides",
+      "newNote": "Nouvelle note",
+      "viewHistory": "Voir l'historique",
+      "recordHint": "Démarrer une dictée",
+      "pttHint": "Maintenir pour dicter"
+    }
   },
   "statistics": {
     "heroEyebrow": "Tableau de bord",


### PR DESCRIPTION
## Contexte

L'app s'ouvrait sur l'historique des dictées, peu utile au lancement. Cette PR introduit une vraie **page d'accueil** comme écran de démarrage, regroupant les informations clés. L'historique reste un onglet à part entière.

## Ce qui change

Nouvel onglet **« Accueil »** en tête de la sidebar (icône `Home`), défini comme onglet par défaut. Il assemble 4 cartes autonomes :

- **Compte / essai** (`TrialAccountCard`) — adaptative : non connecté → CTA créer un compte ; trial actif → minutes restantes + expiration ; abonné → plan + minutes du mois ; connecté sans plan → CTA voir les plans. Branchée sur `useAuth` + `useUsage`.
- **Rappel de synchronisation** (`SyncReminderCard`) — visible uniquement si connecté **et** sync non activée pour le profil ; explique les bénéfices + bouton vers la section Compte.
- **Dernières notes éditées** (`RecentNotesCard`) — petites cartes (titre + date relative + favori), triées par `updatedAt`, clic = ouvre la note. État vide géré.
- **Accès rapides** (`QuickActionsCard`) — nouvelle note, voir l'historique, rappel des hotkeys d'enregistrement.

`AccueilTab` orchestre la grille et adapte le layout selon la visibilité du rappel sync.

## Hors périmètre (reporté)

- Système de **news** (décidé en cadrage : pas pour le v1).

## i18n

Namespace `home.*` complet (`fr.json` + `en.json`), plus `sidebar.home` et `header.subtitle.accueil`.

## Vérification

- `pnpm build` (tsc + vite) ✅ passe sans erreur.
- Vérification visuelle à faire via `pnpm tauri dev` (non lançable côté CI/agent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)