### PR TITLE
feat(settings): regroup 11 sections into 7 pages

### DIFF
--- a/docs/superpowers/specs/2026-06-28-settings-reorganization-design.md
+++ b/docs/superpowers/specs/2026-06-28-settings-reorganization-design.md
@@ -1,0 +1,153 @@
+# Réorganisation des paramètres — Design
+
+Date : 2026-06-28
+Statut : proposé
+
+## Problème
+
+L'écran des paramètres expose **11 sections** dans la sidebar. C'est trop, et le
+découpage est trop granulaire : des réglages qui relèvent du même geste utilisateur
+sont éparpillés (transcription / post-traitement / vocabulaire séparés ; mode
+d'insertion enterré dans « Système » ; « Cloud » isolé du « Compte » alors qu'ils
+parlent du même abonnement). Un nouvel utilisateur ne sait pas où chercher.
+
+## Objectif
+
+Passer de **11 → 7 pages**, en regroupant par modèle mental utilisateur, inspiré des
+réglages de logiciels établis (chaque grand domaine = une page, sous-réglages empilés
+en cartes). Aucune fonctionnalité supprimée — uniquement déplacée/regroupée.
+
+Décisions validées (brainstorming) :
+- Niveau de regroupement : **modéré, ~7 pages**.
+- Navigation interne des pages fusionnées : **cartes empilées + scroll** (pas de
+  sous-onglets ni sous-nav d'ancres).
+
+## Cible : 7 sections
+
+| # | Page (id) | Icône | Contenu | Provenance |
+|---|-----------|-------|---------|-----------|
+| 1 | **Dictée** (`section-dictee`) | Sparkles | Transcription + Post-traitement + Vocabulaire (3 cartes empilées) | fusion `transcription` + `post-process` + `vocabulaire` |
+| 2 | **Audio** (`section-audio`) | Mic | Micro, test, seuil de silence, sons, aperçu audio | inchangé |
+| 3 | **Apparence** (`section-apparence`) | Palette | Thème, langue UI, mini-fenêtre | inchangé |
+| 4 | **Raccourcis** (`section-raccourcis`) | Keyboard | Hotkeys + **mode d'insertion** (cursor/clipboard/none) | `raccourcis` + carte « mode insertion » extraite de `système` |
+| 5 | **Compte & Cloud** (`section-compte`) | UserCircle2 | Auth, sync, backups, appareils, partages + **quota/abonnement** | fusion `compte` + `cloud` |
+| 6 | **Système** (`section-systeme`) | Settings | Démarrage Windows, mode dev, rétention (enregistrements + historique), zone de danger | `système` **moins** la carte mode d'insertion |
+| 7 | **À propos** (`section-a-propos`) | Info | Identité/version + GitHub + **mises à jour** (statut, canal, auto-check) | fusion `à propos` + `mises à jour` |
+
+Ordre de la sidebar = celui du tableau (Dictée d'abord, À propos en dernier).
+
+## Architecture
+
+Le mécanisme actuel est conservé intégralement :
+- `Dashboard` détient l'état `activeSettingsSection: SettingsSectionId`.
+- `DashboardSidebar` → `SettingsSidebarSection` rend la liste depuis `NAV_ITEM_DEFS`.
+- `SettingTabs` rend la section active.
+- Chaque section reste un composant autonome retournant des cartes
+  `vt-card-sectioned` avec leur propre `SectionHeader`. **L'empilement de plusieurs
+  sections existantes dans une page fusionnée est donc trivial** : un composant parent
+  les rend l'une sous l'autre dans un conteneur `space-y-5`.
+
+### Composants
+
+**Pages fusionnées (nouveaux wrappers minces)** — chacune empile les sections
+existantes sans réécrire leur contenu :
+
+- `DictationSection` : rend `<TranscriptionSection/>`, `<PostProcessSection/>`,
+  `<VocabularySection/>`. Les sous-composants existants sont conservés tels quels ;
+  on ne fait que les composer.
+- `AboutSection` étendu : rend son contenu actuel + `<UpdaterSection/>` empilé en
+  dessous. (Ou un wrapper `AboutAndUpdatesSection` ; choix d'implémentation laissé au
+  plan, l'important est l'empilement.)
+- `AccountSection` étendu : rend son contenu actuel + la carte quota/abonnement de
+  `CloudSection` empilée. `CloudSection` exposait déjà tout son contenu dans une
+  carte ; on la réutilise comme sous-composant (visible uniquement signed-in, comme
+  aujourd'hui).
+
+**Carte « mode d'insertion » extraite** :
+- Le bloc « mode d'insertion » (radio cards cursor/clipboard/none) est extrait de
+  `SystemSection` vers un sous-composant réutilisable (ex. `InsertionModeCard`) rendu
+  désormais dans `ShortcutsSection`. `SystemSection` ne l'affiche plus.
+
+**Type & nav** (`common/SettingsNav.tsx`) :
+- `SettingsSectionId` réduit à 7 valeurs : `section-dictee`, `section-audio`,
+  `section-apparence`, `section-raccourcis`, `section-compte`, `section-systeme`,
+  `section-a-propos`.
+- `NAV_ITEM_DEFS` réduit à 7 entrées (ordre ci-dessus), icônes du tableau.
+- `AUTH_ONLY_IDS` vidé : il n'y a plus de section auth-only (`section-cloud`
+  disparaît ; son contenu vit sous `section-compte` qui gère déjà l'état signed-out).
+- Icônes `Wand2`, `BookOpen`, `Cloud`, `RefreshCw` retirées des imports de la nav
+  (elles restent utilisées dans les sections elles-mêmes via `VtIcon`).
+
+**Orchestrateur** (`SettingTabs.tsx`) : 7 branches au lieu de 11.
+
+### Compatibilité des deep-links (anciens ids)
+
+Des appelants externes ciblent encore d'anciens ids. On ajoute un résolveur
+`resolveSettingsTarget(id)` dans `common/SettingsNav.tsx` qui mappe tout id (legacy
+ou nouveau) vers `{ section: SettingsSectionId; anchor?: string }` :
+
+| Id entrant (legacy) | → section | → anchor (scroll vers carte) |
+|---|---|---|
+| `section-transcription` | `section-dictee` | `dictee-transcription` |
+| `section-post-process` | `section-dictee` | `dictee-post-process` |
+| `section-vocabulaire` | `section-dictee` | `dictee-vocabulaire` |
+| `section-cloud` | `section-compte` | `compte-cloud` |
+| `section-mises-a-jour` | `section-a-propos` | `apropos-updates` |
+
+Câblage des appelants :
+- `Dashboard.tsx` défaut `section-transcription` → `section-dictee`. Reset (`:304`)
+  idem. Le handler de l'event `lexena:open-settings` (`:239`) passe par
+  `resolveSettingsTarget` puis sélectionne la section (+ scroll vers l'anchor si
+  présent). Bouton notif MAJ (`:395`) → `section-a-propos` (+ anchor `apropos-updates`).
+- `ExpirationPopup.tsx:76` émet toujours `section-cloud` ; le résolveur le route vers
+  `section-compte` + scroll cloud. (On peut aussi mettre à jour l'émetteur — non
+  bloquant grâce au résolveur.)
+- `TranscriptionSection` « gérer le plan » : `onSectionChange("section-compte")` (au
+  lieu de `section-cloud`).
+- `AboutSection` « vérifier les mises à jour » : devient un scroll vers la carte
+  updater de la même page (anchor `apropos-updates`) au lieu d'une nav inter-section.
+
+Le scroll vers une carte utilise un `id` HTML sur le conteneur de chaque carte
+concernée + `scrollIntoView({ behavior: "smooth" })` (déclenché après le changement
+de section). Mécanisme léger, cohérent avec l'`scrollTo` déjà présent dans
+`SettingsNav`.
+
+## i18n
+
+- Nouvelles clés nav : `settings.nav.dictation` + `settings.nav.dictationSubtitle`
+  (FR « Dictée » / « Transcription, IA et vocabulaire » ; EN équivalents).
+- `settings.nav.about` / `aboutSubtitle` : sous-titre élargi pour inclure les MAJ
+  (ex. FR « Version, mises à jour et liens »).
+- `auth.account.sectionTitle` : devient « Compte & Cloud » (FR/EN). Sous-titre adapté.
+- Clés des entrées supprimées (`postProcess`, `vocabulary`, `audio`*, `shortcuts`*,
+  `updates`, `cloud` côté **nav**) : retirées de `NAV_ITEM_DEFS` mais les clés de
+  **contenu** des sections (`settings.postProcess.*`, `settings.vocabulary.*`, etc.)
+  sont **conservées** (le contenu est juste déplacé, pas supprimé).
+- Toute nouvelle string passe par react-i18next (FR + EN), conformément aux règles
+  projet — aucun texte en dur.
+
+## Hors périmètre (YAGNI)
+
+- Pas de sous-onglets ni de sous-nav d'ancres sticky (rejeté au brainstorming).
+- Pas de refonte visuelle des cartes existantes ni de leur logique métier.
+- Pas de découpage de `AccountSection` (1217 lignes) : hors sujet ici, on se contente
+  d'y composer la carte cloud. Un refactor de ce fichier pourra faire l'objet d'un
+  travail dédié.
+- Pas de changement backend Rust, ni de stockage des settings.
+
+## Tests / vérification
+
+- `pnpm build` (tsc + vite) doit passer : la réduction de `SettingsSectionId` fait
+  remonter à la compilation tout id orphelin → garde-fou naturel.
+- `CloudSection.test.tsx` existant doit continuer à passer (le composant cloud est
+  réutilisé, pas réécrit) ; ajuster si le wrapping change son montage.
+- Vérification manuelle : naviguer les 7 pages, vérifier que les deep-links
+  (popup expiration → cloud, bouton notif MAJ, « gérer le plan », « vérifier MAJ »)
+  atterrissent sur la bonne page/carte.
+
+## Risques
+
+- **Deep-links cassés** si un émetteur est oublié → mitigé par le résolveur central
+  qui accepte les ids legacy.
+- **Perte de repère utilisateur** (sections déplacées) → acceptable, c'est l'objectif ;
+  parc utilisateur nul avant launch v3.0, donc pas d'enjeu de migration.

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -11,7 +11,11 @@ import { AccueilTab } from "./dashboard/tabs/AccueilTab";
 import { HistoriqueTab } from "./dashboard/tabs/HistoriqueTab";
 import { StatistiquesTab } from "./dashboard/tabs/StatistiquesTab";
 import { SettingTabs } from "./settings/SettingTabs";
-import { type SettingsSectionId } from "./settings/common/SettingsNav";
+import {
+  type SettingsSectionId,
+  resolveSettingsTarget,
+  scrollToSettingsAnchor,
+} from "./settings/common/SettingsNav";
 import {
   ALL_LEVELS_ON,
   LogsTab,
@@ -46,7 +50,7 @@ export default function Dashboard() {
   const [activeTab, setActiveTab] = useState<DashboardTabId>("accueil");
   const [sidebarCollapsed, setSidebarCollapsed] = useState(false);
   const [activeSettingsSection, setActiveSettingsSection] =
-    useState<SettingsSectionId>("section-transcription");
+    useState<SettingsSectionId>("section-dictee");
   const [logsLevelFilter, setLogsLevelFilter] =
     useState<LevelFilter>(ALL_LEVELS_ON);
   const [logsSourceFilter, setLogsSourceFilter] = useState<string | null>(null);
@@ -236,10 +240,14 @@ export default function Dashboard() {
   // state. The Cloud section hosts the SubscribeButton.
   useEffect(() => {
     const onOpenSettings = (e: Event) => {
-      const detail = (e as CustomEvent<{ section?: SettingsSectionId }>).detail;
+      const detail = (e as CustomEvent<{ section?: string }>).detail;
       setActiveTab("parametres");
       if (detail?.section) {
-        setActiveSettingsSection(detail.section);
+        // Callers may emit legacy ids of pages that were merged away; resolve
+        // to the hosting page and scroll to the relevant card.
+        const { section, anchor } = resolveSettingsTarget(detail.section);
+        setActiveSettingsSection(section);
+        if (anchor) scrollToSettingsAnchor(anchor);
       }
     };
     window.addEventListener("lexena:open-settings", onOpenSettings as EventListener);
@@ -301,7 +309,8 @@ export default function Dashboard() {
         <SelectedModelMissingBanner
           onGoToSettings={() => {
             setActiveTab("parametres");
-            setActiveSettingsSection("section-transcription");
+            setActiveSettingsSection("section-dictee");
+            scrollToSettingsAnchor("section-transcription");
           }}
         />
 
@@ -392,7 +401,8 @@ export default function Dashboard() {
         onOpenChange={setShowUpdateModal}
         onViewDetails={() => {
           setActiveTab("parametres");
-          setActiveSettingsSection("section-mises-a-jour");
+          setActiveSettingsSection("section-a-propos");
+          scrollToSettingsAnchor("section-mises-a-jour");
         }}
       />
 

--- a/src/components/onboarding/steps/TryItStep.test.tsx
+++ b/src/components/onboarding/steps/TryItStep.test.tsx
@@ -29,8 +29,27 @@ vi.hoisted(() => {
   }
 });
 
-import { render, screen, fireEvent, cleanup, waitFor } from "@testing-library/react";
+import {
+  render,
+  screen,
+  fireEvent,
+  cleanup,
+  waitFor,
+  configure,
+} from "@testing-library/react";
 import "@testing-library/jest-dom/vitest";
+
+// These tests render a stateful component and assert on phases that only appear
+// after a chain of awaits (stop_recording → device id → demo transcription).
+// Under the parallel suite, CPU contention can briefly starve this jsdom-heavy
+// file, so the result occasionally arrives later than the default 1000ms
+// waitFor budget — making assertions flaky (observed ~1065ms on CI). Give async
+// utilities generous headroom, and keep the per-test timeout strictly above it
+// so the test wrapper never fires before waitFor itself (a 5s/5s collision
+// would surface as a misleading timeout). Real failures still surface, just not
+// on a hair-trigger timeout.
+vi.setConfig({ testTimeout: 30000 });
+configure({ asyncUtilTimeout: 15000 });
 
 afterEach(() => {
   cleanup();

--- a/src/components/settings/SettingTabs.tsx
+++ b/src/components/settings/SettingTabs.tsx
@@ -1,17 +1,13 @@
 import { useTranslation } from "react-i18next";
 import { useSettings } from "@/hooks/useSettings";
 import { type SettingsSectionId } from "./common/SettingsNav";
-import { TranscriptionSection } from "./sections/TranscriptionSection";
-import { PostProcessSection } from "./sections/PostProcessSection";
+import { DictationSection } from "./sections/DictationSection";
 import { AudioSection } from "./sections/AudioSection";
-import { VocabularySection } from "./sections/VocabularySection";
 import { SystemSection } from "./sections/SystemSection";
 import { AppearanceSection } from "./sections/AppearanceSection";
 import { ShortcutsSection } from "./sections/ShortcutsSection";
-import { UpdaterSection } from "./sections/UpdaterSection";
 import { AboutSection } from "./sections/AboutSection";
 import { AccountSection } from "./sections/AccountSection";
-import { CloudSection } from "./sections/CloudSection";
 
 interface SettingTabsProps {
   activeSection: SettingsSectionId;
@@ -38,21 +34,15 @@ export function SettingTabs({ activeSection, onSectionChange }: SettingTabsProps
 
   return (
     <div className="vt-app mx-auto max-w-5xl px-3 py-6 sm:px-4 md:px-6">
-      {activeSection === "section-transcription" && (
-        <TranscriptionSection onSectionChange={onSectionChange} />
+      {activeSection === "section-dictee" && (
+        <DictationSection onSectionChange={onSectionChange} />
       )}
-      {activeSection === "section-post-process" && <PostProcessSection />}
       {activeSection === "section-audio" && <AudioSection />}
-      {activeSection === "section-vocabulaire" && <VocabularySection />}
       {activeSection === "section-apparence" && <AppearanceSection />}
       {activeSection === "section-raccourcis" && <ShortcutsSection />}
-      {activeSection === "section-systeme" && <SystemSection />}
-      {activeSection === "section-mises-a-jour" && <UpdaterSection />}
-      {activeSection === "section-a-propos" && (
-        <AboutSection onSectionChange={onSectionChange} />
-      )}
       {activeSection === "section-compte" && <AccountSection />}
-      {activeSection === "section-cloud" && <CloudSection />}
+      {activeSection === "section-systeme" && <SystemSection />}
+      {activeSection === "section-a-propos" && <AboutSection />}
     </div>
   );
 }

--- a/src/components/settings/common/SettingsNav.tsx
+++ b/src/components/settings/common/SettingsNav.tsx
@@ -1,19 +1,14 @@
 import type { ReactNode, RefObject } from "react";
 import { useTranslation } from "react-i18next";
 import {
-  BookOpen,
-  Cloud,
   Info,
   Keyboard,
   Mic,
   Palette,
-  RefreshCw,
   Settings,
   Sparkles,
   UserCircle2,
-  Wand2,
 } from "lucide-react";
-import { useAuth } from "@/hooks/useAuth";
 
 export interface NavItemDef {
   id: string;
@@ -23,35 +18,30 @@ export interface NavItemDef {
   subtitleKey: string;
 }
 
+/**
+ * The seven top-level settings pages. Several former pages were folded into
+ * these (see `resolveSettingsTarget` for the legacy → new mapping):
+ *  - `section-dictee`   ← transcription + post-process + vocabulary
+ *  - `section-raccourcis` also hosts the insertion-mode card (was in system)
+ *  - `section-compte`   ← account + cloud (quota/billing)
+ *  - `section-a-propos` ← about + updates
+ */
 export type SettingsSectionId =
-  | "section-transcription"
-  | "section-post-process"
+  | "section-dictee"
   | "section-audio"
-  | "section-vocabulaire"
   | "section-apparence"
   | "section-raccourcis"
-  | "section-systeme"
-  | "section-mises-a-jour"
-  | "section-a-propos"
   | "section-compte"
-  | "section-cloud";
-
-const AUTH_ONLY_IDS = new Set<SettingsSectionId>(["section-cloud"]);
+  | "section-systeme"
+  | "section-a-propos";
 
 export const NAV_ITEM_DEFS: NavItemDef[] = [
   {
-    id: "section-transcription",
+    id: "section-dictee",
     icon: <Sparkles className="w-3.5 h-3.5 text-vt-violet" />,
     iconBg: "bg-vt-violet/10",
-    titleKey: "settings.nav.transcription",
-    subtitleKey: "settings.nav.transcriptionSubtitle",
-  },
-  {
-    id: "section-post-process",
-    icon: <Wand2 className="w-3.5 h-3.5 text-vt-pin" />,
-    iconBg: "bg-vt-pin/10",
-    titleKey: "settings.nav.postProcess",
-    subtitleKey: "settings.nav.postProcessSubtitle",
+    titleKey: "settings.nav.dictation",
+    subtitleKey: "settings.nav.dictationSubtitle",
   },
   {
     id: "section-audio",
@@ -59,13 +49,6 @@ export const NAV_ITEM_DEFS: NavItemDef[] = [
     iconBg: "bg-vt-cyan/10",
     titleKey: "settings.nav.audio",
     subtitleKey: "settings.nav.audioSubtitle",
-  },
-  {
-    id: "section-vocabulaire",
-    icon: <BookOpen className="w-3.5 h-3.5 text-vt-violet" />,
-    iconBg: "bg-vt-violet/10",
-    titleKey: "settings.nav.vocabulary",
-    subtitleKey: "settings.nav.vocabularySubtitle",
   },
   {
     id: "section-apparence",
@@ -82,18 +65,18 @@ export const NAV_ITEM_DEFS: NavItemDef[] = [
     subtitleKey: "settings.nav.shortcutsSubtitle",
   },
   {
+    id: "section-compte",
+    icon: <UserCircle2 className="w-3.5 h-3.5 text-vt-accent" />,
+    iconBg: "bg-vt-accent/10",
+    titleKey: "auth.account.sectionTitle",
+    subtitleKey: "auth.account.sectionSubtitle",
+  },
+  {
     id: "section-systeme",
     icon: <Settings className="w-3.5 h-3.5 text-vt-warn" />,
     iconBg: "bg-vt-warn/10",
     titleKey: "settings.nav.system",
     subtitleKey: "settings.nav.systemSubtitle",
-  },
-  {
-    id: "section-mises-a-jour",
-    icon: <RefreshCw className="w-3.5 h-3.5 text-vt-cyan" />,
-    iconBg: "bg-vt-cyan/10",
-    titleKey: "settings.nav.updates",
-    subtitleKey: "settings.nav.updatesSubtitle",
   },
   {
     id: "section-a-propos",
@@ -102,31 +85,51 @@ export const NAV_ITEM_DEFS: NavItemDef[] = [
     titleKey: "settings.nav.about",
     subtitleKey: "settings.nav.aboutSubtitle",
   },
-  {
-    id: "section-compte",
-    icon: <UserCircle2 className="w-3.5 h-3.5 text-vt-accent" />,
-    iconBg: "bg-vt-accent/10",
-    titleKey: "auth.account.sectionTitle",
-    subtitleKey: "auth.account.sectionSubtitle",
-  },
-  {
-    id: "section-cloud",
-    icon: <Cloud className="w-3.5 h-3.5 text-vt-cyan" />,
-    iconBg: "bg-vt-cyan/10",
-    titleKey: "settings.nav.cloud",
-    subtitleKey: "settings.nav.cloudSubtitle",
-  },
 ];
 
 // Keep backward compat alias
 export const NAV_ITEMS = NAV_ITEM_DEFS;
 
-/** Returns only the nav items appropriate for the current auth status. */
+/** Returns the nav items to display. (No auth-gated pages anymore — the cloud
+ * card lives inside the account page, which handles its own signed-out state.) */
 export function useNavItems(): NavItemDef[] {
-  const { status } = useAuth();
-  return NAV_ITEM_DEFS.filter((item) =>
-    AUTH_ONLY_IDS.has(item.id as SettingsSectionId) ? status === "signed-in" : true,
-  );
+  return NAV_ITEM_DEFS;
+}
+
+/**
+ * Maps any settings id (including ids of pages that were merged away) to the
+ * page that now hosts it, plus an optional anchor to scroll to within that
+ * page. External callers (expiration popup, update modal, cross-section links)
+ * keep emitting their original ids; this keeps those deep-links working.
+ */
+const LEGACY_SECTION_TARGETS: Record<
+  string,
+  { section: SettingsSectionId; anchor?: string }
+> = {
+  "section-transcription": { section: "section-dictee", anchor: "section-transcription" },
+  "section-post-process": { section: "section-dictee", anchor: "section-post-process" },
+  "section-vocabulaire": { section: "section-dictee", anchor: "section-vocabulaire" },
+  "section-cloud": { section: "section-compte", anchor: "section-cloud" },
+  "section-mises-a-jour": { section: "section-a-propos", anchor: "section-mises-a-jour" },
+};
+
+export function resolveSettingsTarget(id: string): {
+  section: SettingsSectionId;
+  anchor?: string;
+} {
+  return LEGACY_SECTION_TARGETS[id] ?? { section: id as SettingsSectionId };
+}
+
+/** Smoothly scrolls to an anchored card after the section has rendered. */
+export function scrollToSettingsAnchor(anchor: string): void {
+  // Defer past the section swap so the target node exists in the DOM.
+  requestAnimationFrame(() => {
+    setTimeout(() => {
+      document
+        .getElementById(anchor)
+        ?.scrollIntoView({ behavior: "smooth", block: "start" });
+    }, 60);
+  });
 }
 
 interface SettingsNavProps {

--- a/src/components/settings/sections/AboutSection.tsx
+++ b/src/components/settings/sections/AboutSection.tsx
@@ -4,17 +4,14 @@ import { Github, RefreshCw } from "lucide-react";
 import { openUrl } from "@tauri-apps/plugin-opener";
 import { useSettings } from "@/hooks/useSettings";
 import { LexenaWordmark } from "@/components/common/LexenaWordmark";
-import { type SettingsSectionId } from "../common/SettingsNav";
+import { scrollToSettingsAnchor } from "../common/SettingsNav";
 import { Callout, SectionHeader, VtIcon } from "../vt";
+import { UpdaterSection } from "./UpdaterSection";
 
 const ACCENT = "var(--vt-green)";
 const GITHUB_URL = "https://github.com/Nolyo/lexena";
 
-interface AboutSectionProps {
-  onSectionChange?: (id: SettingsSectionId) => void;
-}
-
-export function AboutSection({ onSectionChange }: AboutSectionProps) {
+export function AboutSection() {
   const { t } = useTranslation();
   const { settings } = useSettings();
   const [version, setVersion] = useState<string>("");
@@ -125,38 +122,36 @@ export function AboutSection({ onSectionChange }: AboutSectionProps) {
           </div>
         </div>
 
-        {onSectionChange && (
-          <div className="vt-row">
-            <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
-              <div className="flex flex-col gap-0.5">
-                <span className="text-[13px] font-semibold">
-                  {t("settings.about.checkUpdates", {
-                    defaultValue: "Mises à jour",
-                  })}
-                </span>
-                <span
-                  className="text-[12px]"
-                  style={{ color: "var(--vt-fg-3)" }}
-                >
-                  {t("settings.about.checkUpdatesDesc", {
-                    defaultValue:
-                      "Vérifier la disponibilité d'une nouvelle version.",
-                  })}
-                </span>
-              </div>
-              <button
-                type="button"
-                onClick={() => onSectionChange("section-mises-a-jour")}
-                className="vt-btn-primary inline-flex items-center gap-2"
-              >
-                <RefreshCw className="w-4 h-4" />
-                {t("settings.about.checkUpdatesBtn", {
-                  defaultValue: "Vérifier les mises à jour",
+        <div className="vt-row">
+          <div className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+            <div className="flex flex-col gap-0.5">
+              <span className="text-[13px] font-semibold">
+                {t("settings.about.checkUpdates", {
+                  defaultValue: "Mises à jour",
                 })}
-              </button>
+              </span>
+              <span
+                className="text-[12px]"
+                style={{ color: "var(--vt-fg-3)" }}
+              >
+                {t("settings.about.checkUpdatesDesc", {
+                  defaultValue:
+                    "Vérifier la disponibilité d'une nouvelle version.",
+                })}
+              </span>
             </div>
+            <button
+              type="button"
+              onClick={() => scrollToSettingsAnchor("section-mises-a-jour")}
+              className="vt-btn-primary inline-flex items-center gap-2"
+            >
+              <RefreshCw className="w-4 h-4" />
+              {t("settings.about.checkUpdatesBtn", {
+                defaultValue: "Vérifier les mises à jour",
+              })}
+            </button>
           </div>
-        )}
+        </div>
       </div>
 
       {versionError && (
@@ -170,6 +165,10 @@ export function AboutSection({ onSectionChange }: AboutSectionProps) {
           {versionError}
         </Callout>
       )}
+
+      <div id="section-mises-a-jour">
+        <UpdaterSection />
+      </div>
     </div>
   );
 }

--- a/src/components/settings/sections/AccountSection.tsx
+++ b/src/components/settings/sections/AccountSection.tsx
@@ -35,6 +35,7 @@ import { DeadLettersDialog } from "./DeadLettersDialog";
 import { useCloud } from "@/hooks/useCloud";
 import { formatBytes, getQuotaForPlan, type Plan } from "@/lib/sync/quota";
 import { SharedLinksPanel } from "./SharedLinksPanel";
+import { CloudSection } from "./CloudSection";
 
 const ACCENT_COMPTE = "var(--vt-accent)";
 const ACCENT_SYNC = "var(--vt-cyan)";
@@ -179,6 +180,7 @@ function SignedInBlocks() {
   return (
     <>
       <IdentityCard />
+      <CloudSection />
       <SyncCard />
       <CloudProfilesImportCard />
       <SharedLinksPanel />

--- a/src/components/settings/sections/DictationSection.tsx
+++ b/src/components/settings/sections/DictationSection.tsx
@@ -1,0 +1,31 @@
+import { type SettingsSectionId } from "../common/SettingsNav";
+import { TranscriptionSection } from "./TranscriptionSection";
+import { PostProcessSection } from "./PostProcessSection";
+import { VocabularySection } from "./VocabularySection";
+
+interface DictationSectionProps {
+  onSectionChange?: (id: SettingsSectionId) => void;
+}
+
+/**
+ * "Dictée" page — groups everything that turns speech into final text:
+ * transcription provider/model, AI post-processing, and the custom vocabulary
+ * (snippets, dictionary, prompt). Each former section keeps its own card; they
+ * are simply stacked and given anchor ids so legacy deep-links can scroll to
+ * the right card (see `resolveSettingsTarget`).
+ */
+export function DictationSection({ onSectionChange }: DictationSectionProps) {
+  return (
+    <div className="space-y-5">
+      <div id="section-transcription">
+        <TranscriptionSection onSectionChange={onSectionChange} />
+      </div>
+      <div id="section-post-process">
+        <PostProcessSection />
+      </div>
+      <div id="section-vocabulaire">
+        <VocabularySection />
+      </div>
+    </div>
+  );
+}

--- a/src/components/settings/sections/InsertionModeCard.tsx
+++ b/src/components/settings/sections/InsertionModeCard.tsx
@@ -1,0 +1,57 @@
+import { useTranslation } from "react-i18next";
+import { useSettings } from "@/hooks/useSettings";
+import { RadioCardList, Row, SectionHeader, VtIcon } from "../vt";
+
+const ACCENT = "var(--vt-accent)";
+
+type InsertionMode = "cursor" | "clipboard" | "none";
+
+/**
+ * "Insertion mode" card — controls how transcribed text is delivered
+ * (at cursor, via clipboard, or not at all). Lives on the Shortcuts page since
+ * it sits next to the keyboard-driven output behaviour. Reuses the existing
+ * `settings.system.*` translation keys (the control only moved pages).
+ */
+export function InsertionModeCard() {
+  const { t } = useTranslation();
+  const { settings, updateSetting } = useSettings();
+
+  return (
+    <div className="vt-card-sectioned" style={{ overflow: "hidden" }}>
+      <SectionHeader
+        color={ACCENT}
+        icon={<VtIcon.clipboard />}
+        title={t("settings.system.insertionMode")}
+        description={t("settings.system.insertionModeHint")}
+      />
+      <Row
+        label={t("settings.system.insertionMode")}
+        hint={t("settings.system.insertionModeHint")}
+        align="start"
+      >
+        <RadioCardList<InsertionMode>
+          value={settings.insertion_mode}
+          onChange={(v) => updateSetting("insertion_mode", v)}
+          options={[
+            {
+              id: "cursor",
+              title: t("settings.system.modeCursor"),
+              sub: t("settings.system.modeCursorDesc"),
+              badge: t("common.recommended", { defaultValue: "Recommandé" }),
+            },
+            {
+              id: "clipboard",
+              title: t("settings.system.modeClipboard"),
+              sub: t("settings.system.modeClipboardDesc"),
+            },
+            {
+              id: "none",
+              title: t("settings.system.modeNone"),
+              sub: t("settings.system.modeNoneDesc"),
+            },
+          ]}
+        />
+      </Row>
+    </div>
+  );
+}

--- a/src/components/settings/sections/ShortcutsSection.tsx
+++ b/src/components/settings/sections/ShortcutsSection.tsx
@@ -5,6 +5,7 @@ import { useHotkeyConfig } from "@/hooks/useHotkeyConfig";
 import { DEFAULT_SETTINGS } from "@/lib/settings";
 import { buildShortcutFromEvent } from "../common/HotkeyInput";
 import { Callout, Kbd, SectionHeader, VtIcon } from "../vt";
+import { InsertionModeCard } from "./InsertionModeCard";
 
 const ACCENT = "var(--vt-accent)";
 
@@ -293,6 +294,8 @@ export function ShortcutsSection() {
             "Si un raccourci ne répond pas, il est peut-être capturé par une autre application. Essaie une combinaison avec la touche Win ou Alt.",
         })}
       </Callout>
+
+      <InsertionModeCard />
     </div>
   );
 }

--- a/src/components/settings/sections/SystemSection.tsx
+++ b/src/components/settings/sections/SystemSection.tsx
@@ -1,12 +1,10 @@
 import { useTranslation } from "react-i18next";
 import { useSettings } from "@/hooks/useSettings";
 import { useAutostart } from "@/hooks/useAutostart";
-import { RadioCardList, Row, SectionHeader, Toggle, VtIcon } from "../vt";
+import { Row, SectionHeader, Toggle, VtIcon } from "../vt";
 import { DangerZone } from "./DangerZone";
 
 const ACCENT = "var(--vt-warn)";
-
-type InsertionMode = "cursor" | "clipboard" | "none";
 
 export function SystemSection() {
   const { t } = useTranslation();
@@ -222,35 +220,6 @@ export function SystemSection() {
               <VtIcon.plus />
             </button>
           </div>
-        </Row>
-
-        <Row
-          label={t("settings.system.insertionMode")}
-          hint={t("settings.system.insertionModeHint")}
-          align="start"
-        >
-          <RadioCardList<InsertionMode>
-            value={settings.insertion_mode}
-            onChange={(v) => updateSetting("insertion_mode", v)}
-            options={[
-              {
-                id: "cursor",
-                title: t("settings.system.modeCursor"),
-                sub: t("settings.system.modeCursorDesc"),
-                badge: t("common.recommended", { defaultValue: "Recommandé" }),
-              },
-              {
-                id: "clipboard",
-                title: t("settings.system.modeClipboard"),
-                sub: t("settings.system.modeClipboardDesc"),
-              },
-              {
-                id: "none",
-                title: t("settings.system.modeNone"),
-                sub: t("settings.system.modeNoneDesc"),
-              },
-            ]}
-          />
         </Row>
       </div>
 

--- a/src/components/settings/sections/TranscriptionSection.tsx
+++ b/src/components/settings/sections/TranscriptionSection.tsx
@@ -6,7 +6,10 @@ import { useSettings } from "@/hooks/useSettings";
 import { useModelDownload } from "@/hooks/useModelDownload";
 import { useCloud } from "@/hooks/useCloud";
 import { useAuth } from "@/hooks/useAuth";
-import type { SettingsSectionId } from "../common/SettingsNav";
+import {
+  type SettingsSectionId,
+  scrollToSettingsAnchor,
+} from "../common/SettingsNav";
 import {
   PickerCardGrid,
   Row,
@@ -158,7 +161,10 @@ export function TranscriptionSection({ onSectionChange }: TranscriptionSectionPr
               <CloudEligibilityBanner
                 isSignedIn={isSignedIn}
                 onSignIn={() => openAuthModal()}
-                onManagePlan={() => onSectionChange?.("section-cloud")}
+                onManagePlan={() => {
+                  onSectionChange?.("section-compte");
+                  scrollToSettingsAnchor("section-cloud");
+                }}
                 t={t}
               />
             )}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -302,6 +302,8 @@
     "quitApp": "Close the application completely",
     "footer": "(c) 2026 - Automatic updates via GitHub, By Nolyo Claude",
     "nav": {
+      "dictation": "Dictation",
+      "dictationSubtitle": "Transcription, AI and vocabulary",
       "transcription": "Transcription",
       "transcriptionSubtitle": "Speech → text",
       "postProcess": "Post-processing",
@@ -313,13 +315,13 @@
       "appearance": "Appearance",
       "appearanceSubtitle": "Theme, language, mini window",
       "shortcuts": "Shortcuts",
-      "shortcutsSubtitle": "Command keys",
+      "shortcutsSubtitle": "Keys and insertion mode",
       "system": "System",
       "systemSubtitle": "Startup and storage",
       "updates": "Updates",
       "updatesSubtitle": "New versions",
       "about": "About",
-      "aboutSubtitle": "Version, tagline and links",
+      "aboutSubtitle": "Version, updates and links",
       "cloud": "Cloud",
       "cloudSubtitle": "Trial, quota and subscription"
     },
@@ -940,8 +942,8 @@
       "confirm": "Yes, sign me out"
     },
     "account": {
-      "sectionTitle": "Account",
-      "sectionSubtitle": "Profile, security and sync",
+      "sectionTitle": "Account & Cloud",
+      "sectionSubtitle": "Profile, subscription, security and sync",
       "email": "Email",
       "deleteAccount": "Delete my account",
       "deleteAccountWarning": "This action is irreversible. All synced data will be deleted within 30 days.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -302,6 +302,8 @@
     "quitApp": "Fermer complètement l'application",
     "footer": "(c) 2026 - Mises à jour automatiques via GitHub, Par Nolyo Claude",
     "nav": {
+      "dictation": "Dictée",
+      "dictationSubtitle": "Transcription, IA et vocabulaire",
       "transcription": "Transcription",
       "transcriptionSubtitle": "Parole → texte",
       "postProcess": "Post-traitement",
@@ -313,13 +315,13 @@
       "appearance": "Apparence",
       "appearanceSubtitle": "Thème, langue, mini fenêtre",
       "shortcuts": "Raccourcis",
-      "shortcutsSubtitle": "Touches de commande",
+      "shortcutsSubtitle": "Touches et mode d'insertion",
       "system": "Système",
       "systemSubtitle": "Démarrage et stockage",
       "updates": "Mises à jour",
       "updatesSubtitle": "Nouvelles versions",
       "about": "À propos",
-      "aboutSubtitle": "Version, slogan et liens",
+      "aboutSubtitle": "Version, mises à jour et liens",
       "cloud": "Cloud",
       "cloudSubtitle": "Essai, quota et abonnement"
     },
@@ -940,8 +942,8 @@
       "confirm": "Oui, me déconnecter"
     },
     "account": {
-      "sectionTitle": "Compte",
-      "sectionSubtitle": "Profil, sécurité et synchronisation",
+      "sectionTitle": "Compte & Cloud",
+      "sectionSubtitle": "Profil, abonnement, sécurité et synchronisation",
       "email": "Email",
       "deleteAccount": "Supprimer mon compte",
       "deleteAccountWarning": "Cette action est irréversible. Toutes les données synchronisées seront supprimées sous 30 jours.",


### PR DESCRIPTION
## Objectif

Réorganiser les paramètres : passer de **11 sous-sections** à **7 pages** regroupées par modèle mental utilisateur, inspiré des réglages de logiciels établis. Aucune fonctionnalité supprimée — uniquement déplacée/regroupée.

## Cible : 7 pages

| Page | Regroupe |
|---|---|
| **Dictée** | Transcription + Post-traitement + Vocabulaire (cartes empilées) |
| **Audio** | inchangé |
| **Apparence** | inchangé |
| **Raccourcis** | Hotkeys + **mode d'insertion** (déplacé depuis Système) |
| **Compte & Cloud** | Identité + **quota/abonnement** + sync + backups + appareils + partages |
| **Système** | Démarrage, rétention, mode dev, zone de danger |
| **À propos** | Identité/version + GitHub + **mises à jour** |

## Changements

- Nouveau wrapper `DictationSection` qui empile les 3 sections existantes (aucune logique réécrite).
- `InsertionModeCard` extrait de `SystemSection` → rendu dans `ShortcutsSection`.
- `CloudSection` composée dans le bloc signed-in de `AccountSection` ; `UpdaterSection` empilée dans `AboutSection`.
- `SettingsNav` réduit à 7 ids + helpers `resolveSettingsTarget` (mappe les anciens ids vers la nouvelle page) et `scrollToSettingsAnchor` (scroll vers la carte).
- Deep-links préservés : popup expiration → Cloud, bouton notif MAJ, « gérer le plan », bannière modèle manquant, « vérifier MAJ » atterrissent sur la bonne page + scroll vers la bonne carte.
- i18n FR + EN ajoutés/ajustés (Dictée, sous-titres, « Compte & Cloud »).

## Navigation interne

Cartes empilées + scroll (décision de design validée). Pas de sous-onglets.

## Vérifications

- `pnpm build` (tsc + vite) ✅ — la réduction du type `SettingsSectionId` sert de garde-fou compile.
- `pnpm vitest run src/components/settings` → **12/12** ✅

## Spec

`docs/superpowers/specs/2026-06-28-settings-reorganization-design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
