### PR TITLE
feat: save a transcription to a note

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Drag & drop** for moving notes between folders
 - Custom **folder-creation dialog** (replaces the native browser `prompt()`)
 - Note-to-note linking (`@`) + backlinks panel + broken-link detection (carried over from 2.10.1)
+- **Save a transcription to a note**: from a transcription's detail panel, create a new note seeded with it or append it to an existing note via a searchable picker (sync-safe, 1 MB per-note cap honored)
 
 ### Added — History
 - **Pin transcriptions** to keep important entries at the top of the list

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -85,6 +85,7 @@ export default function Dashboard() {
     moveNoteToFolder,
     moveNoteToFolderAtIndex,
     reorderNotesInFolder,
+    reloadNotes,
   } = useNotes();
   const {
     folders,
@@ -171,6 +172,15 @@ export default function Dashboard() {
       }
     },
     [notes, handleOpenNote],
+  );
+
+  // Open a note (created/updated from a transcription) in the Notes view.
+  const handleOpenNoteFromHistory = useCallback(
+    (noteId: string) => {
+      handleOpenNoteInTabById(noteId);
+      setActiveTab("notes");
+    },
+    [handleOpenNoteInTabById],
   );
 
   const handleDelete = useCallback(
@@ -385,6 +395,8 @@ export default function Dashboard() {
                       onDelete={handleDelete}
                       onClearAll={handleClearAll}
                       onTogglePin={togglePin}
+                      onOpenNote={handleOpenNoteFromHistory}
+                      onNotesMutated={reloadNotes}
                     />
                   )}
                   {activeTab === "statistiques" && (

--- a/src/components/dashboard/tabs/HistoriqueTab.tsx
+++ b/src/components/dashboard/tabs/HistoriqueTab.tsx
@@ -13,6 +13,8 @@ interface HistoriqueTabProps {
   onDelete: (id: string) => void;
   onClearAll: () => void;
   onTogglePin?: (id: string) => void | Promise<void>;
+  onOpenNote?: (noteId: string) => void;
+  onNotesMutated?: () => void;
 }
 
 /**
@@ -31,6 +33,8 @@ export function HistoriqueTab({
   onDelete,
   onClearAll,
   onTogglePin,
+  onOpenNote,
+  onNotesMutated,
 }: HistoriqueTabProps) {
   if (isCompact && isSidebarOpen) {
     return (
@@ -40,6 +44,8 @@ export function HistoriqueTab({
           onClose={onCloseDetails}
           onDelete={onDelete}
           onTogglePin={onTogglePin}
+          onOpenNote={onOpenNote}
+          onNotesMutated={onNotesMutated}
           compact
         />
       </div>
@@ -70,6 +76,8 @@ export function HistoriqueTab({
             onClose={onCloseDetails}
             onDelete={onDelete}
             onTogglePin={onTogglePin}
+            onOpenNote={onOpenNote}
+            onNotesMutated={onNotesMutated}
           />
         </div>
       </div>

--- a/src/components/dashboard/transcription/SaveToNoteDialog.tsx
+++ b/src/components/dashboard/transcription/SaveToNoteDialog.tsx
@@ -1,0 +1,137 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+import { useTranslation } from "react-i18next";
+import { FilePlus2, FileText, Search } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { listNotes } from "@/lib/sync/notes-store";
+import type { LocalNoteMeta } from "@/lib/sync/types";
+
+interface SaveToNoteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Create a brand-new note seeded with the transcription. */
+  onCreateNew: () => void;
+  /** Append the transcription to the chosen existing note. */
+  onSelectExisting: (note: LocalNoteMeta) => void;
+}
+
+/**
+ * Picker shown from a transcription's "Vers une note…" action. Offers a single
+ * "create new note" affordance at the top, then a searchable list of existing
+ * notes to append to. Notes are loaded fresh each time the dialog opens so the
+ * list reflects edits made elsewhere.
+ */
+export function SaveToNoteDialog({
+  open,
+  onOpenChange,
+  onCreateNew,
+  onSelectExisting,
+}: SaveToNoteDialogProps) {
+  const { t } = useTranslation();
+  const [notes, setNotes] = useState<LocalNoteMeta[]>([]);
+  const [query, setQuery] = useState("");
+  const searchRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    setQuery("");
+    let cancelled = false;
+    void (async () => {
+      try {
+        const list = await listNotes();
+        if (!cancelled) setNotes(list.filter((n) => !n.deletedAt));
+      } catch (e) {
+        console.error("[SaveToNoteDialog] failed to list notes", e);
+        if (!cancelled) setNotes([]);
+      }
+    })();
+    const focusId = window.setTimeout(() => searchRef.current?.focus(), 0);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(focusId);
+    };
+  }, [open]);
+
+  const filtered = useMemo(() => {
+    // Most-recently-updated first, matching the notes sidebar ordering.
+    const sorted = [...notes].sort((a, b) =>
+      a.updatedAt < b.updatedAt ? 1 : a.updatedAt > b.updatedAt ? -1 : 0,
+    );
+    const q = query.trim().toLowerCase();
+    if (!q) return sorted;
+    return sorted.filter((n) => (n.title || "").toLowerCase().includes(q));
+  }, [notes, query]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle>{t("saveToNote.title")}</DialogTitle>
+          <DialogDescription>{t("saveToNote.subtitle")}</DialogDescription>
+        </DialogHeader>
+
+        <button
+          type="button"
+          onClick={onCreateNew}
+          className="flex w-full items-center gap-2 rounded-md border border-dashed px-3 py-2.5 text-sm font-medium transition-colors hover:bg-accent"
+        >
+          <FilePlus2 className="h-4 w-4" />
+          {t("saveToNote.createNew")}
+        </button>
+
+        <div className="flex items-center gap-2 text-xs text-muted-foreground">
+          <span className="h-px flex-1 bg-border" />
+          {t("saveToNote.orExisting")}
+          <span className="h-px flex-1 bg-border" />
+        </div>
+
+        <div className="relative">
+          <Search className="pointer-events-none absolute left-2.5 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            ref={searchRef}
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder={t("saveToNote.searchPlaceholder")}
+            aria-label={t("saveToNote.searchPlaceholder")}
+            autoComplete="off"
+            className="pl-8"
+          />
+        </div>
+
+        <div className="-mx-1 max-h-60 space-y-0.5 overflow-y-auto px-1">
+          {notes.length === 0 ? (
+            <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+              {t("saveToNote.empty")}
+            </p>
+          ) : filtered.length === 0 ? (
+            <p className="px-2 py-6 text-center text-sm text-muted-foreground">
+              {t("saveToNote.noResults")}
+            </p>
+          ) : (
+            filtered.map((note) => (
+              <button
+                key={note.id}
+                type="button"
+                onClick={() => onSelectExisting(note)}
+                className="flex w-full items-center gap-2 rounded-md px-2.5 py-2 text-left text-sm transition-colors hover:bg-accent"
+              >
+                <FileText className="h-4 w-4 shrink-0 text-muted-foreground" />
+                <span className="truncate">
+                  {note.title || t("notes.editor.untitled")}
+                </span>
+              </button>
+            ))
+          )}
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/dashboard/transcription/TranscriptionDetails.tsx
+++ b/src/components/dashboard/transcription/TranscriptionDetails.tsx
@@ -17,18 +17,32 @@ import {
   ChevronRight,
   Pin,
   PinOff,
+  NotebookPen,
 } from "lucide-react";
+import { toast } from "sonner";
 import type { Transcription } from "@/hooks/useTranscriptionHistory";
 import { useSettings } from "@/hooks/useSettings";
 import { invoke } from "@tauri-apps/api/core";
 import { useDateFormatters } from "@/lib/date-format";
 import { useCopyToClipboard } from "@/hooks/useCopyToClipboard";
+import type { LocalNoteMeta } from "@/lib/sync/types";
+import {
+  createNoteFromTranscription,
+  appendTranscriptionToNote,
+  NoteTooLargeError,
+} from "@/lib/notes/transcription-note-actions";
+import { SaveToNoteDialog } from "./SaveToNoteDialog";
 
 interface TranscriptionDetailsProps {
   transcription: Transcription | null;
   onClose: () => void;
   onDelete?: (id: string) => void;
   onTogglePin?: (id: string) => void | Promise<void>;
+  /** Open a note (by id) in the Notes view — wired to the "Ouvrir" toast action. */
+  onOpenNote?: (noteId: string) => void;
+  /** Called after a transcription is saved to a note, so the caller can refresh
+   *  its notes list (the new / updated note appears in the sidebar). */
+  onNotesMutated?: () => void;
   compact?: boolean;
 }
 
@@ -92,6 +106,8 @@ export function TranscriptionDetails({
   onClose,
   onDelete,
   onTogglePin,
+  onOpenNote,
+  onNotesMutated,
   compact = false,
 }: TranscriptionDetailsProps) {
   const { t } = useTranslation();
@@ -104,6 +120,7 @@ export function TranscriptionDetails({
   const [isLoading, setIsLoading] = useState(false);
   const [showOriginal, setShowOriginal] = useState(false);
   const [playbackProgress, setPlaybackProgress] = useState(0);
+  const [saveToNoteOpen, setSaveToNoteOpen] = useState(false);
 
   const stopPlayback = useCallback(() => {
     if (audioRef.current) {
@@ -249,6 +266,49 @@ export function TranscriptionDetails({
     (transcription.apiCost ?? 0) + (transcription.postProcessCost ?? 0);
   const words = wordsOf(transcription.text);
   const wpm = durationSec > 0 ? Math.round(words / (durationSec / 60)) : 0;
+
+  const openNoteToast = (noteId: string) =>
+    onOpenNote
+      ? {
+          action: {
+            label: t("saveToNote.open"),
+            onClick: () => onOpenNote(noteId),
+          },
+        }
+      : undefined;
+
+  const handleCreateNote = async () => {
+    try {
+      const meta = await createNoteFromTranscription(transcription.text);
+      setSaveToNoteOpen(false);
+      onNotesMutated?.();
+      toast.success(t("saveToNote.created"), openNoteToast(meta.id));
+    } catch (e) {
+      console.error("[TranscriptionDetails] create note failed", e);
+      toast.error(t("saveToNote.createFailed"));
+    }
+  };
+
+  const handleAppendToNote = async (note: LocalNoteMeta) => {
+    try {
+      await appendTranscriptionToNote(note.id, transcription.text);
+      setSaveToNoteOpen(false);
+      onNotesMutated?.();
+      toast.success(
+        t("saveToNote.added", {
+          title: note.title || t("notes.editor.untitled"),
+        }),
+        openNoteToast(note.id),
+      );
+    } catch (e) {
+      if (e instanceof NoteTooLargeError) {
+        toast.error(t("saveToNote.tooLarge"));
+      } else {
+        console.error("[TranscriptionDetails] append to note failed", e);
+        toast.error(t("saveToNote.addFailed"));
+      }
+    }
+  };
 
   return (
     <div className="vt-card-sectioned vt-fade-up overflow-hidden" key={transcription.id}>
@@ -586,6 +646,14 @@ export function TranscriptionDetails({
         <button
           type="button"
           className="vt-btn"
+          onClick={() => setSaveToNoteOpen(true)}
+        >
+          <NotebookPen className="w-3.5 h-3.5" />
+          <span>{t("saveToNote.trigger")}</span>
+        </button>
+        <button
+          type="button"
+          className="vt-btn"
           disabled
           data-tip={t("transcriptionDetails.exportComingSoon")}
         >
@@ -662,6 +730,13 @@ export function TranscriptionDetails({
           {t("transcriptionDetails.previewDisabledHelp")}
         </div>
       )}
+
+      <SaveToNoteDialog
+        open={saveToNoteOpen}
+        onOpenChange={setSaveToNoteOpen}
+        onCreateNew={handleCreateNote}
+        onSelectExisting={handleAppendToNote}
+      />
     </div>
   );
 }

--- a/src/lib/notes/transcription-note-actions.test.ts
+++ b/src/lib/notes/transcription-note-actions.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the Tauri-backed notes store (hoisted so the factory can reference it).
+const { createNoteSynced, readNote, updateNoteSynced } = vi.hoisted(() => ({
+  createNoteSynced: vi.fn(),
+  readNote: vi.fn(),
+  updateNoteSynced: vi.fn(),
+}));
+vi.mock("@/lib/sync/notes-store", () => ({
+  createNoteSynced,
+  readNote,
+  updateNoteSynced,
+}));
+
+// deriveTitle lives in the notes hook (pulls React / i18n) — stub it so this
+// stays a pure unit test of the orchestration.
+vi.mock("@/hooks/useNotes", () => ({
+  deriveTitle: (html: string) => `title:${html}`,
+}));
+
+import {
+  createNoteFromTranscription,
+  appendTranscriptionToNote,
+  NoteTooLargeError,
+} from "./transcription-note-actions";
+import { NOTE_SIZE_LIMIT_BYTES } from "@/lib/sync/note-size";
+
+beforeEach(() => {
+  createNoteSynced.mockReset();
+  readNote.mockReset();
+  updateNoteSynced.mockReset();
+});
+
+describe("createNoteFromTranscription", () => {
+  it("creates a note, then writes the transcription HTML + derived title", async () => {
+    createNoteSynced.mockResolvedValue({ id: "n1", title: "" });
+    updateNoteSynced.mockImplementation(async (id: string, _c: string, title: string) => ({
+      id,
+      title,
+    }));
+
+    const meta = await createNoteFromTranscription("Bonjour");
+
+    expect(createNoteSynced).toHaveBeenCalledWith(null);
+    expect(updateNoteSynced).toHaveBeenCalledWith(
+      "n1",
+      "<p>Bonjour</p>",
+      "title:<p>Bonjour</p>",
+    );
+    expect(meta).toEqual({ id: "n1", title: "title:<p>Bonjour</p>" });
+  });
+});
+
+describe("appendTranscriptionToNote", () => {
+  it("appends paragraph(s) and preserves the existing title", async () => {
+    readNote.mockResolvedValue({
+      meta: { id: "n1", title: "Mon titre" },
+      content: "<p>existant</p>",
+    });
+    updateNoteSynced.mockImplementation(
+      async (id: string, content: string, title: string) => ({ id, content, title }),
+    );
+
+    await appendTranscriptionToNote("n1", "ajout");
+
+    expect(updateNoteSynced).toHaveBeenCalledWith(
+      "n1",
+      "<p>existant</p><p>ajout</p>",
+      "Mon titre",
+    );
+  });
+
+  it("throws NoteTooLargeError and writes nothing when over the 1 MB cap", async () => {
+    const huge = "x".repeat(NOTE_SIZE_LIMIT_BYTES);
+    readNote.mockResolvedValue({
+      meta: { id: "n1", title: "t" },
+      content: `<p>${huge}</p>`,
+    });
+
+    await expect(appendTranscriptionToNote("n1", "more")).rejects.toBeInstanceOf(
+      NoteTooLargeError,
+    );
+    expect(updateNoteSynced).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/notes/transcription-note-actions.ts
+++ b/src/lib/notes/transcription-note-actions.ts
@@ -1,0 +1,66 @@
+/**
+ * Orchestration for "transcription → note": create a brand-new note from a
+ * transcription, or append a transcription to an existing note.
+ *
+ * Routes every write through the `*Synced` notes-store wrappers so the change
+ * enqueues a cloud upsert when sync is active (and is safely skipped when the
+ * note is over the 1 MB cap — see notes-store). The pure HTML construction
+ * lives in transcription-to-note.ts and is unit-tested there; this module only
+ * wires it to the Tauri-backed store, so it stays intentionally thin.
+ */
+import type { LocalNoteMeta } from "@/lib/sync/types";
+import {
+  createNoteSynced,
+  readNote,
+  updateNoteSynced,
+} from "@/lib/sync/notes-store";
+import { isNoteSyncable } from "@/lib/sync/note-size";
+import { deriveTitle } from "@/hooks/useNotes";
+import {
+  transcriptionToHtml,
+  appendTranscriptionToHtml,
+} from "./transcription-to-note";
+
+/**
+ * Thrown by {@link appendTranscriptionToNote} when the resulting note would
+ * exceed the 1 MB per-note sync hard cap. The note is left untouched; the
+ * caller surfaces a localized message.
+ */
+export class NoteTooLargeError extends Error {
+  constructor() {
+    super("note would exceed the 1 MB per-note sync cap");
+    this.name = "NoteTooLargeError";
+  }
+}
+
+/**
+ * Create a new note seeded with `text`. The title is derived from the first
+ * line, matching how titles are computed everywhere else in the app. Returns
+ * the persisted note meta.
+ */
+export async function createNoteFromTranscription(
+  text: string,
+): Promise<LocalNoteMeta> {
+  const html = transcriptionToHtml(text);
+  const title = deriveTitle(html);
+  const meta = await createNoteSynced(null);
+  return updateNoteSynced(meta.id, html, title);
+}
+
+/**
+ * Append `text` to the note `noteId` as new paragraph(s). The note's title is
+ * preserved (appending at the end never changes the first line). Throws
+ * {@link NoteTooLargeError} when the append would push the note past the 1 MB
+ * sync cap — in that case the note is left unchanged.
+ */
+export async function appendTranscriptionToNote(
+  noteId: string,
+  text: string,
+): Promise<LocalNoteMeta> {
+  const { meta, content } = await readNote(noteId);
+  const next = appendTranscriptionToHtml(content, text);
+  if (!isNoteSyncable(next)) {
+    throw new NoteTooLargeError();
+  }
+  return updateNoteSynced(noteId, next, meta.title);
+}

--- a/src/lib/notes/transcription-to-note.test.ts
+++ b/src/lib/notes/transcription-to-note.test.ts
@@ -1,0 +1,80 @@
+import { describe, it, expect } from "vitest";
+import {
+  escapeNoteHtml,
+  transcriptionToHtml,
+  appendTranscriptionToHtml,
+} from "./transcription-to-note";
+
+describe("escapeNoteHtml", () => {
+  it("escapes the three HTML-significant characters", () => {
+    expect(escapeNoteHtml("a & b < c > d")).toBe("a &amp; b &lt; c &gt; d");
+  });
+
+  it("escapes & first so angle brackets are not double-escaped", () => {
+    expect(escapeNoteHtml("<tag>")).toBe("&lt;tag&gt;");
+    expect(escapeNoteHtml("a & <b>")).toBe("a &amp; &lt;b&gt;");
+  });
+
+  it("leaves accented plain text untouched", () => {
+    expect(escapeNoteHtml("Bonjour, ça va ?")).toBe("Bonjour, ça va ?");
+  });
+});
+
+describe("transcriptionToHtml", () => {
+  it("wraps a single line in a paragraph", () => {
+    expect(transcriptionToHtml("Bonjour le monde")).toBe(
+      "<p>Bonjour le monde</p>",
+    );
+  });
+
+  it("escapes HTML within the text", () => {
+    expect(transcriptionToHtml("1 < 2 & 3 > 0")).toBe(
+      "<p>1 &lt; 2 &amp; 3 &gt; 0</p>",
+    );
+  });
+
+  it("creates one paragraph per non-empty line", () => {
+    expect(transcriptionToHtml("ligne 1\nligne 2")).toBe(
+      "<p>ligne 1</p><p>ligne 2</p>",
+    );
+  });
+
+  it("drops blank lines and trims surrounding whitespace", () => {
+    expect(transcriptionToHtml("  a  \n\n   \n b ")).toBe("<p>a</p><p>b</p>");
+  });
+
+  it("handles CRLF line endings", () => {
+    expect(transcriptionToHtml("a\r\nb")).toBe("<p>a</p><p>b</p>");
+  });
+
+  it("returns an empty paragraph for empty / whitespace-only input", () => {
+    expect(transcriptionToHtml("")).toBe("<p></p>");
+    expect(transcriptionToHtml("   \n  ")).toBe("<p></p>");
+  });
+});
+
+describe("appendTranscriptionToHtml", () => {
+  it("appends paragraphs after existing content", () => {
+    expect(appendTranscriptionToHtml("<p>déjà là</p>", "nouveau")).toBe(
+      "<p>déjà là</p><p>nouveau</p>",
+    );
+  });
+
+  it("returns only the addition when the note is empty", () => {
+    expect(appendTranscriptionToHtml("", "premier")).toBe("<p>premier</p>");
+    expect(appendTranscriptionToHtml("   ", "premier")).toBe("<p>premier</p>");
+  });
+
+  it("preserves order across multiple appends", () => {
+    let html = appendTranscriptionToHtml("", "un");
+    html = appendTranscriptionToHtml(html, "deux");
+    html = appendTranscriptionToHtml(html, "trois");
+    expect(html).toBe("<p>un</p><p>deux</p><p>trois</p>");
+  });
+
+  it("escapes appended text", () => {
+    expect(appendTranscriptionToHtml("<p>x</p>", "a & b")).toBe(
+      "<p>x</p><p>a &amp; b</p>",
+    );
+  });
+});

--- a/src/lib/notes/transcription-to-note.ts
+++ b/src/lib/notes/transcription-to-note.ts
@@ -1,0 +1,47 @@
+/**
+ * Pure helpers that turn a plain-text transcription into note HTML.
+ *
+ * Notes are stored as TipTap-compatible HTML (`content_html`), while a
+ * transcription is plain text (often a single line). These helpers wrap the
+ * text into paragraph markup and escape every HTML-significant character so a
+ * dictated string can never inject markup into a note.
+ *
+ * Deliberately free of React / Tauri imports so the conversion logic stays
+ * unit-testable in isolation (see transcription-to-note.test.ts). The Tauri-
+ * backed orchestration (create / append against the notes store) lives in
+ * transcription-note-actions.ts.
+ */
+
+/** Escape the three HTML-significant characters for safe embedding in note HTML. */
+export function escapeNoteHtml(text: string): string {
+  return text
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
+}
+
+/**
+ * Convert a plain transcription into paragraph HTML: each non-empty line
+ * becomes its own `<p>`, blank lines are dropped, and each line is trimmed.
+ * An empty / whitespace-only input yields a single empty paragraph so the
+ * resulting note is never malformed.
+ */
+export function transcriptionToHtml(text: string): string {
+  const lines = text
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+  if (lines.length === 0) return "<p></p>";
+  return lines.map((line) => `<p>${escapeNoteHtml(line)}</p>`).join("");
+}
+
+/**
+ * Append a transcription to an existing note's HTML as new paragraph(s).
+ * When the note is empty (or whitespace only), returns just the transcription
+ * markup so the note never starts with a stray empty paragraph.
+ */
+export function appendTranscriptionToHtml(existing: string, text: string): string {
+  const addition = transcriptionToHtml(text);
+  const base = (existing ?? "").trim();
+  return base.length > 0 ? `${base}${addition}` : addition;
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -297,6 +297,22 @@
     "back": "Back",
     "backToList": "Back to list"
   },
+  "saveToNote": {
+    "trigger": "To a note…",
+    "title": "Save to a note",
+    "subtitle": "Create a new note or add this dictation to an existing one.",
+    "createNew": "Create a new note",
+    "orExisting": "or add to an existing note",
+    "searchPlaceholder": "Search a note…",
+    "empty": "No notes yet",
+    "noResults": "No matching note",
+    "created": "Note created",
+    "added": "Added to “{{title}}”",
+    "open": "Open",
+    "tooLarge": "The note would exceed the maximum size (1 MB).",
+    "createFailed": "Couldn't create the note.",
+    "addFailed": "Couldn't add to the note."
+  },
   "settings": {
     "loading": "Loading settings...",
     "quitApp": "Close the application completely",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -297,6 +297,22 @@
     "back": "Retour",
     "backToList": "Retour à la liste"
   },
+  "saveToNote": {
+    "trigger": "Vers une note…",
+    "title": "Enregistrer dans une note",
+    "subtitle": "Crée une nouvelle note ou ajoute cette dictée à une note existante.",
+    "createNew": "Créer une nouvelle note",
+    "orExisting": "ou ajouter à une note existante",
+    "searchPlaceholder": "Rechercher une note…",
+    "empty": "Aucune note pour l'instant",
+    "noResults": "Aucune note ne correspond",
+    "created": "Note créée",
+    "added": "Ajouté à « {{title}} »",
+    "open": "Ouvrir",
+    "tooLarge": "La note dépasserait la taille maximale (1 Mo).",
+    "createFailed": "Impossible de créer la note.",
+    "addFailed": "Impossible d'ajouter à la note."
+  },
   "settings": {
     "loading": "Chargement des paramètres...",
     "quitApp": "Fermer complètement l'application",


### PR DESCRIPTION
## Résumé

Permet de transformer une dictée de l'historique en **note**, ou de l'**ajouter à une note existante** — sans jamais quitter le flux clavier habituel pour l'usage, et entièrement configurable depuis le panneau de détail d'une transcription.

Un seul point d'entrée : un bouton **« Vers une note… »** dans la barre d'actions de `TranscriptionDetails`. Il ouvre un dialog qui propose :
- **Créer une nouvelle note** (titre dérivé de la première ligne), puis
- une **liste recherchable des notes existantes** pour y **ajouter** la dictée à la fin.

Un toast de succès propose une action **« Ouvrir »** qui bascule sur la vue Notes et ouvre la note concernée.

## Pourquoi c'est propre

- Écritures routées via les wrappers `*Synced` du store de notes → **enqueue sync LWW** quand la sync est active, **respect du cap 1 Mo par note** (une dictée qui ferait dépasser la limite est bloquée avec un message clair, jamais d'empoisonnement du batch de push).
- Titre dérivé via `deriveTitle` (même logique que partout ailleurs) — pas de duplication.
- Construction HTML **pure et isolée** (`transcription-to-note.ts`, sans React/Tauri) → testable unitairement ; échappement systématique de `& < >` sur le texte dicté.
- **100 % i18n** (FR + EN), aucune string en dur.

## Fichiers

**Nouveaux**
- `src/lib/notes/transcription-to-note.ts` — helpers purs (escape, HTML, append)
- `src/lib/notes/transcription-note-actions.ts` — orchestration via le store (create / append, `NoteTooLargeError`)
- `src/components/dashboard/transcription/SaveToNoteDialog.tsx` — picker (créer / rechercher / ajouter)
- 2 fichiers de tests Vitest

**Modifiés**
- `TranscriptionDetails.tsx` (bouton + dialog + toasts ; props `onOpenNote`, `onNotesMutated`)
- `HistoriqueTab.tsx` (propagation des props)
- `Dashboard.tsx` (ouverture de la note + refresh de la liste)
- `src/locales/{fr,en}.json` (section `saveToNote`)
- `CHANGELOG.md`

## Vérifications

- ✅ `pnpm test` — **360/360** (dont **16** nouveaux pour ce code)
- ✅ `pnpm exec tsc --noEmit` — exit 0
- ✅ `pnpm build` (tsc + vite) — exit 0
- ⚙️ Aucun changement Rust, **aucune migration Supabase** (les notes se synchronisent déjà).

## À tester à la main (non automatisable sans app live)

- Bouton « Vers une note… » → créer une nouvelle note, vérifier le contenu + le titre.
- Ajouter à une note existante (recherche dans le picker) → la dictée se colle à la fin.
- Toast « Ouvrir » → bascule sur la vue Notes et ouvre la bonne note.
- Avec la sync activée : la note créée/modifiée remonte bien côté cloud.

🤖 Generated with [Claude Code](https://claude.com/claude-code)