### PR TITLE
docs: repoint references to archived superpowers specs/plans

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -330,7 +330,8 @@ Built with React 19, TypeScript, and Tailwind CSS v4.
 - `docs/v3/runbooks/` — rotations, backups, incidents (cf. `docs/v3/runbooks/README.md`)
 - `docs/v3/compliance/` — registre GDPR, base légale
 - `docs/v3/ops/` — bootstrap infra (Supabase, Cloudflare Pages) et checklist 2FA
-- `docs/superpowers/plans/` — plans d'implémentation (dont `2026-04-24-v3-sub-epic-00-security-foundations.md`)
+- `docs/superpowers/plans/` — plans d'implémentation actifs (les sous-épiques clôturées sont dans `docs/archive/superpowers/plans/`, dont `2026-04-24-v3-sub-epic-00-security-foundations.md`)
+- `docs/archive/` — plans/specs des sous-épiques livrées (≤ 2026-05-19) + research POC, conservés pour mémoire
 
 ### V3 Auth (livré sous-épique 01)
 
@@ -395,8 +396,8 @@ Built with React 19, TypeScript, and Tailwind CSS v4.
 - Procédure de déploiement Supabase : `emails/DEPLOY_SUPABASE.md` (manuel, dashboard)
 - Checklist multi-clients : `emails/COMPATIBILITY.md` (à remplir via Litmus / Email on Acid)
 - Phase 2 prévue : 4 templates Resend via Edge Functions (welcome, new-device, deletion ×2)
-- Spec : `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md`
-- Plan : `docs/superpowers/plans/2026-05-02-email-templates-supabase-auth.md`
+- Spec : `docs/archive/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md`
+- Plan : `docs/archive/superpowers/plans/2026-05-02-email-templates-supabase-auth.md`
 
 ## Commit and Push
 

--- a/docs/archive/superpowers/plans/2026-04-24-v3-sub-epic-00-security-foundations.md
+++ b/docs/archive/superpowers/plans/2026-04-24-v3-sub-epic-00-security-foundations.md
@@ -11,7 +11,7 @@
 
 **Tech Stack:** GitHub Actions YAML, `cargo audit` (crate `cargo-audit`), `pnpm audit` (natif), Node script Node.js pour scanner regex, Markdown pour docs. Aucun changement dans `src/`, `src-tauri/src/`, `app/`.
 
-**Related spec:** [`docs/v3/00-threat-model.md`](../../v3/00-threat-model.md) (figé 2026-04-22), [`docs/v3/decisions/0006-threat-model.md`](../../v3/decisions/0006-threat-model.md), [`docs/v3/decisions/0007-auth-configuration.md`](../../v3/decisions/0007-auth-configuration.md).
+**Related spec:** [`docs/v3/00-threat-model.md`](../../../v3/00-threat-model.md) (figé 2026-04-22), [`docs/v3/decisions/0006-threat-model.md`](../../../v3/decisions/0006-threat-model.md), [`docs/v3/decisions/0007-auth-configuration.md`](../../../v3/decisions/0007-auth-configuration.md).
 
 **Build verification:** Le projet n'a pas de suite de tests. Pour la CI : valider localement les workflows via `act` si installé, sinon pousser sur une branche jetable et vérifier que le job passe/échoue comme attendu. Pour les docs : relecture manuelle avant commit, pas de test automatique.
 
@@ -661,7 +661,7 @@ Garantir qu'un backup Supabase Pro est effectivement restaurable, pas juste pré
 
 ## Préconditions
 
-- Projet Supabase Pro `voice-tool-v3-prod` créé (cf. [`../ops/supabase-bootstrap.md`](../ops/supabase-bootstrap.md))
+- Projet Supabase Pro `voice-tool-v3-prod` créé (cf. [`../ops/supabase-bootstrap.md`](../../../v3/ops/supabase-bootstrap.md))
 - Accès owner au projet
 - PITR activé
 

--- a/docs/archive/superpowers/plans/2026-04-24-v3-sub-epic-01-auth.md
+++ b/docs/archive/superpowers/plans/2026-04-24-v3-sub-epic-01-auth.md
@@ -12,7 +12,7 @@
 
 **Tech Stack:** Rust `keyring` crate, `@supabase/supabase-js`, `otpauth` (TOTP côté front pour l'URI QR), React 19 + i18next, Tailwind 4 + shadcn/ui + design system `.vt-app`, Tauri 2 single-instance plugin pour le deep link, Cloudflare Pages (statique + `_headers`), Supabase Auth + Postgres.
 
-**Related spec:** [`docs/v3/01-auth.md`](../../v3/01-auth.md) (figée 2026-04-22), [`docs/v3/decisions/0004-auth-methods.md`](../../v3/decisions/0004-auth-methods.md), [`0005-callback-flow-web-page.md`](../../v3/decisions/0005-callback-flow-web-page.md), [`0007-auth-configuration.md`](../../v3/decisions/0007-auth-configuration.md), [`docs/v3/00-threat-model.md`](../../v3/00-threat-model.md).
+**Related spec:** [`docs/v3/01-auth.md`](../../../v3/01-auth.md) (figée 2026-04-22), [`docs/v3/decisions/0004-auth-methods.md`](../../../v3/decisions/0004-auth-methods.md), [`0005-callback-flow-web-page.md`](../../../v3/decisions/0005-callback-flow-web-page.md), [`0007-auth-configuration.md`](../../../v3/decisions/0007-auth-configuration.md), [`docs/v3/00-threat-model.md`](../../../v3/00-threat-model.md).
 
 **Build verification:**
 - Rust : `LIBCLANG_PATH="C:/Program Files/LLVM/bin" PATH="$PATH:/c/Program Files/CMake/bin" cargo check` dans `src-tauri/` (cf. `memory/MEMORY.md`).

--- a/docs/archive/superpowers/plans/2026-04-24-v3-sub-epic-02-sync-settings.md
+++ b/docs/archive/superpowers/plans/2026-04-24-v3-sub-epic-02-sync-settings.md
@@ -12,7 +12,7 @@
 
 **Tech Stack:** `@supabase/supabase-js` (déjà en place), Supabase Edge Functions (Deno + TypeScript), `zod` (validation), Tauri Store plugin v2 (déjà en place), React 19 + Context, Tailwind 4 + design system `.vt-app`, i18next. **Pas de nouveau code Rust** : toute la logique sync vit côté TS (cohérent avec le pattern sub-epic 01 où auth.rs ne couvrait que keyring / deep link / device ID).
 
-**Related spec:** [`docs/v3/02-sync-settings.md`](../../v3/02-sync-settings.md) (figée 2026-04-22), [`docs/v3/decisions/0002-server-side-encryption.md`](../../v3/decisions/0002-server-side-encryption.md), [`docs/v3/decisions/0003-api-keys-device-local.md`](../../v3/decisions/0003-api-keys-device-local.md), [`docs/v3/decisions/0008-sync-strategy.md`](../../v3/decisions/0008-sync-strategy.md), [`docs/v3/00-threat-model.md`](../../v3/00-threat-model.md).
+**Related spec:** [`docs/v3/02-sync-settings.md`](../../../v3/02-sync-settings.md) (figée 2026-04-22), [`docs/v3/decisions/0002-server-side-encryption.md`](../../../v3/decisions/0002-server-side-encryption.md), [`docs/v3/decisions/0003-api-keys-device-local.md`](../../../v3/decisions/0003-api-keys-device-local.md), [`docs/v3/decisions/0008-sync-strategy.md`](../../../v3/decisions/0008-sync-strategy.md), [`docs/v3/00-threat-model.md`](../../../v3/00-threat-model.md).
 
 **Build verification:**
 - Rust : `LIBCLANG_PATH="C:/Program Files/LLVM/bin" PATH="$PATH:/c/Program Files/CMake/bin" cargo check` dans `src-tauri/` (cf. `memory/MEMORY.md`) — **seulement si** une tâche touche Rust (Task 5 backup fs, Task 17 export).

--- a/docs/archive/superpowers/plans/2026-05-04-managed-transcription-architecture.md
+++ b/docs/archive/superpowers/plans/2026-05-04-managed-transcription-architecture.md
@@ -12,7 +12,7 @@
 
 **Tech Stack:** TypeScript + `@cloudflare/workers-types` + `jose` (JWT verify) + `@supabase/supabase-js` (Worker côté serveur, service-role) ; Wrangler 3 ; Vitest + Miniflare pour tests Worker. PostgreSQL 15 (Supabase). Côté client : Tauri Rust + `reqwest`, React 19 + Context, Tailwind 4 design system `.vt-app`, i18next, Vitest. Pas de framework de routing dans le Worker (vanilla `fetch` handler).
 
-**Related spec:** [`docs/superpowers/specs/2026-05-04-managed-transcription-architecture-design.md`](../specs/2026-05-04-managed-transcription-architecture-design.md), [`docs/superpowers/specs/2026-04-27-v3-premium-offer-design.md`](../specs/2026-04-27-v3-premium-offer-design.md), [`docs/v3/EPIC.md`](../../v3/EPIC.md), [`docs/v3/05-managed-transcription.md`](../../v3/05-managed-transcription.md).
+**Related spec:** [`docs/superpowers/specs/2026-05-04-managed-transcription-architecture-design.md`](../specs/2026-05-04-managed-transcription-architecture-design.md), [`docs/superpowers/specs/2026-04-27-v3-premium-offer-design.md`](../specs/2026-04-27-v3-premium-offer-design.md), [`docs/v3/EPIC.md`](../../../v3/EPIC.md), [`docs/v3/05-managed-transcription.md`](../../../v3/05-managed-transcription.md).
 
 **Build verification:**
 - **Worker** : `pnpm --filter @lexena/transcription-api typecheck` + `pnpm --filter @lexena/transcription-api test` (Vitest + Miniflare). `pnpm --filter @lexena/transcription-api dev` lance Wrangler dev local.

--- a/docs/archive/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md
+++ b/docs/archive/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md
@@ -13,7 +13,7 @@
 
 **Tech Stack :** identique sub-épique 02. `@supabase/supabase-js`, Supabase Edge Functions Deno + TypeScript, `zod`, Tauri Store plugin v2, React 19 + Context, Tailwind 4, i18next. **Pas de nouvelle dépendance front/back.**
 
-**Related design :** [`docs/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md`](../specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md), [`docs/v3/03-sync-notes.md`](../../v3/03-sync-notes.md), [`docs/v3/decisions/0016-notes-sync-strategy.md`](../../v3/decisions/0016-notes-sync-strategy.md).
+**Related design :** [`docs/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md`](../specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md), [`docs/v3/03-sync-notes.md`](../../../v3/03-sync-notes.md), [`docs/v3/decisions/0016-notes-sync-strategy.md`](../../../v3/decisions/0016-notes-sync-strategy.md).
 
 **Build verification :**
 - Rust : `LIBCLANG_PATH="C:/Program Files/LLVM/bin" PATH="$PATH:/c/Program Files/CMake/bin" cargo check` dans `src-tauri/` (cf. `memory/MEMORY.md`).
@@ -160,11 +160,11 @@ Expected: 0 régression.
 
 - [ ] **Step 5: Lire la spec figée**
 
-Fichier : [`docs/v3/03-sync-notes.md`](../../v3/03-sync-notes.md). Repérer le schéma DB, le sync engine, la conflict resolution, et la migration.
+Fichier : [`docs/v3/03-sync-notes.md`](../../../v3/03-sync-notes.md). Repérer le schéma DB, le sync engine, la conflict resolution, et la migration.
 
 - [ ] **Step 6: Lire l'ADR 0016**
 
-Fichier : [`docs/v3/decisions/0016-notes-sync-strategy.md`](../../v3/decisions/0016-notes-sync-strategy.md). Les 13 décisions sont **figées** — ne pas re-débattre en cours d'impl.
+Fichier : [`docs/v3/decisions/0016-notes-sync-strategy.md`](../../../v3/decisions/0016-notes-sync-strategy.md). Les 13 décisions sont **figées** — ne pas re-débattre en cours d'impl.
 
 - [ ] **Step 7: Lire le design doc**
 
@@ -1106,7 +1106,7 @@ PR description doit inclure :
 ## Liens
 
 - [Design doc](../specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md)
-- [Living spec](../../v3/03-sync-notes.md)
-- [ADR 0016](../../v3/decisions/0016-notes-sync-strategy.md)
+- [Living spec](../../../v3/03-sync-notes.md)
+- [ADR 0016](../../../v3/decisions/0016-notes-sync-strategy.md)
 - [Sub-epic 02 plan (référence pattern)](2026-04-24-v3-sub-epic-02-sync-settings.md)
-- [Sub-epic 02 closure ADR](../../v3/decisions/0010-sub-epic-02-closure.md)
+- [Sub-epic 02 closure ADR](../../../v3/decisions/0010-sub-epic-02-closure.md)

--- a/docs/archive/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md
+++ b/docs/archive/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md
@@ -4,8 +4,8 @@
 **Statut** : design figé, prêt à être planifié
 **Sous-épique principal** : `03-sync-notes` (livraison dans une future bêta `v3.0.0-beta.X` — tout sort sur v3.0 incrémentale)
 **Sous-épiques touchés** : `02-sync-settings` (extension queue + Edge Function), `01-auth` (réutilisation JWT)
-**ADR créé** : [`0016-notes-sync-strategy.md`](../../v3/decisions/0016-notes-sync-strategy.md)
-**Living document** : [`docs/v3/03-sync-notes.md`](../../v3/03-sync-notes.md)
+**ADR créé** : [`0016-notes-sync-strategy.md`](../../../v3/decisions/0016-notes-sync-strategy.md)
+**Living document** : [`docs/v3/03-sync-notes.md`](../../../v3/03-sync-notes.md)
 
 ---
 
@@ -13,7 +13,7 @@
 
 Le sous-épique 02 (sync settings) est livré et stabilisé : 3 tables Supabase, RLS deny-by-default, Edge Function `sync-push`, lifecycle-based, LWW par item, soft-delete, quota 5 MB, backup local, modale migration. Le pattern est éprouvé.
 
-Le sous-épique 03 livre la sync cloud des notes texte + dossiers. Le stub [`03-sync-notes.md`](../../v3/03-sync-notes.md) listait 8 questions ouvertes. Cette spec figée fait écho à la décision : **aligner maximalement sur le pattern settings**, et n'introduire des écarts que là où la nature "édition continue" des notes l'exige.
+Le sous-épique 03 livre la sync cloud des notes texte + dossiers. Le stub [`03-sync-notes.md`](../../../v3/03-sync-notes.md) listait 8 questions ouvertes. Cette spec figée fait écho à la décision : **aligner maximalement sur le pattern settings**, et n'introduire des écarts que là où la nature "édition continue" des notes l'exige.
 
 ### Contraintes de cadrage
 
@@ -157,7 +157,7 @@ Aucun nouveau composant infra. La sync notes **extend** :
 
 ### A10. Chiffrement E2E
 
-**Hors scope.** Cf. [ADR 0002 server-side encryption](../../v3/decisions/0002-server-side-encryption.md). Posture style Notion : encryption at rest Postgres + TLS in transit, pas d'E2E. Réversible long terme si position prend.
+**Hors scope.** Cf. [ADR 0002 server-side encryption](../../../v3/decisions/0002-server-side-encryption.md). Posture style Notion : encryption at rest Postgres + TLS in transit, pas d'E2E. Réversible long terme si position prend.
 
 ### A11. Pagination liste notes
 
@@ -209,5 +209,5 @@ Aucun nouveau composant infra. La sync notes **extend** :
 ## 8. Suite
 
 - Plan d'implémentation : [`docs/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md`](../plans/2026-05-19-v3-sub-epic-03-sync-notes.md)
-- Living document spec : [`docs/v3/03-sync-notes.md`](../../v3/03-sync-notes.md)
-- ADR : [`docs/v3/decisions/0016-notes-sync-strategy.md`](../../v3/decisions/0016-notes-sync-strategy.md)
+- Living document spec : [`docs/v3/03-sync-notes.md`](../../../v3/03-sync-notes.md)
+- ADR : [`docs/v3/decisions/0016-notes-sync-strategy.md`](../../../v3/decisions/0016-notes-sync-strategy.md)

--- a/docs/v3/00-threat-model-implementation-matrix.md
+++ b/docs/v3/00-threat-model-implementation-matrix.md
@@ -68,7 +68,7 @@
 | Edge Functions Supabase | P1 | Validation Zod + CORS lock + service role server-only + rate limit RPC dispo | `supabase/functions/_shared/{auth,cors,rate-limit}.ts`, `sync-push/schema.ts` |
 | Flow OAuth Google | P2 | `state` nonce one-time validé Rust + redirect URI strict côté Google Console | `src-tauri/src/auth.rs` (nonce), Google Cloud Console (manuel) |
 | Flow Magic Link | P2 | Token one-time Supabase + TTL court + anti-enumeration (réponses identiques) | `src/components/auth/SignInPanel.tsx` (UX neutre), Supabase native |
-| Webhook Lemon Squeezy | P2 | HMAC + idempotence (POC validé) | `docs/research/lemonsqueezy-poc/` — à recâbler v3.2 |
+| Webhook Lemon Squeezy | P2 | HMAC + idempotence (POC validé) | `docs/archive/research/lemonsqueezy-poc/` — à recâbler v3.2 |
 | Page web auth-callback | P2 | CSP stricte + zéro JS tiers + token nettoyé URL | Repo `voice-tool-auth-callback` (Cloudflare Pages) |
 | Deep link `lexena://` | P3 | Validation Rust : nonce one-time + parsing JWT shape + anti-replay | `src-tauri/src/auth.rs` (11 tests unitaires) |
 | App desktop Tauri (IPC commands) | P3 | Capabilities Tauri 2 limitées (`src-tauri/capabilities/default.json`, `mini.json`) | Capabilities files + audit dépendances `cargo audit` |

--- a/docs/v3/03-sync-notes-e2e-checklist.md
+++ b/docs/v3/03-sync-notes-e2e-checklist.md
@@ -115,5 +115,5 @@
 
 - [Spec figée](./03-sync-notes.md)
 - [ADR 0016](./decisions/0016-notes-sync-strategy.md)
-- [Plan d'implémentation](../superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md)
+- [Plan d'implémentation](../archive/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md)
 - [Runbook purge cron](./runbooks/account-deletion-purge.md)

--- a/docs/v3/04-billing.md
+++ b/docs/v3/04-billing.md
@@ -9,7 +9,7 @@
 ## Décisions déjà actées (cf. EPIC.md)
 
 - Provider: **Lemon Squeezy** (Merchant of Record) ([ADR 0001](decisions/0001-lemonsqueezy-vs-stripe.md))
-- POC technique fonctionnel: voir [`docs/research/lemonsqueezy-poc/`](../research/lemonsqueezy-poc/)
+- POC technique fonctionnel: voir [`docs/archive/research/lemonsqueezy-poc/`](../archive/research/lemonsqueezy-poc/)
 
 ---
 

--- a/docs/v3/EPIC.md
+++ b/docs/v3/EPIC.md
@@ -23,7 +23,7 @@ La v3 introduit deux changements majeurs qui remettent en cause cette posture:
 ## État de l'existant
 
 - **`docs/BACKLOG.md`** définit déjà EPIC-07 (audit sécurité, **bloquant** pour v3) et EPIC-08 (comptes + service payant, v3.0).
-- **`docs/research/lemonsqueezy-poc/`** contient un POC technique fonctionnel (HMAC, idempotence, RLS) prouvant que Lemon Squeezy + Supabase peut marcher. Le POC ne couvre **que** le flow billing — pas le sync, pas le chiffrement, pas le proxy.
+- **`docs/archive/research/lemonsqueezy-poc/`** contient un POC technique fonctionnel (HMAC, idempotence, RLS) prouvant que Lemon Squeezy + Supabase peut marcher. Le POC ne couvre **que** le flow billing — pas le sync, pas le chiffrement, pas le proxy.
 - **`docs/IDEES_AMELIORATION_2026-04-17.md` section 16** liste les pistes monétisation (crédits transcription, modèles premium, sync, partage, team/enterprise).
 
 ---
@@ -114,5 +114,5 @@ _Mise à jour 2026-05-05 : 04-billing livré (cf. [ADR 0015](decisions/0015-sub-
 
 - [Backlog général](../BACKLOG.md) — EPIC-07 et EPIC-08 macro
 - [Idées d'amélioration 2026-04-17](../IDEES_AMELIORATION_2026-04-17.md) — section 16 pour pistes monétisation
-- [POC Lemon Squeezy](../research/lemonsqueezy-poc/) — preuve technique existante
+- [POC Lemon Squeezy](../archive/research/lemonsqueezy-poc/) — preuve technique existante
 - [README de l'épique](README.md) — convention de travail

--- a/docs/v3/GA-READINESS-2026-05-01.md
+++ b/docs/v3/GA-READINESS-2026-05-01.md
@@ -101,7 +101,7 @@
 
 12. **CGU article 12 activé** (section "Service payant" actuellement marquée non applicable)
 
-13. **Webhook LS recâblé depuis le POC** (`docs/research/lemonsqueezy-poc/`)
+13. **Webhook LS recâblé depuis le POC** (`docs/archive/research/lemonsqueezy-poc/`)
 
 ---
 

--- a/docs/v3/README.md
+++ b/docs/v3/README.md
@@ -11,7 +11,7 @@ Ce dossier est l'**epic story** de la v3 de Voice Tool. Il se construit progress
 - **[01-auth.md](01-auth.md)** — Auth & comptes (signup, login, OAuth, deep link).
 - **[02-sync-settings.md](02-sync-settings.md)** — Sync settings (sans clés API).
 - **[03-sync-notes.md](03-sync-notes.md)** — Sync notes texte + migration locale.
-- **[04-billing.md](04-billing.md)** — Lemon Squeezy + gating premium (intègre POC `docs/research/lemonsqueezy-poc/`).
+- **[04-billing.md](04-billing.md)** — Lemon Squeezy + gating premium (intègre POC `docs/archive/research/lemonsqueezy-poc/`).
 - **[05-managed-transcription.md](05-managed-transcription.md)** — Proxy modèles transcription (v3.1+).
 - **[06-onboarding.md](06-onboarding.md)** — Marketing, pricing, onboarding UX.
 - **[decisions/](decisions/)** — Architecture Decision Records (ADR) au format Michael Nygard.

--- a/docs/v3/decisions/0001-lemonsqueezy-vs-stripe.md
+++ b/docs/v3/decisions/0001-lemonsqueezy-vs-stripe.md
@@ -34,7 +34,7 @@ On retient **Lemon Squeezy**.
 
 - **MoR (Merchant of Record)** = Lemon Squeezy gère intégralement la TVA EU MOSS, la sales tax US (multi-états post-Wayfair), et les autres juridictions. Pour un dev solo français, c'est plusieurs dizaines d'heures par an économisées en déclarations et compliance.
 - Le surcoût de ~2% en frais comparé à Stripe est largement compensé par le temps gagné.
-- **Un POC technique fonctionnel existe déjà** (`docs/research/lemonsqueezy-poc/`): webhook HMAC SHA-256, idempotence, RLS Supabase. La techno est validée bout-en-bout.
+- **Un POC technique fonctionnel existe déjà** (`docs/archive/research/lemonsqueezy-poc/`): webhook HMAC SHA-256, idempotence, RLS Supabase. La techno est validée bout-en-bout.
 - L'alternative crédible était Paddle (plus mature pour le SaaS récurrent), mais le POC Lemon Squeezy étant déjà fait, refaire un POC Paddle = coût de migration sans gain démontré pour notre cas.
 
 ## Conséquences

--- a/docs/v3/decisions/0011-account-deletion-completion.md
+++ b/docs/v3/decisions/0011-account-deletion-completion.md
@@ -26,5 +26,5 @@ L'épique v3 ne peut pas sortir publiquement avec un bouton "Supprimer mon compt
 
 ## Spec & plan
 
-- Spec : `docs/superpowers/specs/2026-04-25-account-deletion-completion-design.md`
-- Plan : `docs/superpowers/plans/2026-04-25-account-deletion-completion.md`
+- Spec : `docs/archive/superpowers/specs/2026-04-25-account-deletion-completion-design.md`
+- Plan : `docs/archive/superpowers/plans/2026-04-25-account-deletion-completion.md`

--- a/docs/v3/decisions/0011-email-canonical.md
+++ b/docs/v3/decisions/0011-email-canonical.md
@@ -67,7 +67,7 @@ Sub-épique 01-auth was frozen 2026-04-22, before the trial mechanic was finaliz
 
 ## References
 
-- Spec: `docs/superpowers/specs/2026-04-27-v3-premium-offer-design.md` sections 8 + 10.1
+- Spec: `docs/archive/superpowers/specs/2026-04-27-v3-premium-offer-design.md` sections 8 + 10.1
 - Sub-épique: `docs/v3/01-auth.md`
 - Migration: `supabase/migrations/20260601000100_email_canonical.sql`
 - Tests: `supabase/tests/email_canonical.sql`, `src/lib/email-normalize.test.ts`

--- a/docs/v3/decisions/0012-managed-transcription-stack.md
+++ b/docs/v3/decisions/0012-managed-transcription-stack.md
@@ -3,7 +3,7 @@
 **Date** : 2026-05-04
 **Statut** : Accepté
 **Contexte** : sous-épique 05 (managed transcription, cible bundle launch v3.2)
-**Spec source** : [`docs/superpowers/specs/2026-05-04-managed-transcription-architecture-design.md`](../../superpowers/specs/2026-05-04-managed-transcription-architecture-design.md)
+**Spec source** : [`docs/archive/superpowers/specs/2026-05-04-managed-transcription-architecture-design.md`](../../archive/superpowers/specs/2026-05-04-managed-transcription-architecture-design.md)
 
 ## Décisions
 
@@ -33,6 +33,6 @@
 
 ## Liens
 
-- Spec : `docs/superpowers/specs/2026-05-04-managed-transcription-architecture-design.md`
-- Plan : `docs/superpowers/plans/2026-05-04-managed-transcription-architecture.md`
+- Spec : `docs/archive/superpowers/specs/2026-05-04-managed-transcription-architecture-design.md`
+- Plan : `docs/archive/superpowers/plans/2026-05-04-managed-transcription-architecture.md`
 - Sous-épique : `docs/v3/05-managed-transcription.md`

--- a/docs/v3/decisions/0013-premium-offer.md
+++ b/docs/v3/decisions/0013-premium-offer.md
@@ -2,7 +2,7 @@
 
 > **Statut**: Acté.
 > **Date**: 2026-04-27 (spec) / 2026-05-05 (ADR rédigé en clôture sous-épique 04).
-> **Source canonique**: [`docs/superpowers/specs/2026-04-27-v3-premium-offer-design.md`](../../superpowers/specs/2026-04-27-v3-premium-offer-design.md), sections 3 et 4.
+> **Source canonique**: [`docs/archive/superpowers/specs/2026-04-27-v3-premium-offer-design.md`](../../archive/superpowers/specs/2026-04-27-v3-premium-offer-design.md), sections 3 et 4.
 
 ## Contexte
 

--- a/docs/v3/decisions/0014-trial-mechanics.md
+++ b/docs/v3/decisions/0014-trial-mechanics.md
@@ -2,7 +2,7 @@
 
 > **Statut**: Acté.
 > **Date**: 2026-04-27 (spec) / 2026-05-05 (ADR rédigé en clôture sous-épique 04).
-> **Source canonique**: [`docs/superpowers/specs/2026-04-27-v3-premium-offer-design.md`](../../superpowers/specs/2026-04-27-v3-premium-offer-design.md), section 5.
+> **Source canonique**: [`docs/archive/superpowers/specs/2026-04-27-v3-premium-offer-design.md`](../../archive/superpowers/specs/2026-04-27-v3-premium-offer-design.md), section 5.
 
 ## Contexte
 

--- a/docs/v3/decisions/0017-sub-epic-03-closure.md
+++ b/docs/v3/decisions/0017-sub-epic-03-closure.md
@@ -4,8 +4,8 @@
 - **Date** : 2026-05-19
 - **Sous-épique** : 03 — Sync notes
 - **Supersedes** : —
-- **Lien plan** : [`docs/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md`](../../superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md)
-- **Lien design** : [`docs/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md`](../../superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md)
+- **Lien plan** : [`docs/archive/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md`](../../archive/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md)
+- **Lien design** : [`docs/archive/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md`](../../archive/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md)
 - **Lien spec figée** : [`docs/v3/03-sync-notes.md`](../03-sync-notes.md)
 - **ADR principal** : [`0016-notes-sync-strategy.md`](./0016-notes-sync-strategy.md)
 
@@ -76,7 +76,7 @@ Tout sort sur une future bêta `v3.0.0-beta.X` (cf. `project_v3_no_subversions`)
 
 - ADR 0016 (figé) : [`0016-notes-sync-strategy.md`](./0016-notes-sync-strategy.md)
 - Spec figée : [`../03-sync-notes.md`](../03-sync-notes.md)
-- Plan : [`../../superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md`](../../superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md)
-- Design : [`../../superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md`](../../superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md)
+- Plan : [`../../archive/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md`](../../archive/superpowers/plans/2026-05-19-v3-sub-epic-03-sync-notes.md)
+- Design : [`../../archive/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md`](../../archive/superpowers/specs/2026-05-19-v3-sub-epic-03-sync-notes-design.md)
 - Checklist E2E : [`../03-sync-notes-e2e-checklist.md`](../03-sync-notes-e2e-checklist.md)
 - Runbook purge : [`../runbooks/account-deletion-purge.md`](../runbooks/account-deletion-purge.md)

--- a/docs/v3/decisions/adr-implementation-matrix.md
+++ b/docs/v3/decisions/adr-implementation-matrix.md
@@ -5,7 +5,7 @@
 
 | ADR | Décision | Statut | Implémentation |
 |---|---|---|---|
-| **0001** — Lemon Squeezy MoR | Billing via Lemon Squeezy (pas Stripe direct, pas Paddle) | ⏳ v3.2 | POC : `docs/research/lemonsqueezy-poc/`. Pas câblé en v3.0 (billing décalé). Décision toujours valide. |
+| **0001** — Lemon Squeezy MoR | Billing via Lemon Squeezy (pas Stripe direct, pas Paddle) | ⏳ v3.2 | POC : `docs/archive/research/lemonsqueezy-poc/`. Pas câblé en v3.0 (billing décalé). Décision toujours valide. |
 | **0002** — Server-side encryption (style Notion) | Encryption at rest Postgres + TLS in transit, pas de E2E v3.0 | ✅ | Supabase managé (encryption at rest natif), TLS forcé client `src/lib/supabase.ts`. Documenté threat model § Compromis acceptés. |
 | **0003** — Clés API device-local | Clés OpenAI/Groq jamais syncées, jamais en transit serveur | ✅ | Filtre sync : `src/lib/sync/mapping.ts` (whitelist 9 clés scalaires, exclut `openai_api_key`, `groq_api_key`, etc.). Stockage local : Tauri Store (chiffré côté OS pour les valeurs sensibles via keyring quand applicable). Test : `mapping.test.ts`. |
 | **0004** — Méthodes auth | Email/password + Magic link + Google OAuth | ✅ | Composants : `src/components/auth/SignInPanel.tsx` (E/P + magic link), `AuthModal.tsx`. OAuth Google : configuré côté Supabase Dashboard + callback handler `src-tauri/src/auth.rs`. Tests : `cargo test` couvre nonce + JWT shape. |

--- a/docs/v3/legal/email-templates.md
+++ b/docs/v3/legal/email-templates.md
@@ -9,7 +9,7 @@
 > ⚠️ **Phase 1 livrée 2026-05-02** — les 3 templates Supabase Auth (magic link, signup confirmation, password reset) sont implémentés en HTML stylé via React Email.
 > **Source de vérité** : `emails/templates/*.tsx`. Le markdown ci-dessous reste de référence textuelle (FR + EN) pour comparaison et préparation des phases suivantes.
 > **Langue déployée v3.0** : EN uniquement. FR reporté à une phase ultérieure (Edge Function `auth-email-hook` selon `user_settings.ui_language`).
-> **Spec & plan** : `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md` + `docs/superpowers/plans/2026-05-02-email-templates-supabase-auth.md`.
+> **Spec & plan** : `docs/archive/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md` + `docs/archive/superpowers/plans/2026-05-02-email-templates-supabase-auth.md`.
 
 ---
 

--- a/docs/v3/runbooks/device-fingerprint-investigation.md
+++ b/docs/v3/runbooks/device-fingerprint-investigation.md
@@ -46,5 +46,5 @@ If a clear abuse pattern is detected:
 
 ## Related
 
-- Spec: `docs/superpowers/specs/2026-04-27-v3-premium-offer-design.md` sections 8.1, 8.2
+- Spec: `docs/archive/superpowers/specs/2026-04-27-v3-premium-offer-design.md` sections 8.1, 8.2
 - Schema: `supabase/migrations/20260501000000_user_devices.sql`

--- a/emails/README.md
+++ b/emails/README.md
@@ -67,7 +67,7 @@ Edge Functions Resend templates, sharing the same components:
 - Account deletion request
 - Account deletion completion
 
-See `docs/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md` section 9 (out of scope of phase 1).
+See `docs/archive/superpowers/specs/2026-05-02-email-templates-supabase-auth-design.md` section 9 (out of scope of phase 1).
 
 ## Operator runbook
 


### PR DESCRIPTION
## Summary

Follow-up to #65, which moved the delivered sub-epic specs/plans into `docs/archive/`. This updates the remaining cross-references that still pointed at the old `docs/superpowers/` / `docs/research/` paths.

24 files: `CLAUDE.md`, `docs/v3/**`, a few `docs/archive/**` (internal links), and `emails/README.md`. Link-path edits only — no content changes (45 insertions / 44 deletions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)