### PR TITLE
feat: improve onboarding — mic picker, skip button, and guided tour

### DIFF
--- a/docs/superpowers/plans/2026-06-28-onboarding-improvements.md
+++ b/docs/superpowers/plans/2026-06-28-onboarding-improvements.md
@@ -1,0 +1,1040 @@
+# Onboarding Improvements Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make first-run clearer by adding a microphone picker + skip button to the wizard's demo step, and add a one-pass guided tour (coach marks) that explains the main UI after onboarding.
+
+**Architecture:** Two independent workstreams. (A) Small edits to `TryItStep` + `OnboardingFlow`. (B) A custom, dependency-free guided-tour engine: a pure `useGuidedTour` hook (testable sequencing) + a `GuidedTour` portal component (spotlight via a giant `box-shadow`, bubble styled with `.vt-app` tokens), driven by a declarative `TOUR_STEPS` list anchored to `data-tour` attributes on always-visible Accueil-tab elements. A new `tour_pending` settings flag (default `false`) triggers the tour exactly once after a fresh wizard completion.
+
+**Tech Stack:** React 19, TypeScript, Tailwind v4 + `.vt-app` OKLCH tokens, Radix primitives, react-i18next, Vitest + jsdom, Tauri (`get_audio_devices` command already exists).
+
+## Global Constraints
+
+- No new runtime dependency (custom tour engine; reuse Radix + existing UI primitives).
+- Never break existing dependencies/features (no `cargo update`, no feature flag changes).
+- No hardcoded UI strings — every visible string goes through react-i18next, in **both** `fr` and `en`.
+- i18n namespaces (verified): tour strings + replay button → **default** namespace files `src/locales/fr.json` + `src/locales/en.json` under a top-level `tour` key. Mic-picker label + skip link → **billing** namespace files `src/locales/fr/billing.json` + `src/locales/en/billing.json` under `welcome.try.*`.
+- `tour_pending` defaults to `false` so existing beta users never get a surprise tour on update.
+- The tour must not drive tab navigation; it only points at elements always visible on the Accueil tab.
+- Branch: `feat/onboarding-improvements` (already created). Never commit to `main`.
+- Test command: `pnpm test` (= `vitest run`); single file: `pnpm test <path>`. Typecheck: `pnpm exec tsc --noEmit`. Full build: `pnpm build`.
+- Commit style: conventional commits, English (`feat:`, `test:`, `chore:`...).
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `src/components/onboarding/steps/TryItStep.tsx` | (modify) mic picker + skip link | 1 |
+| `src/components/onboarding/OnboardingFlow.tsx` | (modify) wire `onSkip`; set `tour_pending` on complete | 1, 6 |
+| `src/locales/fr/billing.json`, `src/locales/en/billing.json` | (modify) `welcome.try.device_*` + `welcome.try.cta_skip` | 1 |
+| `src/lib/settings.ts` | (modify) add `tour_pending` flag + default | 2 |
+| `src/lib/settings.test.ts` | (create) lock the `tour_pending=false` default | 2 |
+| `src/hooks/useGuidedTour.ts` | (create) pure step sequencing | 3 |
+| `src/hooks/useGuidedTour.test.ts` | (create) sequencing tests | 3 |
+| `src/components/onboarding/tour/tourSteps.ts` | (create) `TOUR_STEPS` + `shouldShowGuidedTour` | 4 |
+| `src/components/onboarding/tour/tourSteps.test.ts` | (create) steps shape + trigger truth table | 4 |
+| `src/locales/fr.json`, `src/locales/en.json` | (modify) `tour.*` keys | 4, 6 |
+| `src/components/onboarding/tour/GuidedTour.tsx` | (create) portal spotlight + bubble | 5 |
+| `src/components/onboarding/tour/GuidedTour.test.tsx` | (create) smoke + skip test | 5 |
+| `src/components/dashboard/home/HeroDictationCard.tsx` | (modify) `data-tour="hero-dictation"` | 6 |
+| `src/components/dashboard/DashboardSidebar.tsx` | (modify) `data-tour` on nav buttons + profile wrapper | 6 |
+| `src/components/Dashboard.tsx` | (modify) mount `GuidedTour` behind the trigger gate | 6 |
+| `src/components/settings/sections/AppearanceSection.tsx` | (modify) "Replay tour" button | 6 |
+
+---
+
+## Task 1: Wizard — microphone picker + skip button (workstream A)
+
+Independent of the tour; can ship first. Adds a device `Select` to the demo step and a "Skip this step" link that jumps to the cloud-vs-local Choice step (without escaping the wizard).
+
+**Files:**
+- Modify: `src/components/onboarding/steps/TryItStep.tsx`
+- Modify: `src/components/onboarding/OnboardingFlow.tsx`
+- Modify: `src/locales/fr/billing.json`, `src/locales/en/billing.json`
+
+**Interfaces:**
+- Consumes: `useAudioDevices()` → `{ devices: { name: string; index: number; is_default: boolean }[] }`; `useSettings()` → `{ settings, updateSetting }`; existing `Select*` from `@/components/ui/select`.
+- Produces: `TryItStep` gains a required `onSkip: () => void` prop.
+
+- [ ] **Step 1: Add the i18n keys (billing namespace, both languages)**
+
+In `src/locales/fr/billing.json`, inside the existing `"welcome": { "try": { ... } }` object, add:
+
+```json
+"device_label": "Microphone",
+"device_default": "Périphérique par défaut",
+"cta_skip": "Passer cette étape"
+```
+
+In `src/locales/en/billing.json`, inside `welcome.try`, add:
+
+```json
+"device_label": "Microphone",
+"device_default": "Default device",
+"cta_skip": "Skip this step"
+```
+
+- [ ] **Step 2: Add `onSkip` to the props and import the picker deps**
+
+In `src/components/onboarding/steps/TryItStep.tsx`, update the imports and props:
+
+```tsx
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { useAudioDevices } from "@/hooks/useAudioDevices";
+```
+
+Change the props interface and destructuring:
+
+```tsx
+interface TryItStepProps {
+  onCloud: () => void;
+  onLocal: () => void;
+  onBack: () => void;
+  onSkip: () => void;
+}
+
+export function TryItStep({ onCloud, onLocal, onBack, onSkip }: TryItStepProps) {
+  const { t, i18n } = useTranslation("billing");
+  const { settings, updateSetting } = useSettings();
+  const { devices } = useAudioDevices();
+```
+
+- [ ] **Step 3: Render the device picker above the demo card**
+
+Still in `TryItStep.tsx`, add this block immediately after the closing `</div>` of the title section (the `<div className="space-y-2 text-center">…</div>`) and before the demo card `<div className="flex min-h-[220px] …">`:
+
+```tsx
+{(phase.status === "idle" || phase.status === "error") && devices.length > 0 && (
+  <div className="mx-auto flex w-full max-w-xs flex-col gap-1.5">
+    <label
+      className="text-xs font-medium"
+      style={{ color: "var(--vt-fg-3)" }}
+    >
+      {t("welcome.try.device_label")}
+    </label>
+    <Select
+      value={
+        settings.input_device_index == null
+          ? "default"
+          : String(settings.input_device_index)
+      }
+      onValueChange={(val) =>
+        void updateSetting(
+          "input_device_index",
+          val === "default" ? null : Number(val),
+        )
+      }
+    >
+      <SelectTrigger className="w-full">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="default">
+          {t("welcome.try.device_default")}
+        </SelectItem>
+        {devices.map((d) => (
+          <SelectItem key={d.index} value={String(d.index)}>
+            {d.name}
+          </SelectItem>
+        ))}
+      </SelectContent>
+    </Select>
+  </div>
+)}
+```
+
+- [ ] **Step 4: Add the "Skip this step" link to the idle footer**
+
+Still in `TryItStep.tsx`, replace the `idle`-state footer block:
+
+```tsx
+{phase.status === "idle" && (
+  <div className="flex items-center justify-between gap-3">
+    <Button variant="ghost" onClick={onBack} className="gap-2">
+      <ArrowLeft className="h-4 w-4" />
+      {t("welcome.try.cta_back")}
+    </Button>
+  </div>
+)}
+```
+
+with:
+
+```tsx
+{phase.status === "idle" && (
+  <div className="flex items-center justify-between gap-3">
+    <Button variant="ghost" onClick={onBack} className="gap-2">
+      <ArrowLeft className="h-4 w-4" />
+      {t("welcome.try.cta_back")}
+    </Button>
+    <button
+      type="button"
+      onClick={onSkip}
+      className="text-sm underline-offset-4 hover:underline"
+      style={{ color: "var(--vt-fg-3)" }}
+    >
+      {t("welcome.try.cta_skip")}
+    </button>
+  </div>
+)}
+```
+
+- [ ] **Step 5: Wire `onSkip` in `OnboardingFlow`**
+
+In `src/components/onboarding/OnboardingFlow.tsx`, update the step-3 render:
+
+```tsx
+{step === 3 && (
+  <TryItStep
+    onBack={() => setStep(2)}
+    onCloud={handleCloud}
+    onLocal={handleLocal}
+    onSkip={() => setStep(4)}
+  />
+)}
+```
+
+- [ ] **Step 6: Typecheck**
+
+Run: `pnpm exec tsc --noEmit`
+Expected: PASS (no errors).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/components/onboarding/steps/TryItStep.tsx src/components/onboarding/OnboardingFlow.tsx src/locales/fr/billing.json src/locales/en/billing.json
+git commit -m "feat: add mic picker and skip button to onboarding demo step"
+```
+
+---
+
+## Task 2: Settings — `tour_pending` flag (workstream B foundation)
+
+**Files:**
+- Modify: `src/lib/settings.ts:76-77` (interface), `src/lib/settings.ts:159-160` (defaults)
+- Create: `src/lib/settings.test.ts`
+
+**Interfaces:**
+- Produces: `AppSettings["settings"].tour_pending: boolean` (default `false`).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/lib/settings.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { DEFAULT_SETTINGS, mergeSettings } from "./settings";
+
+describe("tour_pending setting", () => {
+  it("defaults to false so existing users get no surprise tour on update", () => {
+    expect(DEFAULT_SETTINGS.settings.tour_pending).toBe(false);
+  });
+
+  it("mergeSettings preserves an explicit tour_pending=true", () => {
+    const merged = mergeSettings({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { tour_pending: true } as any,
+    });
+    expect(merged.settings.tour_pending).toBe(true);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test src/lib/settings.test.ts`
+Expected: FAIL — `DEFAULT_SETTINGS.settings.tour_pending` is `undefined`.
+
+- [ ] **Step 3: Add the flag to the interface**
+
+In `src/lib/settings.ts`, in the `// Onboarding` block of the interface:
+
+```ts
+    // Onboarding
+    onboarding_completed: boolean;
+    /** True for exactly one fresh wizard completion → triggers the guided tour once. */
+    tour_pending: boolean;
+```
+
+- [ ] **Step 4: Add the default**
+
+In `src/lib/settings.ts`, in the `// Onboarding` block of `DEFAULT_SETTINGS.settings`:
+
+```ts
+    // Onboarding
+    onboarding_completed: false,
+    tour_pending: false,
+```
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `pnpm test src/lib/settings.test.ts`
+Expected: PASS (2 passing).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/lib/settings.ts src/lib/settings.test.ts
+git commit -m "feat: add tour_pending settings flag for guided tour trigger"
+```
+
+---
+
+## Task 3: `useGuidedTour` hook (pure sequencing)
+
+**Files:**
+- Create: `src/hooks/useGuidedTour.ts`
+- Create: `src/hooks/useGuidedTour.test.ts`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  interface GuidedTourController {
+    index: number; total: number;
+    isFirst: boolean; isLast: boolean;
+    next: () => void; prev: () => void; reset: () => void;
+  }
+  function useGuidedTour(total: number, onFinish: () => void): GuidedTourController
+  ```
+  `next()` past the last step calls `onFinish()` and clamps; `prev()` clamps at 0.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/hooks/useGuidedTour.test.ts`:
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useGuidedTour } from "./useGuidedTour";
+
+describe("useGuidedTour", () => {
+  it("starts at index 0", () => {
+    const { result } = renderHook(() => useGuidedTour(3, vi.fn()));
+    expect(result.current.index).toBe(0);
+    expect(result.current.isFirst).toBe(true);
+    expect(result.current.isLast).toBe(false);
+  });
+
+  it("advances with next() and clamps isLast", () => {
+    const { result } = renderHook(() => useGuidedTour(3, vi.fn()));
+    act(() => result.current.next());
+    expect(result.current.index).toBe(1);
+    act(() => result.current.next());
+    expect(result.current.index).toBe(2);
+    expect(result.current.isLast).toBe(true);
+  });
+
+  it("calls onFinish when next() is invoked on the last step and does not overflow", () => {
+    const onFinish = vi.fn();
+    const { result } = renderHook(() => useGuidedTour(2, onFinish));
+    act(() => result.current.next()); // → index 1 (last)
+    act(() => result.current.next()); // → onFinish, stays at 1
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(result.current.index).toBe(1);
+  });
+
+  it("prev() decrements and clamps at 0", () => {
+    const { result } = renderHook(() => useGuidedTour(3, vi.fn()));
+    act(() => result.current.next());
+    act(() => result.current.prev());
+    expect(result.current.index).toBe(0);
+    act(() => result.current.prev());
+    expect(result.current.index).toBe(0);
+  });
+
+  it("reset() returns to 0", () => {
+    const { result } = renderHook(() => useGuidedTour(3, vi.fn()));
+    act(() => result.current.next());
+    act(() => result.current.reset());
+    expect(result.current.index).toBe(0);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test src/hooks/useGuidedTour.test.ts`
+Expected: FAIL — module `./useGuidedTour` not found.
+
+- [ ] **Step 3: Implement the hook**
+
+Create `src/hooks/useGuidedTour.ts`:
+
+```ts
+import { useCallback, useState } from "react";
+
+export interface GuidedTourController {
+  index: number;
+  total: number;
+  isFirst: boolean;
+  isLast: boolean;
+  next: () => void;
+  prev: () => void;
+  reset: () => void;
+}
+
+/**
+ * Pure step-sequencing for the guided tour. Holds the current index and clamps
+ * at both ends. `next()` past the final step triggers `onFinish` (used both for
+ * the "Done" button on the last step and for any auto-advance). All DOM /
+ * positioning concerns live in the GuidedTour presentation layer.
+ */
+export function useGuidedTour(
+  total: number,
+  onFinish: () => void,
+): GuidedTourController {
+  const [index, setIndex] = useState(0);
+
+  const next = useCallback(() => {
+    setIndex((i) => {
+      if (i >= total - 1) {
+        onFinish();
+        return i;
+      }
+      return i + 1;
+    });
+  }, [total, onFinish]);
+
+  const prev = useCallback(() => {
+    setIndex((i) => (i <= 0 ? 0 : i - 1));
+  }, []);
+
+  const reset = useCallback(() => setIndex(0), []);
+
+  return {
+    index,
+    total,
+    isFirst: index === 0,
+    isLast: index === total - 1,
+    next,
+    prev,
+    reset,
+  };
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test src/hooks/useGuidedTour.test.ts`
+Expected: PASS (5 passing).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useGuidedTour.ts src/hooks/useGuidedTour.test.ts
+git commit -m "feat: add useGuidedTour sequencing hook"
+```
+
+---
+
+## Task 4: Tour steps + trigger helper + i18n keys
+
+**Files:**
+- Create: `src/components/onboarding/tour/tourSteps.ts`
+- Create: `src/components/onboarding/tour/tourSteps.test.ts`
+- Modify: `src/locales/fr.json`, `src/locales/en.json`
+
+**Interfaces:**
+- Produces:
+  ```ts
+  interface TourStep { anchor: string | null; titleKey: string; bodyKey: string; placement: "center" | "right" | "bottom" | "top"; }
+  const TOUR_STEPS: TourStep[]   // 6 entries
+  function shouldShowGuidedTour(settingsLoaded: boolean, tourPending: boolean, activeTab: string): boolean
+  ```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/onboarding/tour/tourSteps.test.ts`:
+
+```ts
+import { describe, it, expect } from "vitest";
+import { TOUR_STEPS, shouldShowGuidedTour } from "./tourSteps";
+
+describe("TOUR_STEPS", () => {
+  it("starts with a centered, anchorless welcome step", () => {
+    expect(TOUR_STEPS[0].anchor).toBeNull();
+    expect(TOUR_STEPS[0].placement).toBe("center");
+  });
+
+  it("every step has title and body keys", () => {
+    for (const s of TOUR_STEPS) {
+      expect(s.titleKey).toMatch(/^tour\./);
+      expect(s.bodyKey).toMatch(/^tour\./);
+    }
+  });
+
+  it("includes the four sidebar/hero anchors", () => {
+    const anchors = TOUR_STEPS.map((s) => s.anchor);
+    expect(anchors).toContain("hero-dictation");
+    expect(anchors).toContain("nav-historique");
+    expect(anchors).toContain("nav-notes");
+    expect(anchors).toContain("nav-parametres");
+    expect(anchors).toContain("profile-switcher");
+  });
+});
+
+describe("shouldShowGuidedTour", () => {
+  it("is true only when loaded, pending, and on the accueil tab", () => {
+    expect(shouldShowGuidedTour(true, true, "accueil")).toBe(true);
+  });
+  it("is false when settings not loaded", () => {
+    expect(shouldShowGuidedTour(false, true, "accueil")).toBe(false);
+  });
+  it("is false when not pending", () => {
+    expect(shouldShowGuidedTour(true, false, "accueil")).toBe(false);
+  });
+  it("is false on any other tab", () => {
+    expect(shouldShowGuidedTour(true, true, "parametres")).toBe(false);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test src/components/onboarding/tour/tourSteps.test.ts`
+Expected: FAIL — module `./tourSteps` not found.
+
+- [ ] **Step 3: Implement the steps + helper**
+
+Create `src/components/onboarding/tour/tourSteps.ts`:
+
+```ts
+export interface TourStep {
+  /** `data-tour` anchor id, or null for a centered anchorless step. */
+  anchor: string | null;
+  titleKey: string;
+  bodyKey: string;
+  /** Preferred bubble placement relative to the spotlight. */
+  placement: "center" | "right" | "bottom" | "top";
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  { anchor: null, titleKey: "tour.welcome.title", bodyKey: "tour.welcome.body", placement: "center" },
+  { anchor: "hero-dictation", titleKey: "tour.dictate.title", bodyKey: "tour.dictate.body", placement: "bottom" },
+  { anchor: "nav-historique", titleKey: "tour.history.title", bodyKey: "tour.history.body", placement: "right" },
+  { anchor: "nav-notes", titleKey: "tour.notes.title", bodyKey: "tour.notes.body", placement: "right" },
+  { anchor: "nav-parametres", titleKey: "tour.settings.title", bodyKey: "tour.settings.body", placement: "right" },
+  { anchor: "profile-switcher", titleKey: "tour.account.title", bodyKey: "tour.account.body", placement: "right" },
+];
+
+/**
+ * The tour shows once, on the Accueil tab, after a fresh wizard completion flips
+ * `tour_pending`. Gating on `settingsLoaded` avoids a flash before state is known.
+ */
+export function shouldShowGuidedTour(
+  settingsLoaded: boolean,
+  tourPending: boolean,
+  activeTab: string,
+): boolean {
+  return settingsLoaded && tourPending && activeTab === "accueil";
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test src/components/onboarding/tour/tourSteps.test.ts`
+Expected: PASS (7 passing).
+
+- [ ] **Step 5: Add the `tour.*` i18n keys (French)**
+
+In `src/locales/fr.json`, add a new top-level `"tour"` key:
+
+```json
+"tour": {
+  "next": "Suivant",
+  "prev": "Précédent",
+  "finish": "Terminer",
+  "skip": "Passer le tour",
+  "welcome": {
+    "title": "Bienvenue dans Lexena",
+    "body": "30 secondes pour découvrir l'essentiel. Tu peux passer à tout moment."
+  },
+  "dictate": {
+    "title": "Dicte d'un clic",
+    "body": "Lance l'enregistrement ici — ou depuis n'importe quelle application avec ton raccourci global. Le texte s'insère dans la fenêtre active et une mini-fenêtre flotte pendant la dictée."
+  },
+  "history": {
+    "title": "Ton historique",
+    "body": "Toutes tes transcriptions sont conservées ici, prêtes à être copiées ou transformées en notes."
+  },
+  "notes": {
+    "title": "Tes notes",
+    "body": "Écris, organise en dossiers et relie tes notes entre elles."
+  },
+  "settings": {
+    "title": "Réglages",
+    "body": "Choisis ton micro, ton modèle de transcription et personnalise tes raccourcis ici."
+  },
+  "account": {
+    "title": "Compte & synchro",
+    "body": "Connecte-toi pour synchroniser tes réglages et tes notes dans le cloud, sur tous tes appareils."
+  }
+}
+```
+
+- [ ] **Step 6: Add the `tour.*` i18n keys (English)**
+
+In `src/locales/en.json`, add the matching top-level `"tour"` key:
+
+```json
+"tour": {
+  "next": "Next",
+  "prev": "Back",
+  "finish": "Done",
+  "skip": "Skip tour",
+  "welcome": {
+    "title": "Welcome to Lexena",
+    "body": "30 seconds to learn the essentials. You can skip anytime."
+  },
+  "dictate": {
+    "title": "Dictate in one click",
+    "body": "Start recording here — or from any app with your global shortcut. The text is inserted into the active window and a mini window floats while you dictate."
+  },
+  "history": {
+    "title": "Your history",
+    "body": "Every transcription is kept here, ready to copy or turn into a note."
+  },
+  "notes": {
+    "title": "Your notes",
+    "body": "Write, organize into folders and link your notes together."
+  },
+  "settings": {
+    "title": "Settings",
+    "body": "Choose your microphone, transcription model and customize your shortcuts here."
+  },
+  "account": {
+    "title": "Account & sync",
+    "body": "Sign in to sync your settings and notes to the cloud across all your devices."
+  }
+}
+```
+
+- [ ] **Step 7: Verify JSON parses + tests still pass**
+
+Run: `pnpm exec tsc --noEmit && pnpm test src/components/onboarding/tour/tourSteps.test.ts`
+Expected: PASS. (If `tsc` complains the JSON is malformed, fix the trailing-comma placement where you inserted the `tour` key.)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/components/onboarding/tour/tourSteps.ts src/components/onboarding/tour/tourSteps.test.ts src/locales/fr.json src/locales/en.json
+git commit -m "feat: add guided tour steps, trigger helper and i18n keys"
+```
+
+---
+
+## Task 5: `GuidedTour` presentation component
+
+**Files:**
+- Create: `src/components/onboarding/tour/GuidedTour.tsx`
+- Create: `src/components/onboarding/tour/GuidedTour.test.tsx`
+
+**Interfaces:**
+- Consumes: `useGuidedTour` (Task 3), `TOUR_STEPS` / `TourStep` (Task 4), `Button` from `@/components/ui/button`.
+- Produces: `function GuidedTour({ onFinish }: { onFinish: () => void }): JSX.Element` — a portal overlay. When a step's anchor element is missing it auto-advances via `next()`. Mount it only behind the `shouldShowGuidedTour` gate (Task 6).
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/components/onboarding/tour/GuidedTour.test.tsx`:
+
+```tsx
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { GuidedTour } from "./GuidedTour";
+
+// i18n returns the key verbatim so we can assert on keys, not copy.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+describe("GuidedTour", () => {
+  it("renders the centered welcome step first", () => {
+    render(<GuidedTour onFinish={vi.fn()} />);
+    expect(screen.getByText("tour.welcome.title")).toBeTruthy();
+    expect(screen.getByText("1 / 6")).toBeTruthy();
+  });
+
+  it("calls onFinish when the skip link is clicked", () => {
+    const onFinish = vi.fn();
+    render(<GuidedTour onFinish={onFinish} />);
+    fireEvent.click(screen.getByText("tour.skip"));
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `pnpm test src/components/onboarding/tour/GuidedTour.test.tsx`
+Expected: FAIL — module `./GuidedTour` not found.
+
+- [ ] **Step 3: Implement the component**
+
+Create `src/components/onboarding/tour/GuidedTour.tsx`:
+
+```tsx
+import type { CSSProperties } from "react";
+import { useLayoutEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { useGuidedTour } from "@/hooks/useGuidedTour";
+import { TOUR_STEPS, type TourStep } from "./tourSteps";
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const SPOTLIGHT_PAD = 8;
+const BUBBLE_GAP = 16;
+
+function readRect(anchor: string): Rect | null {
+  const el = document.querySelector<HTMLElement>(`[data-tour="${anchor}"]`);
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { top: r.top, left: r.left, width: r.width, height: r.height };
+}
+
+function bubbleStyle(
+  placement: TourStep["placement"],
+  spot: Rect | null,
+): CSSProperties {
+  if (!spot || placement === "center") {
+    return { top: "50%", left: "50%", transform: "translate(-50%, -50%)" };
+  }
+  switch (placement) {
+    case "right":
+      return { top: spot.top, left: spot.left + spot.width + BUBBLE_GAP };
+    case "bottom":
+      return { top: spot.top + spot.height + BUBBLE_GAP, left: spot.left };
+    case "top":
+      return { top: Math.max(8, spot.top - BUBBLE_GAP), left: spot.left };
+    default:
+      return { top: spot.top, left: spot.left };
+  }
+}
+
+export function GuidedTour({ onFinish }: { onFinish: () => void }) {
+  const { t } = useTranslation();
+  const { index, total, isFirst, isLast, next, prev } = useGuidedTour(
+    TOUR_STEPS.length,
+    onFinish,
+  );
+  const step = TOUR_STEPS[index];
+  const [rect, setRect] = useState<Rect | null>(null);
+
+  // Resolve the anchor rect for the current step. A missing anchor auto-advances
+  // rather than rendering an orphan bubble. Recomputes on window resize.
+  useLayoutEffect(() => {
+    if (step.anchor === null) {
+      setRect(null);
+      return;
+    }
+    const el = document.querySelector<HTMLElement>(
+      `[data-tour="${step.anchor}"]`,
+    );
+    if (!el) {
+      next();
+      return;
+    }
+    el.scrollIntoView({ block: "nearest", inline: "nearest" });
+    const update = () => setRect(readRect(step.anchor as string));
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [step.anchor, next]);
+
+  const spot: Rect | null = rect
+    ? {
+        top: rect.top - SPOTLIGHT_PAD,
+        left: rect.left - SPOTLIGHT_PAD,
+        width: rect.width + SPOTLIGHT_PAD * 2,
+        height: rect.height + SPOTLIGHT_PAD * 2,
+      }
+    : null;
+
+  return createPortal(
+    <div
+      className="vt-app fixed inset-0 z-[60]"
+      role="dialog"
+      aria-modal="true"
+    >
+      {spot ? (
+        <div
+          className="absolute rounded-xl transition-all duration-200"
+          style={{
+            top: spot.top,
+            left: spot.left,
+            width: spot.width,
+            height: spot.height,
+            boxShadow: "0 0 0 9999px rgba(0,0,0,0.6)",
+            pointerEvents: "none",
+          }}
+        />
+      ) : (
+        <div
+          className="absolute inset-0"
+          style={{ background: "rgba(0,0,0,0.6)" }}
+        />
+      )}
+
+      <div
+        className="absolute w-[320px] max-w-[90vw] rounded-xl border p-4 shadow-2xl"
+        style={{
+          ...bubbleStyle(step.placement, spot),
+          background: "var(--vt-panel)",
+          borderColor: "var(--vt-border)",
+          color: "var(--vt-fg)",
+        }}
+      >
+        <h3 className="vt-display text-base font-semibold">{t(step.titleKey)}</h3>
+        <p className="mt-1.5 text-sm" style={{ color: "var(--vt-fg-2)" }}>
+          {t(step.bodyKey)}
+        </p>
+        <div className="mt-4 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onFinish}
+            className="text-xs underline-offset-4 hover:underline"
+            style={{ color: "var(--vt-fg-3)" }}
+          >
+            {t("tour.skip")}
+          </button>
+          <div className="flex items-center gap-2">
+            <span className="text-xs" style={{ color: "var(--vt-fg-3)" }}>
+              {index + 1} / {total}
+            </span>
+            {!isFirst && (
+              <Button variant="outline" size="sm" onClick={prev}>
+                {t("tour.prev")}
+              </Button>
+            )}
+            <Button size="sm" onClick={next}>
+              {isLast ? t("tour.finish") : t("tour.next")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}
+```
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `pnpm test src/components/onboarding/tour/GuidedTour.test.tsx`
+Expected: PASS (2 passing).
+
+> Note: in jsdom the `data-tour` anchors don't exist, so the welcome step (anchorless) renders correctly; the test never advances past it. The auto-advance-on-missing-anchor path is exercised manually in the app.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/onboarding/tour/GuidedTour.tsx src/components/onboarding/tour/GuidedTour.test.tsx
+git commit -m "feat: add GuidedTour spotlight overlay component"
+```
+
+---
+
+## Task 6: Integration — anchors, trigger, replay button
+
+Wires everything together: `data-tour` anchors on real elements, the trigger gate in `Dashboard`, `tour_pending` set on wizard completion, and a "Replay tour" button in Appearance settings. Verification is build + typecheck + the existing unit suite staying green, plus the manual smoke checklist at the end.
+
+**Files:**
+- Modify: `src/components/dashboard/home/HeroDictationCard.tsx:42-49` (root `div`)
+- Modify: `src/components/dashboard/DashboardSidebar.tsx:193-208` (nav button), `:305` (profile wrapper)
+- Modify: `src/components/Dashboard.tsx`
+- Modify: `src/components/onboarding/OnboardingFlow.tsx`
+- Modify: `src/components/settings/sections/AppearanceSection.tsx`
+- Modify: `src/locales/fr.json`, `src/locales/en.json` (replay button keys)
+
+**Interfaces:**
+- Consumes: `GuidedTour` (Task 5), `shouldShowGuidedTour` (Task 4), `useAuth().isAuthModalOpen`, `useSettings().updateSetting`, `settings.tour_pending` (Task 2).
+
+- [ ] **Step 1: Add the hero anchor**
+
+In `src/components/dashboard/home/HeroDictationCard.tsx`, add `data-tour="hero-dictation"` to the root `div` (the one with `className="vt-card-elevated relative overflow-hidden p-6 flex flex-col"`):
+
+```tsx
+    <div
+      data-tour="hero-dictation"
+      className="vt-card-elevated relative overflow-hidden p-6 flex flex-col"
+      style={{
+```
+
+- [ ] **Step 2: Add the sidebar nav anchors**
+
+In `src/components/dashboard/DashboardSidebar.tsx`, on the nav `<button>` inside `visibleNavItems.map(...)`, add the `data-tour` attribute:
+
+```tsx
+            <button
+              key={id}
+              data-tour={`nav-${id}`}
+              onClick={() => onTabChange(id)}
+```
+
+This yields `nav-accueil`, `nav-historique`, `nav-notes`, `nav-parametres`, etc. The tour references `nav-historique`, `nav-notes`, `nav-parametres`.
+
+- [ ] **Step 3: Add the profile-switcher anchor**
+
+In `src/components/dashboard/DashboardSidebar.tsx`, on the wrapper around `<ProfileSwitcher>` (the `<div className="border-t border-border shrink-0 p-2">` near the bottom):
+
+```tsx
+      {/* Profile switcher — always at the very bottom */}
+      <div data-tour="profile-switcher" className="border-t border-border shrink-0 p-2">
+        <ProfileSwitcher
+          collapsed={collapsed}
+          onOpenAccountPage={onOpenAccountPage}
+        />
+      </div>
+```
+
+- [ ] **Step 4: Set `tour_pending` on wizard completion**
+
+In `src/components/onboarding/OnboardingFlow.tsx`, update `markComplete`:
+
+```tsx
+  const markComplete = () => {
+    void updateSetting("onboarding_completed", true);
+    void updateSetting("tour_pending", true);
+  };
+```
+
+- [ ] **Step 5: Mount the tour behind the trigger gate in `Dashboard`**
+
+In `src/components/Dashboard.tsx`:
+
+5a. Add imports:
+
+```tsx
+import { GuidedTour } from "./onboarding/tour/GuidedTour";
+import { shouldShowGuidedTour } from "./onboarding/tour/tourSteps";
+```
+
+5b. Pull `updateSetting` and `isAuthModalOpen`:
+
+```tsx
+  const { settings, isLoaded: settingsLoaded, updateSetting } = useSettings();
+  const { user, status: authStatus, isAuthModalOpen } = useAuth();
+```
+
+5c. Render the tour next to the existing `{showOnboarding && <OnboardingFlow ... />}` line:
+
+```tsx
+      {showOnboarding && <OnboardingFlow onComplete={recheckOnboarding} />}
+
+      {!isAuthModalOpen &&
+        shouldShowGuidedTour(
+          settingsLoaded,
+          settings.tour_pending,
+          activeTab,
+        ) && (
+          <GuidedTour
+            onFinish={() => void updateSetting("tour_pending", false)}
+          />
+        )}
+```
+
+- [ ] **Step 6: Add the replay button to Appearance settings**
+
+6a. In `src/locales/fr.json`, inside the `"tour"` object you created in Task 4, add two keys:
+
+```json
+"replayButton": "Revoir le tour guidé",
+"replayHint": "Relance la visite guidée des fonctionnalités principales."
+```
+
+In `src/locales/en.json`, inside `"tour"`:
+
+```json
+"replayButton": "Replay guided tour",
+"replayHint": "Restart the guided tour of the main features."
+```
+
+6b. In `src/components/settings/sections/AppearanceSection.tsx`, add a `Row` inside the first `vt-card-sectioned` card (the "Interface" card), right after the theme `Row`'s closing tag and before that card's closing `</div>`. The tour only renders on the Accueil tab, so the button sets `tour_pending` and dispatches a dedicated `lexena:start-tour` event (handled in Step 7) to navigate there:
+
+```tsx
+        <Row
+          label={t("tour.replayButton")}
+          hint={t("tour.replayHint")}
+        >
+          <button
+            type="button"
+            className="vt-btn"
+            style={{ height: 36 }}
+            onClick={async () => {
+              await updateSetting("tour_pending", true);
+              window.dispatchEvent(new CustomEvent("lexena:start-tour"));
+            }}
+          >
+            {t("tour.replayButton")}
+          </button>
+        </Row>
+```
+
+- [ ] **Step 7: Handle `lexena:start-tour` in `Dashboard` (switch to Accueil)**
+
+In `src/components/Dashboard.tsx`, add an effect (next to the existing `lexena:open-settings` listener effect) that switches to the Accueil tab when the tour is requested:
+
+```tsx
+  useEffect(() => {
+    const onStartTour = () => setActiveTab("accueil");
+    window.addEventListener("lexena:start-tour", onStartTour);
+    return () => window.removeEventListener("lexena:start-tour", onStartTour);
+  }, []);
+```
+
+- [ ] **Step 8: Typecheck, build, and run the full test suite**
+
+Run: `pnpm exec tsc --noEmit && pnpm test`
+Expected: PASS — typecheck clean, all unit tests green (including the new settings/hook/tour tests and the existing `useOnboardingCheck` suite).
+
+- [ ] **Step 9: Manual smoke (ask the user to run `pnpm tauri dev`)**
+
+Verify, in order:
+1. Fresh profile (or temporarily set `onboarding_completed=false`, `tour_pending=false`): wizard appears.
+2. On the demo step: the **Microphone** dropdown lists devices; changing it persists. The **"Passer cette étape"** link jumps to the cloud-vs-local Choice step.
+3. Complete the wizard (cloud or local). On landing on Accueil, the **guided tour** appears starting at the welcome step.
+4. Next/Back/step counter work; spotlight lands on hero card → Historique → Notes → Paramètres → profile switcher; **Done**/**Skip tour** closes it and it does **not** reappear on reload.
+5. Settings → Appearance → **"Revoir le tour guidé"** returns to Accueil and replays the tour.
+6. Cloud path: while the auth modal is open, the tour does **not** overlap it.
+
+- [ ] **Step 10: Commit**
+
+```bash
+git add src/components/dashboard/home/HeroDictationCard.tsx src/components/dashboard/DashboardSidebar.tsx src/components/Dashboard.tsx src/components/onboarding/OnboardingFlow.tsx src/components/settings/sections/AppearanceSection.tsx src/locales/fr.json src/locales/en.json
+git commit -m "feat: wire guided tour trigger, anchors and replay button"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- A1 mic selector → Task 1 (Steps 2–3). ✓
+- A2 skip button → Task 1 (Steps 4–5). ✓
+- A3 clarity (label) → Task 1 (Step 3, "Microphone" label). ✓
+- B1 `useGuidedTour` → Task 3. ✓
+- B2 `GuidedTour` spotlight/bubble → Task 5. ✓
+- B3 anchors (hero, nav-*, profile) → Task 6 (Steps 1–3). ✓
+- C itinerary (6 steps) → Task 4 `TOUR_STEPS` + i18n. ✓
+- D trigger + `tour_pending` default false + migration safety → Task 2 + Task 6 (Steps 4–5). ✓
+- E replay button in Appearance → Task 6 (Steps 6–7). ✓
+- F i18n (fr+en, both namespaces) + tests → Tasks 1, 3, 4, 5. ✓
+- Edge: missing anchor → auto-advance (Task 5, `useLayoutEffect`). Auth-modal overlap → gated in Task 6 Step 5c. Settings-loading flash → `shouldShowGuidedTour` requires `settingsLoaded`. ✓
+
+**Placeholder scan:** No TBD/TODO; every code step shows complete code. ✓
+
+**Type consistency:** `useGuidedTour(total, onFinish)` signature identical across Tasks 3 and 5. `TourStep` fields (`anchor`/`titleKey`/`bodyKey`/`placement`) identical across Tasks 4 and 5. `shouldShowGuidedTour(settingsLoaded, tourPending, activeTab)` identical across Tasks 4 and 6. `tour_pending` key identical across Tasks 2, 6. The replay button and its `Dashboard` listener both use the `lexena:start-tour` event. ✓

--- a/docs/superpowers/specs/2026-06-28-onboarding-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-28-onboarding-improvements-design.md
@@ -1,0 +1,169 @@
+# Onboarding improvements — design
+
+Date: 2026-06-28
+Status: Draft (pending user review)
+Branch: `feat/onboarding-improvements`
+
+## Problem
+
+The first-run experience has three concrete friction points raised by the product owner:
+
+1. **No microphone choice during the "test mic" step.** The `TryItStep` (the demo
+   recording in the first-run wizard) silently uses the default input device
+   (`settings.input_device_index ?? null`). If the default device is wrong, the
+   user is stuck — there is no picker.
+2. **No way to skip the demo.** In the `idle` state, `TryItStep` only renders a
+   *Back* button. The only path forward without a successful recording is clicking
+   the progress dots to jump to step 4, which is not discoverable. The user
+   perceives this as "I can't pass."
+3. **The app is not self-explanatory after onboarding.** Modern apps surface small
+   contextual pop-ups (coach marks) that point at UI elements and explain what does
+   what. Lexena has none.
+
+## Goals
+
+- Let the user pick their microphone inside the wizard's demo step.
+- Let the user skip the demo (but not escape the wizard's cloud-vs-local choice).
+- Add a guided sequential tour (coach marks) that runs once after onboarding and
+  explains the main UI elements.
+
+## Non-goals
+
+- No redesign of the wizard's overall 4-step structure (hero → capabilities →
+  try-it → choice).
+- No ambient/always-on help icons. The chosen experience is a one-pass guided tour
+  (replayable on demand), not persistent hint badges.
+- No live pre-record level meter in the demo. The existing during-recording bars
+  remain the "is my mic working" feedback; scope stays minimal.
+- The tour does not drive tab navigation. It points only at elements that are
+  always visible on the Accueil tab (hero card + sidebar + profile switcher).
+
+## Decisions (from brainstorming)
+
+| Question | Decision |
+|---|---|
+| Scope | Both: fix wizard frictions **and** add the guided tour. |
+| Mic-test step role | Keep the cloud demo; add a visible mic selector + a Skip button. |
+| Coach-mark style | Guided **sequential** tour (not ambient hints). |
+| Tour engine | **Custom lightweight** (~150–200 lines), built on Radix + `.vt-app` OKLCH tokens. No new dependency. |
+
+## Architecture
+
+Two workstreams, designed together, shippable independently.
+
+### A. Wizard friction fixes (`TryItStep`)
+
+**A1 — Microphone selector.**
+A compact `Select` at the top of the demo card (visible in `idle` and `recording`
+states), populated by the existing `useAudioDevices()` hook (Rust command
+`get_audio_devices`, returns `{ name, index, is_default }[]`). Initial value =
+`settings.input_device_index` (falls back to the default device). On change, persist
+to `settings.input_device_index`, so the choice applies app-wide, not just the demo.
+The existing `handleStart` already reads `settings.input_device_index` — no Rust
+change required.
+
+**A2 — Skip button.**
+A discreet "Passer cette étape" link in the `idle`-state footer that jumps to the
+**Choice** step (step 4) via a new `onSkip` prop wired in `OnboardingFlow`
+(`() => setStep(4)`). This does **not** exit the wizard: the comment in
+`OnboardingFlow` documents that a "hard dismiss" would leave a brand-new user with
+no local model and no account → unusable. Skipping only bypasses the demo; the
+cloud-vs-local choice remains mandatory.
+
+**A3 — Clarity.**
+A small "Micro" label above the selector. No further copy rework.
+
+**Files:** `src/components/onboarding/steps/TryItStep.tsx`,
+`src/components/onboarding/OnboardingFlow.tsx`.
+
+### B. Guided tour engine (custom)
+
+**B1 — `useGuidedTour` hook (all testable logic).**
+Holds the current step index and exposes `next()` / `prev()` / `skip()` /
+`finish()`, with clamping at the bounds and the visible/hidden state. No DOM
+dependency → fully unit-testable.
+
+**B2 — `GuidedTour` component (presentation, via portal).**
+- **Spotlight overlay:** compute `getBoundingClientRect()` of the target element
+  (located by a `data-tour="<id>"` attribute) and cut a "hole" around it using a
+  large `box-shadow` on a positioned div (simple; no SVG mask). Dimmed backdrop
+  elsewhere.
+- **Bubble:** positioned near the target — title, body, step counter ("2 / 6"),
+  *Précédent / Suivant / Terminer* buttons, and a *Passer le tour* link.
+- Recompute the rect on `resize`; `scrollIntoView` the target when needed.
+- Styled entirely with `.vt-app` tokens for visual consistency.
+
+**B3 — Anchors.**
+`data-tour` attributes added to always-visible elements on the Accueil tab:
+`HeroDictationCard`, the sidebar nav buttons (Historique, Notes, Paramètres), and
+`ProfileSwitcher`. The tour stays on the Accueil tab and points at the sidebar — no
+cross-tab orchestration needed, which keeps the engine simple.
+
+**Files:** new `src/components/onboarding/tour/GuidedTour.tsx`,
+`src/hooks/useGuidedTour.ts`, `src/components/onboarding/tour/tourSteps.ts`;
+`data-tour` added to `HeroDictationCard.tsx`, `DashboardSidebar.tsx`,
+`ProfileSwitcher.tsx`; mount in `Dashboard.tsx`.
+
+### C. Tour itinerary (6 steps, Accueil tab)
+
+| # | Anchor (`data-tour`) | Message (summary) |
+|---|---|---|
+| 1 | *(centered, no anchor)* | "Bienvenue dans Lexena — 30 s pour l'essentiel." |
+| 2 | `HeroDictationCard` | "Dicte d'un clic. Le texte s'insère dans l'app active. Lance depuis n'importe où avec ton raccourci global → une mini-fenêtre flotte pendant l'enregistrement." |
+| 3 | sidebar `Historique` | "Toutes tes transcriptions sont conservées ici." |
+| 4 | sidebar `Notes` | "Écris, organise et relie tes notes." |
+| 5 | sidebar `Paramètres` | "Micro, modèle de transcription, raccourcis : tout se règle ici." |
+| 6 | `ProfileSwitcher` | "Ton compte et la synchro cloud de tes réglages/notes." → *Terminer* |
+
+Step 2 absorbs the global hotkey + mini-window explanation in text (no dedicated
+anchor — the mini window is a separate OS window). 6 steps = "standard" depth;
+can be trimmed to 4 if preferred.
+
+### D. Trigger & persistence
+
+- New flag `tour_pending: boolean` in `src/lib/settings.ts` (default **`false`**).
+- `OnboardingFlow.markComplete()` sets `tour_pending = true` alongside
+  `onboarding_completed = true`.
+- The tour renders when `settingsLoaded && tour_pending && activeTab === "accueil"`.
+  On *Terminer* / *Passer le tour* → `tour_pending = false`.
+- **Migration safety:** default `false` means existing beta users (who already have
+  `onboarding_completed = true`) never get `tour_pending = true`, so no surprise
+  tour on update. Only a fresh wizard completion activates it.
+
+### E. Replay
+
+A "Revoir le tour guidé" button in Settings → Appearance/General that sets
+`tour_pending = true` and switches to the Accueil tab. Near-zero cost; also useful
+for manual testing.
+
+**Files:** `src/lib/settings.ts` (flag + default), `Dashboard.tsx` (trigger),
+a Settings section (replay button), translation files.
+
+### F. i18n & testing
+
+- **i18n:** new FR + EN keys for tour steps, the "Micro" label, "Passer cette
+  étape", and the replay button. No hardcoded UI strings (project rule).
+- **Tests:** unit tests for `useGuidedTour` (next/prev/skip/finish, clamping) and
+  the trigger condition. Positioning/layout lives in the presentation layer and is
+  not covered under jsdom.
+
+## Error handling & edge cases
+
+- **Device list fails to load** (A1): the selector falls back to showing only the
+  default; the demo still works with the system default.
+- **Device unplugged mid-wizard:** `start_recording` already surfaces an error →
+  existing `error` phase handles it.
+- **Target element missing when a tour step renders** (B2): if `data-tour` anchor is
+  not found, skip to the next step rather than rendering an orphan bubble.
+- **Window resized / sidebar collapsed during the tour:** recompute rect on resize;
+  if the sidebar is collapsed, the nav buttons are still present (icon-only) and
+  remain valid anchors.
+- **Settings still loading:** the tour gate requires `settingsLoaded`, so it never
+  flashes before state is known.
+
+## Rollout
+
+- Ship A (wizard fixes) and B (tour) as separate commits/PRs on
+  `feat/onboarding-improvements`; A is low-risk and can merge first.
+- No DB / Supabase change. Purely local settings + frontend.
+- No new runtime dependency.

--- a/docs/superpowers/specs/2026-06-28-onboarding-improvements-design.md
+++ b/docs/superpowers/specs/2026-06-28-onboarding-improvements-design.md
@@ -93,16 +93,22 @@ dependency → fully unit-testable.
 - Recompute the rect on `resize`; `scrollIntoView` the target when needed.
 - Styled entirely with `.vt-app` tokens for visual consistency.
 
-**B3 — Anchors.**
-`data-tour` attributes added to always-visible elements on the Accueil tab:
-`HeroDictationCard`, the sidebar nav buttons (Historique, Notes, Paramètres), and
-`ProfileSwitcher`. The tour stays on the Accueil tab and points at the sidebar — no
-cross-tab orchestration needed, which keeps the engine simple.
+**B3 — Anchors.** `data-tour` attributes on always-visible Accueil-tab elements.
+Concrete placements (verified against the current code):
+
+| Anchor id | Where | Note |
+|---|---|---|
+| `hero-dictation` | root `div` of `HeroDictationCard.tsx` | The card already renders the toggle + push-to-talk hotkey rows, so the spotlight visually reinforces the "global shortcut" message of step 2. |
+| `nav-historique` / `nav-notes` / `nav-parametres` | sidebar nav buttons in `DashboardSidebar.tsx` | Generated in a `.map()` over `visibleNavItems`; add `data-tour={`nav-${id}`}` on each button. Buttons remain present (icon-only) when the sidebar is collapsed → still valid anchors. |
+| `profile-switcher` | wrapper `div.border-t…p-2` in `DashboardSidebar.tsx` (~line 305) | `ProfileSwitcher`'s own root is a fragment, so anchor on its sidebar wrapper rather than inside the component. |
+
+The tour stays on the Accueil tab and points at the sidebar — no cross-tab
+orchestration needed, which keeps the engine simple.
 
 **Files:** new `src/components/onboarding/tour/GuidedTour.tsx`,
 `src/hooks/useGuidedTour.ts`, `src/components/onboarding/tour/tourSteps.ts`;
-`data-tour` added to `HeroDictationCard.tsx`, `DashboardSidebar.tsx`,
-`ProfileSwitcher.tsx`; mount in `Dashboard.tsx`.
+`data-tour` added in `HeroDictationCard.tsx` and `DashboardSidebar.tsx` (nav
+buttons + profile wrapper); mount in `Dashboard.tsx`.
 
 ### C. Tour itinerary (6 steps, Accueil tab)
 
@@ -132,17 +138,26 @@ can be trimmed to 4 if preferred.
 
 ### E. Replay
 
-A "Revoir le tour guidé" button in Settings → Appearance/General that sets
-`tour_pending = true` and switches to the Accueil tab. Near-zero cost; also useful
-for manual testing.
+A "Revoir le tour guidé" button in the **Appearance** settings page
+(`AppearanceSection.tsx`, section id `section-apparence` — where theme + UI language
+already live; there is no "General" page). It sets `tour_pending = true` and
+switches to the Accueil tab. Near-zero cost; also useful for manual testing.
 
 **Files:** `src/lib/settings.ts` (flag + default), `Dashboard.tsx` (trigger),
-a Settings section (replay button), translation files.
+`src/components/settings/sections/AppearanceSection.tsx` (replay button),
+translation files.
 
 ### F. i18n & testing
 
-- **i18n:** new FR + EN keys for tour steps, the "Micro" label, "Passer cette
-  étape", and the replay button. No hardcoded UI strings (project rule).
+- **i18n — namespaces (verified):**
+  - Tour steps + replay button → **default** namespace, files
+    `src/locales/fr.json` + `src/locales/en.json`, under a new `tour.*` prefix
+    (matches `home.*`, `sidebar.*`, `onboarding.*`, accessed via `useTranslation()`).
+  - Mic selector label + Skip link → **billing** namespace, files
+    `src/locales/fr/billing.json` + `src/locales/en/billing.json`, under
+    `welcome.try.*` (same namespace `TryItStep` already uses,
+    `useTranslation("billing")`).
+  - No hardcoded UI strings (project rule).
 - **Tests:** unit tests for `useGuidedTour` (next/prev/skip/finish, clamping) and
   the trigger condition. Positioning/layout lives in the presentation layer and is
   not covered under jsdom.

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -24,6 +24,8 @@ import {
 import { NotesEditor } from "./notes/NotesEditor/NotesEditor";
 import { UpdateModal } from "./common/UpdateModal";
 import { OnboardingFlow } from "./onboarding/OnboardingFlow";
+import { GuidedTour } from "./onboarding/tour/GuidedTour";
+import { shouldShowGuidedTour } from "./onboarding/tour/tourSteps";
 import { ExpirationPopup } from "./billing/ExpirationPopup";
 import { AuthModal } from "./auth/AuthModal";
 import { useAuth } from "@/hooks/useAuth";
@@ -56,8 +58,8 @@ export default function Dashboard() {
   const [logsSourceFilter, setLogsSourceFilter] = useState<string | null>(null);
   const [tabScrollEl, setTabScrollEl] = useState<HTMLDivElement | null>(null);
 
-  const { settings, isLoaded: settingsLoaded } = useSettings();
-  const { user, status: authStatus } = useAuth();
+  const { settings, isLoaded: settingsLoaded, updateSetting } = useSettings();
+  const { user, status: authStatus, isAuthModalOpen } = useAuth();
   const { showOnboarding, recheck: recheckOnboarding } = useOnboardingCheck(
     settings,
     settingsLoaded,
@@ -267,6 +269,14 @@ export default function Dashboard() {
     };
   }, []);
 
+  // Replay tour (from settings) → land on the Accueil tab so the tour, which
+  // only renders there, can show. `tour_pending` is flipped by the caller.
+  useEffect(() => {
+    const onStartTour = () => setActiveTab("accueil");
+    window.addEventListener("lexena:start-tour", onStartTour);
+    return () => window.removeEventListener("lexena:start-tour", onStartTour);
+  }, []);
+
   return (
     <div className="h-screen flex overflow-hidden bg-background">
       <DashboardSidebar
@@ -426,6 +436,17 @@ export default function Dashboard() {
       />
 
       {showOnboarding && <OnboardingFlow onComplete={recheckOnboarding} />}
+
+      {!isAuthModalOpen &&
+        shouldShowGuidedTour(
+          settingsLoaded,
+          settings.tour_pending,
+          activeTab,
+        ) && (
+          <GuidedTour
+            onFinish={() => void updateSetting("tour_pending", false)}
+          />
+        )}
 
       <ExpirationPopup />
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -438,6 +438,7 @@ export default function Dashboard() {
       {showOnboarding && <OnboardingFlow onComplete={recheckOnboarding} />}
 
       {!isAuthModalOpen &&
+        !showOnboarding &&
         shouldShowGuidedTour(
           settingsLoaded,
           settings.tour_pending,

--- a/src/components/OnboardingWizard.tsx
+++ b/src/components/OnboardingWizard.tsx
@@ -84,6 +84,7 @@ export function OnboardingWizard({
     <DialogPrimitive.Root open>
       <DialogPrimitive.Portal>
         <DialogPrimitive.Overlay
+          data-onboarding-overlay
           className="vt-app fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0"
         />
         <DialogPrimitive.Content

--- a/src/components/dashboard/DashboardSidebar.tsx
+++ b/src/components/dashboard/DashboardSidebar.tsx
@@ -192,6 +192,7 @@ export function DashboardSidebar({
           return (
             <button
               key={id}
+              data-tour={`nav-${id}`}
               onClick={() => onTabChange(id)}
               title={collapsed ? t(labelKey) : undefined}
               aria-current={isActive ? "page" : undefined}
@@ -302,7 +303,7 @@ export function DashboardSidebar({
       )}
 
       {/* Profile switcher — always at the very bottom */}
-      <div className="border-t border-border shrink-0 p-2">
+      <div data-tour="profile-switcher" className="border-t border-border shrink-0 p-2">
         <ProfileSwitcher
           collapsed={collapsed}
           onOpenAccountPage={onOpenAccountPage}

--- a/src/components/dashboard/home/HeroDictationCard.tsx
+++ b/src/components/dashboard/home/HeroDictationCard.tsx
@@ -41,6 +41,7 @@ export function HeroDictationCard({
 
   return (
     <div
+      data-tour="hero-dictation"
       className="vt-card-elevated relative overflow-hidden p-6 flex flex-col"
       style={{
         background:

--- a/src/components/onboarding/OnboardingFlow.test.tsx
+++ b/src/components/onboarding/OnboardingFlow.test.tsx
@@ -36,6 +36,7 @@ afterEach(() => {
 
 const openAuthModal = vi.fn();
 const updateSetting = vi.fn();
+const updateSettings = vi.fn();
 
 vi.mock("@/hooks/useAuth", () => ({
   useAuth: () => ({ openAuthModal, user: null }),
@@ -45,6 +46,7 @@ vi.mock("@/hooks/useSettings", () => ({
   useSettings: () => ({
     settings: { record_hotkey: "Ctrl+F11" },
     updateSetting,
+    updateSettings,
   }),
 }));
 
@@ -133,7 +135,10 @@ describe("OnboardingFlow", () => {
     fireEvent.click(screen.getByRole("button", { name: /Continuer$|Continue$/i }));
     expect(screen.getByTestId("try-it-step")).toBeInTheDocument();
     fireEvent.click(screen.getByText("try-cloud"));
-    expect(updateSetting).toHaveBeenCalledWith("onboarding_completed", true);
+    expect(updateSettings).toHaveBeenCalledWith({
+      onboarding_completed: true,
+      tour_pending: true,
+    });
     expect(openAuthModal).toHaveBeenCalled();
     expect(onComplete).toHaveBeenCalled();
   });
@@ -176,7 +181,10 @@ describe("OnboardingFlow", () => {
     // card on ChoiceStep separately by directly triggering it — the cloud CTA
     // in TryItStep already routes through handleCloud (same callback).
     fireEvent.click(screen.getByText("try-cloud"));
-    expect(updateSetting).toHaveBeenCalledWith("onboarding_completed", true);
+    expect(updateSettings).toHaveBeenCalledWith({
+      onboarding_completed: true,
+      tour_pending: true,
+    });
     expect(openAuthModal).toHaveBeenCalled();
     expect(onComplete).toHaveBeenCalled();
   });
@@ -188,7 +196,10 @@ describe("OnboardingFlow", () => {
     fireEvent.click(screen.getByRole("button", { name: /Continuer$|Continue$/i }));
     fireEvent.click(screen.getByText("try-local"));
     fireEvent.click(screen.getByText(/finish/i));
-    expect(updateSetting).toHaveBeenCalledWith("onboarding_completed", true);
+    expect(updateSettings).toHaveBeenCalledWith({
+      onboarding_completed: true,
+      tour_pending: true,
+    });
     expect(onComplete).toHaveBeenCalled();
   });
 

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -64,6 +64,19 @@ export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
     return () => setOnboardingActive(false);
   }, []);
 
+  // This wizard is a Radix dialog that is always `open` and torn down by
+  // unmount (not by an open→closed transition). Radix sets
+  // `body { pointer-events: none }` for modal dialogs and only restores it on a
+  // clean close, so unmounting while open can leave the whole app — and any
+  // portal mounted afterwards (the guided tour) — frozen. Restore it on unmount.
+  useEffect(() => {
+    return () => {
+      if (document.body.style.pointerEvents === "none") {
+        document.body.style.pointerEvents = "";
+      }
+    };
+  }, []);
+
   const isEligible = systemInfo ? isLocalEligible(systemInfo) : true;
 
   const markComplete = () => {

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -35,7 +35,7 @@ const TOTAL_STEPS = 4;
 export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
   const { t } = useTranslation("billing");
   const { openAuthModal } = useAuth();
-  const { settings, updateSetting } = useSettings();
+  const { settings, updateSetting, updateSettings } = useSettings();
   const [step, setStep] = useState<Step>(1);
   const [systemInfo, setSystemInfo] = useState<SystemInfo | null>(null);
 
@@ -79,9 +79,13 @@ export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
 
   const isEligible = systemInfo ? isLocalEligible(systemInfo) : true;
 
+  // Flip both flags in ONE store write. Two back-to-back `updateSetting` calls
+  // race: each reads the same stale base before the other persists, so the
+  // last write wins and silently drops the other flag — which left
+  // `onboarding_completed` false (wizard never tears down, its overlay lingers
+  // under the tour) and could even re-show onboarding on the next launch.
   const markComplete = () => {
-    void updateSetting("onboarding_completed", true);
-    void updateSetting("tour_pending", true);
+    void updateSettings({ onboarding_completed: true, tour_pending: true });
   };
 
   const handleCloud = () => {
@@ -119,7 +123,10 @@ export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
   return (
     <DialogPrimitive.Root open>
       <DialogPrimitive.Portal>
-        <DialogPrimitive.Overlay className="vt-app fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0" />
+        <DialogPrimitive.Overlay
+          data-onboarding-overlay
+          className="vt-app fixed inset-0 z-50 bg-black/60 backdrop-blur-sm data-[state=open]:animate-in data-[state=open]:fade-in-0"
+        />
         <DialogPrimitive.Content
           className="vt-app fixed left-1/2 top-1/2 z-50 w-full max-w-3xl -translate-x-1/2 -translate-y-1/2 rounded-xl border bg-background p-8 shadow-2xl"
           onInteractOutside={(e) => e.preventDefault()}

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -135,6 +135,7 @@ export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
               onBack={() => setStep(2)}
               onCloud={handleCloud}
               onLocal={handleLocal}
+              onSkip={() => setStep(4)}
             />
           )}
           {step === 4 && (

--- a/src/components/onboarding/OnboardingFlow.tsx
+++ b/src/components/onboarding/OnboardingFlow.tsx
@@ -68,6 +68,7 @@ export function OnboardingFlow({ onComplete }: { onComplete: () => void }) {
 
   const markComplete = () => {
     void updateSetting("onboarding_completed", true);
+    void updateSetting("tour_pending", true);
   };
 
   const handleCloud = () => {

--- a/src/components/onboarding/steps/TryItStep.test.tsx
+++ b/src/components/onboarding/steps/TryItStep.test.tsx
@@ -63,6 +63,21 @@ vi.mock("@/hooks/useSettings", () => ({
       silence_threshold: 0.005,
       language: "fr-FR",
     },
+    updateSetting: vi.fn(),
+  }),
+}));
+
+// Controllable audio-device list: tests mutate `audioDeviceState.devices` to
+// show/hide the mic picker without hitting the real `get_audio_devices` command.
+const audioDeviceState = vi.hoisted(() => ({
+  devices: [] as { name: string; index: number; is_default: boolean }[],
+}));
+vi.mock("@/hooks/useAudioDevices", () => ({
+  useAudioDevices: () => ({
+    devices: audioDeviceState.devices,
+    isLoading: false,
+    error: null,
+    refresh: () => {},
   }),
 }));
 
@@ -101,6 +116,7 @@ beforeEach(() => {
   submitDemo.mockReset();
   getDeviceId.mockReset();
   getDeviceId.mockResolvedValue("dev-uuid-12345678");
+  audioDeviceState.devices = [];
 });
 
 import "@/i18n";
@@ -112,12 +128,13 @@ const renderStep = (overrides: Partial<Parameters<typeof TryItStep>[0]> = {}) =>
       onCloud={vi.fn()}
       onLocal={vi.fn()}
       onBack={vi.fn()}
+      onSkip={vi.fn()}
       {...overrides}
     />,
   );
 
 describe("TryItStep", () => {
-  it("renders idle state with record button + back control (no skip)", () => {
+  it("renders idle state with record button + back + skip controls", () => {
     renderStep();
     expect(
       screen.getByRole("button", { name: /Démarrer|Start recording/i }),
@@ -126,8 +143,8 @@ describe("TryItStep", () => {
       screen.getByRole("button", { name: /Retour|Back/i }),
     ).toBeInTheDocument();
     expect(
-      screen.queryByRole("button", { name: /Sauter|Skip the demo/i }),
-    ).not.toBeInTheDocument();
+      screen.getByRole("button", { name: /Passer cette étape|Skip this step/i }),
+    ).toBeInTheDocument();
   });
 
   it("calls onBack from idle", () => {
@@ -135,6 +152,28 @@ describe("TryItStep", () => {
     renderStep({ onBack });
     fireEvent.click(screen.getByRole("button", { name: /Retour|Back/i }));
     expect(onBack).toHaveBeenCalled();
+  });
+
+  it("calls onSkip from the idle skip link", () => {
+    const onSkip = vi.fn();
+    renderStep({ onSkip });
+    fireEvent.click(
+      screen.getByRole("button", { name: /Passer cette étape|Skip this step/i }),
+    );
+    expect(onSkip).toHaveBeenCalled();
+  });
+
+  it("renders the mic picker only when devices are available", () => {
+    audioDeviceState.devices = [
+      { name: "Micro USB", index: 1, is_default: false },
+    ];
+    renderStep();
+    expect(
+      screen.getByText(/^Microphone$/i),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByRole("combobox"),
+    ).toBeInTheDocument();
   });
 
   it("transitions idle → recording on start", async () => {

--- a/src/components/onboarding/steps/TryItStep.tsx
+++ b/src/components/onboarding/steps/TryItStep.tsx
@@ -12,7 +12,15 @@ import {
   Square,
 } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { useSettings } from "@/hooks/useSettings";
+import { useAudioDevices } from "@/hooks/useAudioDevices";
 import { getDemoDeviceId } from "@/lib/device-id";
 import {
   DemoTranscribeError,
@@ -34,11 +42,13 @@ interface TryItStepProps {
   onCloud: () => void;
   onLocal: () => void;
   onBack: () => void;
+  onSkip: () => void;
 }
 
-export function TryItStep({ onCloud, onLocal, onBack }: TryItStepProps) {
+export function TryItStep({ onCloud, onLocal, onBack, onSkip }: TryItStepProps) {
   const { t, i18n } = useTranslation("billing");
-  const { settings } = useSettings();
+  const { settings, updateSetting } = useSettings();
+  const { devices } = useAudioDevices();
   const [phase, setPhase] = useState<Phase>({ status: "idle" });
   const phaseRef = useRef(phase);
   useEffect(() => {
@@ -163,6 +173,45 @@ export function TryItStep({ onCloud, onLocal, onBack }: TryItStepProps) {
         </p>
       </div>
 
+      {(phase.status === "idle" || phase.status === "error") &&
+        devices.length > 0 && (
+          <div className="mx-auto flex w-full max-w-xs flex-col gap-1.5">
+            <label
+              className="text-xs font-medium"
+              style={{ color: "var(--vt-fg-3)" }}
+            >
+              {t("welcome.try.device_label")}
+            </label>
+            <Select
+              value={
+                settings.input_device_index == null
+                  ? "default"
+                  : String(settings.input_device_index)
+              }
+              onValueChange={(val) =>
+                void updateSetting(
+                  "input_device_index",
+                  val === "default" ? null : Number(val),
+                )
+              }
+            >
+              <SelectTrigger className="w-full">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="default">
+                  {t("welcome.try.device_default")}
+                </SelectItem>
+                {devices.map((d) => (
+                  <SelectItem key={d.index} value={String(d.index)}>
+                    {d.name}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+          </div>
+        )}
+
       <div
         className="flex min-h-[220px] flex-col items-center justify-center gap-4 rounded-xl border p-6"
         style={{
@@ -279,6 +328,14 @@ export function TryItStep({ onCloud, onLocal, onBack }: TryItStepProps) {
             <ArrowLeft className="h-4 w-4" />
             {t("welcome.try.cta_back")}
           </Button>
+          <button
+            type="button"
+            onClick={onSkip}
+            className="text-sm underline-offset-4 hover:underline"
+            style={{ color: "var(--vt-fg-3)" }}
+          >
+            {t("welcome.try.cta_skip")}
+          </button>
         </div>
       )}
 

--- a/src/components/onboarding/tour/GuidedTour.test.tsx
+++ b/src/components/onboarding/tour/GuidedTour.test.tsx
@@ -36,6 +36,15 @@ describe("GuidedTour", () => {
     expect(document.body.style.pointerEvents).toBe("");
   });
 
+  it("keeps the overlay container transparent so the spotlight reveals the page (regression)", () => {
+    // `.vt-app` applies an opaque `background: var(--vt-bg)`. If the full-screen
+    // tour container inherits it, it paints a solid dark fill over the dashboard
+    // and the spotlight hole reveals that fill instead of the highlighted card.
+    render(<GuidedTour onFinish={vi.fn()} />);
+    const container = screen.getByRole("dialog");
+    expect(container.style.background).toBe("transparent");
+  });
+
   it("removes a leaked onboarding overlay on mount (regression)", () => {
     // The onboarding Radix dialog, unmounted while still `open`, can leave its
     // full-screen dim veil orphaned in the DOM. The tour sits above it, so its

--- a/src/components/onboarding/tour/GuidedTour.test.tsx
+++ b/src/components/onboarding/tour/GuidedTour.test.tsx
@@ -36,6 +36,19 @@ describe("GuidedTour", () => {
     expect(document.body.style.pointerEvents).toBe("");
   });
 
+  it("removes a leaked onboarding overlay on mount (regression)", () => {
+    // The onboarding Radix dialog, unmounted while still `open`, can leave its
+    // full-screen dim veil orphaned in the DOM. The tour sits above it, so its
+    // spotlight hole would reveal the veil instead of the highlighted card.
+    const veil = document.createElement("div");
+    veil.setAttribute("data-onboarding-overlay", "");
+    document.body.appendChild(veil);
+
+    render(<GuidedTour onFinish={vi.fn()} />);
+
+    expect(document.querySelector("[data-onboarding-overlay]")).toBeNull();
+  });
+
   it("calls onFinish when the skip link is clicked", () => {
     const onFinish = vi.fn();
     render(<GuidedTour onFinish={onFinish} />);

--- a/src/components/onboarding/tour/GuidedTour.test.tsx
+++ b/src/components/onboarding/tour/GuidedTour.test.tsx
@@ -1,0 +1,26 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, fireEvent, cleanup } from "@testing-library/react";
+import { GuidedTour } from "./GuidedTour";
+
+// i18n returns the key verbatim so we can assert on keys, not copy.
+vi.mock("react-i18next", () => ({
+  useTranslation: () => ({ t: (k: string) => k }),
+}));
+
+afterEach(() => cleanup());
+
+describe("GuidedTour", () => {
+  it("renders the centered welcome step first", () => {
+    render(<GuidedTour onFinish={vi.fn()} />);
+    expect(screen.getByText("tour.welcome.title")).toBeTruthy();
+    expect(screen.getByText("1 / 6")).toBeTruthy();
+  });
+
+  it("calls onFinish when the skip link is clicked", () => {
+    const onFinish = vi.fn();
+    render(<GuidedTour onFinish={onFinish} />);
+    fireEvent.click(screen.getByText("tour.skip"));
+    expect(onFinish).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/onboarding/tour/GuidedTour.test.tsx
+++ b/src/components/onboarding/tour/GuidedTour.test.tsx
@@ -8,13 +8,32 @@ vi.mock("react-i18next", () => ({
   useTranslation: () => ({ t: (k: string) => k }),
 }));
 
-afterEach(() => cleanup());
+afterEach(() => {
+  cleanup();
+  document.body.style.pointerEvents = "";
+});
 
 describe("GuidedTour", () => {
   it("renders the centered welcome step first", () => {
     render(<GuidedTour onFinish={vi.fn()} />);
     expect(screen.getByText("tour.welcome.title")).toBeTruthy();
     expect(screen.getByText("1 / 6")).toBeTruthy();
+  });
+
+  it("clears a stale body pointer-events lock on mount (regression)", () => {
+    // Simulates a Radix dialog (onboarding wizard) that unmounted while open
+    // and left the body frozen — which made the tour buttons unclickable.
+    document.body.style.pointerEvents = "none";
+    render(<GuidedTour onFinish={vi.fn()} />);
+    expect(document.body.style.pointerEvents).toBe("");
+  });
+
+  it("restores the body lock cleanup when unmounted", () => {
+    document.body.style.pointerEvents = "none";
+    const { unmount } = render(<GuidedTour onFinish={vi.fn()} />);
+    document.body.style.pointerEvents = "none"; // re-poison while mounted
+    unmount();
+    expect(document.body.style.pointerEvents).toBe("");
   });
 
   it("calls onFinish when the skip link is clicked", () => {

--- a/src/components/onboarding/tour/GuidedTour.tsx
+++ b/src/components/onboarding/tour/GuidedTour.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { useEffect, useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -15,6 +15,7 @@ interface Rect {
 
 const SPOTLIGHT_PAD = 8;
 const BUBBLE_GAP = 16;
+const VIEWPORT_MARGIN = 12;
 
 function readRect(anchor: string): Rect | null {
   const el = document.querySelector<HTMLElement>(`[data-tour="${anchor}"]`);
@@ -23,30 +24,51 @@ function readRect(anchor: string): Rect | null {
   return { top: r.top, left: r.left, width: r.width, height: r.height };
 }
 
-function bubbleStyle(
+/**
+ * Anchor-relative bubble position, then clamped so the whole bubble — and its
+ * buttons — always stays inside the viewport (never cut off at an edge).
+ */
+export function bubblePosition(
   placement: TourStep["placement"],
   spot: Rect | null,
+  bubble: { width: number; height: number },
+  vw: number,
+  vh: number,
 ): CSSProperties {
+  let top: number;
+  let left: number;
+
   if (!spot || placement === "center") {
-    return { top: "50%", left: "50%", transform: "translate(-50%, -50%)" };
+    top = vh / 2 - bubble.height / 2;
+    left = vw / 2 - bubble.width / 2;
+  } else if (placement === "right") {
+    top = spot.top;
+    left = spot.left + spot.width + BUBBLE_GAP;
+  } else if (placement === "bottom") {
+    top = spot.top + spot.height + BUBBLE_GAP;
+    left = spot.left;
+  } else if (placement === "top") {
+    top = spot.top - bubble.height - BUBBLE_GAP;
+    left = spot.left;
+  } else {
+    top = spot.top;
+    left = spot.left;
   }
-  switch (placement) {
-    case "right":
-      return { top: spot.top, left: spot.left + spot.width + BUBBLE_GAP };
-    case "bottom":
-      return { top: spot.top + spot.height + BUBBLE_GAP, left: spot.left };
-    case "top":
-      return { top: Math.max(8, spot.top - BUBBLE_GAP), left: spot.left };
-    default:
-      return { top: spot.top, left: spot.left };
-  }
+
+  const maxLeft = Math.max(VIEWPORT_MARGIN, vw - bubble.width - VIEWPORT_MARGIN);
+  const maxTop = Math.max(VIEWPORT_MARGIN, vh - bubble.height - VIEWPORT_MARGIN);
+  left = Math.min(Math.max(VIEWPORT_MARGIN, left), maxLeft);
+  top = Math.min(Math.max(VIEWPORT_MARGIN, top), maxTop);
+
+  return { top: Math.round(top), left: Math.round(left) };
 }
 
 /**
  * One-pass guided tour overlay. Sequencing lives in `useGuidedTour`; this layer
  * resolves each step's `data-tour` anchor into a spotlight rect (a giant
- * box-shadow cuts the dim everywhere except the anchor) and positions the bubble.
- * A missing anchor auto-advances rather than rendering an orphan bubble.
+ * box-shadow cuts the dim everywhere except the anchor) and positions the
+ * bubble, clamped to the viewport. A missing anchor auto-advances rather than
+ * rendering an orphan bubble.
  */
 export function GuidedTour({ onFinish }: { onFinish: () => void }) {
   const { t } = useTranslation();
@@ -56,6 +78,12 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
   );
   const step = TOUR_STEPS[index];
   const [rect, setRect] = useState<Rect | null>(null);
+  const [viewport, setViewport] = useState(() => ({
+    w: typeof window !== "undefined" ? window.innerWidth : 1280,
+    h: typeof window !== "undefined" ? window.innerHeight : 800,
+  }));
+  const [bubbleSize, setBubbleSize] = useState({ width: 320, height: 200 });
+  const bubbleRef = useRef<HTMLDivElement>(null);
 
   // A Radix dialog (the onboarding wizard) that unmounts while still `open`
   // leaves `body { pointer-events: none }` behind. The tour is a body-level
@@ -73,6 +101,17 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
     return unlock;
   }, []);
 
+  // Track viewport size so positions recompute on resize — including the
+  // anchorless centered step, which has no rect to react to.
+  useEffect(() => {
+    const onResize = () =>
+      setViewport({ w: window.innerWidth, h: window.innerHeight });
+    window.addEventListener("resize", onResize);
+    return () => window.removeEventListener("resize", onResize);
+  }, []);
+
+  // Resolve the anchor rect for the current step (and on resize). A missing
+  // anchor auto-advances rather than rendering an orphan bubble.
   useLayoutEffect(() => {
     if (step.anchor === null) {
       setRect(null);
@@ -86,11 +125,8 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
       return;
     }
     el.scrollIntoView({ block: "nearest", inline: "nearest" });
-    const update = () => setRect(readRect(step.anchor as string));
-    update();
-    window.addEventListener("resize", update);
-    return () => window.removeEventListener("resize", update);
-  }, [step.anchor, next]);
+    setRect(readRect(step.anchor));
+  }, [step.anchor, next, viewport]);
 
   const spot: Rect | null = rect
     ? {
@@ -100,6 +136,26 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
         height: rect.height + SPOTLIGHT_PAD * 2,
       }
     : null;
+
+  // Measure the rendered bubble so positioning can clamp it to the viewport.
+  useLayoutEffect(() => {
+    const el = bubbleRef.current;
+    if (!el) return;
+    const r = el.getBoundingClientRect();
+    setBubbleSize((prev) =>
+      Math.abs(prev.width - r.width) < 1 && Math.abs(prev.height - r.height) < 1
+        ? prev
+        : { width: r.width, height: r.height },
+    );
+  }, [index, rect, viewport]);
+
+  const pos = bubblePosition(
+    step.placement,
+    spot,
+    bubbleSize,
+    viewport.w,
+    viewport.h,
+  );
 
   return createPortal(
     <div
@@ -115,7 +171,8 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
             left: spot.left,
             width: spot.width,
             height: spot.height,
-            boxShadow: "0 0 0 9999px rgba(0,0,0,0.6)",
+            boxShadow:
+              "0 0 0 2px var(--vt-accent), 0 0 0 9999px rgba(0,0,0,0.6)",
             pointerEvents: "none",
           }}
         />
@@ -127,9 +184,10 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
       )}
 
       <div
+        ref={bubbleRef}
         className="absolute w-[320px] max-w-[90vw] rounded-xl border p-4 shadow-2xl"
         style={{
-          ...bubbleStyle(step.placement, spot),
+          ...pos,
           background: "var(--vt-panel)",
           borderColor: "var(--vt-border)",
           color: "var(--vt-fg)",

--- a/src/components/onboarding/tour/GuidedTour.tsx
+++ b/src/components/onboarding/tour/GuidedTour.tsx
@@ -170,8 +170,17 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
   );
 
   return createPortal(
+    // `vt-app` is kept for the design tokens the bubble + spotlight ring read
+    // (`--vt-accent`, `--vt-fg`, …), but that class also sets an OPAQUE
+    // `background: var(--vt-bg)` (App.css). On a full-screen overlay that paints
+    // a solid dark fill over the whole dashboard, and the spotlight's box-shadow
+    // only cuts a hole in the dim — not in this background — so the "hole" would
+    // reveal the container's own dark fill instead of the highlighted element.
+    // Force the container transparent (inline beats `.vt-app` specificity); the
+    // dim comes solely from the spotlight box-shadow / anchorless backdrop.
     <div
       className="vt-app fixed inset-0 z-[60] pointer-events-auto"
+      style={{ background: "transparent" }}
       role="dialog"
       aria-modal="true"
     >

--- a/src/components/onboarding/tour/GuidedTour.tsx
+++ b/src/components/onboarding/tour/GuidedTour.tsx
@@ -1,0 +1,153 @@
+import type { CSSProperties } from "react";
+import { useLayoutEffect, useState } from "react";
+import { createPortal } from "react-dom";
+import { useTranslation } from "react-i18next";
+import { Button } from "@/components/ui/button";
+import { useGuidedTour } from "@/hooks/useGuidedTour";
+import { TOUR_STEPS, type TourStep } from "./tourSteps";
+
+interface Rect {
+  top: number;
+  left: number;
+  width: number;
+  height: number;
+}
+
+const SPOTLIGHT_PAD = 8;
+const BUBBLE_GAP = 16;
+
+function readRect(anchor: string): Rect | null {
+  const el = document.querySelector<HTMLElement>(`[data-tour="${anchor}"]`);
+  if (!el) return null;
+  const r = el.getBoundingClientRect();
+  return { top: r.top, left: r.left, width: r.width, height: r.height };
+}
+
+function bubbleStyle(
+  placement: TourStep["placement"],
+  spot: Rect | null,
+): CSSProperties {
+  if (!spot || placement === "center") {
+    return { top: "50%", left: "50%", transform: "translate(-50%, -50%)" };
+  }
+  switch (placement) {
+    case "right":
+      return { top: spot.top, left: spot.left + spot.width + BUBBLE_GAP };
+    case "bottom":
+      return { top: spot.top + spot.height + BUBBLE_GAP, left: spot.left };
+    case "top":
+      return { top: Math.max(8, spot.top - BUBBLE_GAP), left: spot.left };
+    default:
+      return { top: spot.top, left: spot.left };
+  }
+}
+
+/**
+ * One-pass guided tour overlay. Sequencing lives in `useGuidedTour`; this layer
+ * resolves each step's `data-tour` anchor into a spotlight rect (a giant
+ * box-shadow cuts the dim everywhere except the anchor) and positions the bubble.
+ * A missing anchor auto-advances rather than rendering an orphan bubble.
+ */
+export function GuidedTour({ onFinish }: { onFinish: () => void }) {
+  const { t } = useTranslation();
+  const { index, total, isFirst, isLast, next, prev } = useGuidedTour(
+    TOUR_STEPS.length,
+    onFinish,
+  );
+  const step = TOUR_STEPS[index];
+  const [rect, setRect] = useState<Rect | null>(null);
+
+  useLayoutEffect(() => {
+    if (step.anchor === null) {
+      setRect(null);
+      return;
+    }
+    const el = document.querySelector<HTMLElement>(
+      `[data-tour="${step.anchor}"]`,
+    );
+    if (!el) {
+      next();
+      return;
+    }
+    el.scrollIntoView({ block: "nearest", inline: "nearest" });
+    const update = () => setRect(readRect(step.anchor as string));
+    update();
+    window.addEventListener("resize", update);
+    return () => window.removeEventListener("resize", update);
+  }, [step.anchor, next]);
+
+  const spot: Rect | null = rect
+    ? {
+        top: rect.top - SPOTLIGHT_PAD,
+        left: rect.left - SPOTLIGHT_PAD,
+        width: rect.width + SPOTLIGHT_PAD * 2,
+        height: rect.height + SPOTLIGHT_PAD * 2,
+      }
+    : null;
+
+  return createPortal(
+    <div
+      className="vt-app fixed inset-0 z-[60]"
+      role="dialog"
+      aria-modal="true"
+    >
+      {spot ? (
+        <div
+          className="absolute rounded-xl transition-all duration-200"
+          style={{
+            top: spot.top,
+            left: spot.left,
+            width: spot.width,
+            height: spot.height,
+            boxShadow: "0 0 0 9999px rgba(0,0,0,0.6)",
+            pointerEvents: "none",
+          }}
+        />
+      ) : (
+        <div
+          className="absolute inset-0"
+          style={{ background: "rgba(0,0,0,0.6)" }}
+        />
+      )}
+
+      <div
+        className="absolute w-[320px] max-w-[90vw] rounded-xl border p-4 shadow-2xl"
+        style={{
+          ...bubbleStyle(step.placement, spot),
+          background: "var(--vt-panel)",
+          borderColor: "var(--vt-border)",
+          color: "var(--vt-fg)",
+        }}
+      >
+        <h3 className="vt-display text-base font-semibold">{t(step.titleKey)}</h3>
+        <p className="mt-1.5 text-sm" style={{ color: "var(--vt-fg-2)" }}>
+          {t(step.bodyKey)}
+        </p>
+        <div className="mt-4 flex items-center justify-between">
+          <button
+            type="button"
+            onClick={onFinish}
+            className="text-xs underline-offset-4 hover:underline"
+            style={{ color: "var(--vt-fg-3)" }}
+          >
+            {t("tour.skip")}
+          </button>
+          <div className="flex items-center gap-2">
+            <span className="text-xs" style={{ color: "var(--vt-fg-3)" }}>
+              {index + 1} / {total}
+            </span>
+            {!isFirst && (
+              <Button variant="outline" size="sm" onClick={prev}>
+                {t("tour.prev")}
+              </Button>
+            )}
+            <Button size="sm" onClick={next}>
+              {isLast ? t("tour.finish") : t("tour.next")}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>,
+    document.body,
+  );
+}

--- a/src/components/onboarding/tour/GuidedTour.tsx
+++ b/src/components/onboarding/tour/GuidedTour.tsx
@@ -1,5 +1,5 @@
 import type { CSSProperties } from "react";
-import { useLayoutEffect, useState } from "react";
+import { useEffect, useLayoutEffect, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 import { Button } from "@/components/ui/button";
@@ -57,6 +57,22 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
   const step = TOUR_STEPS[index];
   const [rect, setRect] = useState<Rect | null>(null);
 
+  // A Radix dialog (the onboarding wizard) that unmounts while still `open`
+  // leaves `body { pointer-events: none }` behind. The tour is a body-level
+  // portal, so it would inherit that lock and become unclickable. Clear any
+  // stale lock on mount, and again on unmount so the dashboard underneath is
+  // interactive once the tour closes. The container below also forces
+  // `pointer-events: auto` as a timing-independent guarantee.
+  useEffect(() => {
+    const unlock = () => {
+      if (document.body.style.pointerEvents === "none") {
+        document.body.style.pointerEvents = "";
+      }
+    };
+    unlock();
+    return unlock;
+  }, []);
+
   useLayoutEffect(() => {
     if (step.anchor === null) {
       setRect(null);
@@ -87,7 +103,7 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
 
   return createPortal(
     <div
-      className="vt-app fixed inset-0 z-[60]"
+      className="vt-app fixed inset-0 z-[60] pointer-events-auto"
       role="dialog"
       aria-modal="true"
     >

--- a/src/components/onboarding/tour/GuidedTour.tsx
+++ b/src/components/onboarding/tour/GuidedTour.tsx
@@ -86,19 +86,31 @@ export function GuidedTour({ onFinish }: { onFinish: () => void }) {
   const bubbleRef = useRef<HTMLDivElement>(null);
 
   // A Radix dialog (the onboarding wizard) that unmounts while still `open`
-  // leaves `body { pointer-events: none }` behind. The tour is a body-level
-  // portal, so it would inherit that lock and become unclickable. Clear any
-  // stale lock on mount, and again on unmount so the dashboard underneath is
-  // interactive once the tour closes. The container below also forces
-  // `pointer-events: auto` as a timing-independent guarantee.
+  // leaves two things behind: `body { pointer-events: none }`, and — more
+  // visibly — its full-screen dim overlay portal node (`[data-onboarding-
+  // overlay]`). The tour is a body-level portal sitting ABOVE that leaked z-50
+  // veil, so its spotlight "hole" reveals the dark veil instead of the
+  // highlighted card — the card looks empty. The tour only ever runs once
+  // onboarding has finished, so any onboarding overlay still in the DOM is
+  // definitely orphaned: clear the lock and remove the leaked veil on mount,
+  // and again on unmount so the dashboard is clean once the tour closes.
   useEffect(() => {
-    const unlock = () => {
+    const cleanup = () => {
       if (document.body.style.pointerEvents === "none") {
         document.body.style.pointerEvents = "";
       }
+      document
+        .querySelectorAll("[data-onboarding-overlay]")
+        .forEach((node) => {
+          try {
+            node.remove();
+          } catch {
+            // Node already detached by React/Radix — nothing to do.
+          }
+        });
     };
-    unlock();
-    return unlock;
+    cleanup();
+    return cleanup;
   }, []);
 
   // Track viewport size so positions recompute on resize — including the

--- a/src/components/onboarding/tour/bubblePosition.test.ts
+++ b/src/components/onboarding/tour/bubblePosition.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { bubblePosition } from "./GuidedTour";
+
+const VW = 1280;
+const VH = 800;
+const BUBBLE = { width: 320, height: 200 };
+
+function nums(style: ReturnType<typeof bubblePosition>) {
+  return { top: style.top as number, left: style.left as number };
+}
+
+describe("bubblePosition", () => {
+  it("centers the anchorless step within the viewport", () => {
+    const { top, left } = nums(bubblePosition("center", null, BUBBLE, VW, VH));
+    expect(left).toBe(Math.round(VW / 2 - BUBBLE.width / 2));
+    expect(top).toBe(Math.round(VH / 2 - BUBBLE.height / 2));
+  });
+
+  it("never lets the bubble overflow the bottom edge (anchor at screen bottom)", () => {
+    // Profile switcher: anchored near the very bottom of the sidebar.
+    const spot = { top: VH - 40, left: 8, width: 244, height: 56 };
+    const { top, left } = nums(bubblePosition("right", spot, BUBBLE, VW, VH));
+    expect(top + BUBBLE.height).toBeLessThanOrEqual(VH);
+    expect(left + BUBBLE.width).toBeLessThanOrEqual(VW);
+  });
+
+  it("never lets the bubble overflow the right edge", () => {
+    const spot = { top: 100, left: VW - 60, width: 50, height: 50 };
+    const { left } = nums(bubblePosition("right", spot, BUBBLE, VW, VH));
+    expect(left + BUBBLE.width).toBeLessThanOrEqual(VW);
+  });
+
+  it("clamps to the top-left margin when the anchor sits past the edge", () => {
+    const spot = { top: -500, left: -500, width: 10, height: 10 };
+    const { top, left } = nums(bubblePosition("top", spot, BUBBLE, VW, VH));
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(left).toBeGreaterThanOrEqual(0);
+  });
+
+  it("keeps the bubble on-screen even when it is larger than a tiny viewport", () => {
+    const { top, left } = nums(
+      bubblePosition("center", null, BUBBLE, 200, 150),
+    );
+    expect(top).toBeGreaterThanOrEqual(0);
+    expect(left).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/components/onboarding/tour/tourSteps.test.ts
+++ b/src/components/onboarding/tour/tourSteps.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { TOUR_STEPS, shouldShowGuidedTour } from "./tourSteps";
+
+describe("TOUR_STEPS", () => {
+  it("starts with a centered, anchorless welcome step", () => {
+    expect(TOUR_STEPS[0].anchor).toBeNull();
+    expect(TOUR_STEPS[0].placement).toBe("center");
+  });
+
+  it("every step has tour.* title and body keys", () => {
+    for (const s of TOUR_STEPS) {
+      expect(s.titleKey).toMatch(/^tour\./);
+      expect(s.bodyKey).toMatch(/^tour\./);
+    }
+  });
+
+  it("includes the hero, sidebar and profile anchors", () => {
+    const anchors = TOUR_STEPS.map((s) => s.anchor);
+    expect(anchors).toContain("hero-dictation");
+    expect(anchors).toContain("nav-historique");
+    expect(anchors).toContain("nav-notes");
+    expect(anchors).toContain("nav-parametres");
+    expect(anchors).toContain("profile-switcher");
+  });
+});
+
+describe("shouldShowGuidedTour", () => {
+  it("is true only when loaded, pending, and on the accueil tab", () => {
+    expect(shouldShowGuidedTour(true, true, "accueil")).toBe(true);
+  });
+  it("is false when settings not loaded", () => {
+    expect(shouldShowGuidedTour(false, true, "accueil")).toBe(false);
+  });
+  it("is false when not pending", () => {
+    expect(shouldShowGuidedTour(true, false, "accueil")).toBe(false);
+  });
+  it("is false on any other tab", () => {
+    expect(shouldShowGuidedTour(true, true, "parametres")).toBe(false);
+  });
+});

--- a/src/components/onboarding/tour/tourSteps.ts
+++ b/src/components/onboarding/tour/tourSteps.ts
@@ -13,7 +13,7 @@ export const TOUR_STEPS: TourStep[] = [
   { anchor: "nav-historique", titleKey: "tour.history.title", bodyKey: "tour.history.body", placement: "right" },
   { anchor: "nav-notes", titleKey: "tour.notes.title", bodyKey: "tour.notes.body", placement: "right" },
   { anchor: "nav-parametres", titleKey: "tour.settings.title", bodyKey: "tour.settings.body", placement: "right" },
-  { anchor: "profile-switcher", titleKey: "tour.account.title", bodyKey: "tour.account.body", placement: "right" },
+  { anchor: "profile-switcher", titleKey: "tour.account.title", bodyKey: "tour.account.body", placement: "top" },
 ];
 
 /**

--- a/src/components/onboarding/tour/tourSteps.ts
+++ b/src/components/onboarding/tour/tourSteps.ts
@@ -1,0 +1,29 @@
+export interface TourStep {
+  /** `data-tour` anchor id, or null for a centered anchorless step. */
+  anchor: string | null;
+  titleKey: string;
+  bodyKey: string;
+  /** Preferred bubble placement relative to the spotlight. */
+  placement: "center" | "right" | "bottom" | "top";
+}
+
+export const TOUR_STEPS: TourStep[] = [
+  { anchor: null, titleKey: "tour.welcome.title", bodyKey: "tour.welcome.body", placement: "center" },
+  { anchor: "hero-dictation", titleKey: "tour.dictate.title", bodyKey: "tour.dictate.body", placement: "bottom" },
+  { anchor: "nav-historique", titleKey: "tour.history.title", bodyKey: "tour.history.body", placement: "right" },
+  { anchor: "nav-notes", titleKey: "tour.notes.title", bodyKey: "tour.notes.body", placement: "right" },
+  { anchor: "nav-parametres", titleKey: "tour.settings.title", bodyKey: "tour.settings.body", placement: "right" },
+  { anchor: "profile-switcher", titleKey: "tour.account.title", bodyKey: "tour.account.body", placement: "right" },
+];
+
+/**
+ * The tour shows once, on the Accueil tab, after a fresh wizard completion flips
+ * `tour_pending`. Gating on `settingsLoaded` avoids a flash before state is known.
+ */
+export function shouldShowGuidedTour(
+  settingsLoaded: boolean,
+  tourPending: boolean,
+  activeTab: string,
+): boolean {
+  return settingsLoaded && tourPending && activeTab === "accueil";
+}

--- a/src/components/settings/sections/AppearanceSection.tsx
+++ b/src/components/settings/sections/AppearanceSection.tsx
@@ -125,6 +125,20 @@ export function AppearanceSection() {
             ]}
           />
         </Row>
+
+        <Row label={t("tour.replayButton")} hint={t("tour.replayHint")}>
+          <button
+            type="button"
+            className="vt-btn"
+            style={{ height: 36 }}
+            onClick={async () => {
+              await updateSetting("tour_pending", true);
+              window.dispatchEvent(new CustomEvent("lexena:start-tour"));
+            }}
+          >
+            {t("tour.replayButton")}
+          </button>
+        </Row>
       </div>
 
       {/* Mini fenêtre */}

--- a/src/hooks/useGuidedTour.test.ts
+++ b/src/hooks/useGuidedTour.test.ts
@@ -1,0 +1,47 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi } from "vitest";
+import { act, renderHook } from "@testing-library/react";
+import { useGuidedTour } from "./useGuidedTour";
+
+describe("useGuidedTour", () => {
+  it("starts at index 0", () => {
+    const { result } = renderHook(() => useGuidedTour(3, vi.fn()));
+    expect(result.current.index).toBe(0);
+    expect(result.current.isFirst).toBe(true);
+    expect(result.current.isLast).toBe(false);
+  });
+
+  it("advances with next() and clamps isLast", () => {
+    const { result } = renderHook(() => useGuidedTour(3, vi.fn()));
+    act(() => result.current.next());
+    expect(result.current.index).toBe(1);
+    act(() => result.current.next());
+    expect(result.current.index).toBe(2);
+    expect(result.current.isLast).toBe(true);
+  });
+
+  it("calls onFinish when next() is invoked on the last step and does not overflow", () => {
+    const onFinish = vi.fn();
+    const { result } = renderHook(() => useGuidedTour(2, onFinish));
+    act(() => result.current.next()); // → index 1 (last)
+    act(() => result.current.next()); // → onFinish, stays at 1
+    expect(onFinish).toHaveBeenCalledTimes(1);
+    expect(result.current.index).toBe(1);
+  });
+
+  it("prev() decrements and clamps at 0", () => {
+    const { result } = renderHook(() => useGuidedTour(3, vi.fn()));
+    act(() => result.current.next());
+    act(() => result.current.prev());
+    expect(result.current.index).toBe(0);
+    act(() => result.current.prev());
+    expect(result.current.index).toBe(0);
+  });
+
+  it("reset() returns to 0", () => {
+    const { result } = renderHook(() => useGuidedTour(3, vi.fn()));
+    act(() => result.current.next());
+    act(() => result.current.reset());
+    expect(result.current.index).toBe(0);
+  });
+});

--- a/src/hooks/useGuidedTour.ts
+++ b/src/hooks/useGuidedTour.ts
@@ -1,0 +1,50 @@
+import { useCallback, useState } from "react";
+
+export interface GuidedTourController {
+  index: number;
+  total: number;
+  isFirst: boolean;
+  isLast: boolean;
+  next: () => void;
+  prev: () => void;
+  reset: () => void;
+}
+
+/**
+ * Pure step-sequencing for the guided tour. Holds the current index and clamps
+ * at both ends. `next()` past the final step triggers `onFinish` (used both for
+ * the "Done" button on the last step and for any auto-advance). All DOM /
+ * positioning concerns live in the GuidedTour presentation layer.
+ */
+export function useGuidedTour(
+  total: number,
+  onFinish: () => void,
+): GuidedTourController {
+  const [index, setIndex] = useState(0);
+
+  const next = useCallback(() => {
+    setIndex((i) => {
+      if (i >= total - 1) {
+        onFinish();
+        return i;
+      }
+      return i + 1;
+    });
+  }, [total, onFinish]);
+
+  const prev = useCallback(() => {
+    setIndex((i) => (i <= 0 ? 0 : i - 1));
+  }, []);
+
+  const reset = useCallback(() => setIndex(0), []);
+
+  return {
+    index,
+    total,
+    isFirst: index === 0,
+    isLast: index === total - 1,
+    next,
+    prev,
+    reset,
+  };
+}

--- a/src/lib/settings.test.ts
+++ b/src/lib/settings.test.ts
@@ -1,0 +1,16 @@
+import { describe, it, expect } from "vitest";
+import { DEFAULT_SETTINGS, mergeSettings } from "./settings";
+
+describe("tour_pending setting", () => {
+  it("defaults to false so existing users get no surprise tour on update", () => {
+    expect(DEFAULT_SETTINGS.settings.tour_pending).toBe(false);
+  });
+
+  it("mergeSettings preserves an explicit tour_pending=true", () => {
+    const merged = mergeSettings({
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      settings: { tour_pending: true } as any,
+    });
+    expect(merged.settings.tour_pending).toBe(true);
+  });
+});

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -75,6 +75,8 @@ export interface AppSettings {
 
     // Onboarding
     onboarding_completed: boolean;
+    /** True for exactly one fresh wizard completion → triggers the guided tour once. */
+    tour_pending: boolean;
   };
 }
 
@@ -158,6 +160,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
 
     // Onboarding
     onboarding_completed: false,
+    tour_pending: false,
   },
 };
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -38,6 +38,38 @@
     "processing": "Running AI post-processing...",
     "error": "AI post-processing failed: {{error}}"
   },
+  "tour": {
+    "next": "Next",
+    "prev": "Back",
+    "finish": "Done",
+    "skip": "Skip tour",
+    "replayButton": "Replay guided tour",
+    "replayHint": "Restart the guided tour of the main features.",
+    "welcome": {
+      "title": "Welcome to Lexena",
+      "body": "30 seconds to learn the essentials. You can skip anytime."
+    },
+    "dictate": {
+      "title": "Dictate in one click",
+      "body": "Start recording here — or from any app with your global shortcut. The text is inserted into the active window and a mini window floats while you dictate."
+    },
+    "history": {
+      "title": "Your history",
+      "body": "Every transcription is kept here, ready to copy or turn into a note."
+    },
+    "notes": {
+      "title": "Your notes",
+      "body": "Write, organize into folders and link your notes together."
+    },
+    "settings": {
+      "title": "Settings",
+      "body": "Choose your microphone, transcription model and customize your shortcuts here."
+    },
+    "account": {
+      "title": "Account & sync",
+      "body": "Sign in to sync your settings and notes to the cloud across all your devices."
+    }
+  },
   "sidebar": {
     "home": "Home",
     "history": "History",

--- a/src/locales/en/billing.json
+++ b/src/locales/en/billing.json
@@ -73,6 +73,9 @@
       "cta_local": "Continue with local instead",
       "cta_back": "Back",
       "cta_retry": "Try again",
+      "cta_skip": "Skip this step",
+      "device_label": "Microphone",
+      "device_default": "Default device",
       "error": {
         "rate_limited_title": "You've reached the free demo limit",
         "rate_limited_body": "Create an account for 60 free minutes — you'll be able to test without limits.",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -38,6 +38,38 @@
     "processing": "Post-traitement IA en cours...",
     "error": "Post-traitement IA échoué : {{error}}"
   },
+  "tour": {
+    "next": "Suivant",
+    "prev": "Précédent",
+    "finish": "Terminer",
+    "skip": "Passer le tour",
+    "replayButton": "Revoir le tour guidé",
+    "replayHint": "Relance la visite guidée des fonctionnalités principales.",
+    "welcome": {
+      "title": "Bienvenue dans Lexena",
+      "body": "30 secondes pour découvrir l'essentiel. Tu peux passer à tout moment."
+    },
+    "dictate": {
+      "title": "Dicte d'un clic",
+      "body": "Lance l'enregistrement ici — ou depuis n'importe quelle application avec ton raccourci global. Le texte s'insère dans la fenêtre active et une mini-fenêtre flotte pendant la dictée."
+    },
+    "history": {
+      "title": "Ton historique",
+      "body": "Toutes tes transcriptions sont conservées ici, prêtes à être copiées ou transformées en notes."
+    },
+    "notes": {
+      "title": "Tes notes",
+      "body": "Écris, organise en dossiers et relie tes notes entre elles."
+    },
+    "settings": {
+      "title": "Réglages",
+      "body": "Choisis ton micro, ton modèle de transcription et personnalise tes raccourcis ici."
+    },
+    "account": {
+      "title": "Compte & synchro",
+      "body": "Connecte-toi pour synchroniser tes réglages et tes notes dans le cloud, sur tous tes appareils."
+    }
+  },
   "sidebar": {
     "home": "Accueil",
     "history": "Historique",

--- a/src/locales/fr/billing.json
+++ b/src/locales/fr/billing.json
@@ -73,6 +73,9 @@
       "cta_local": "Continuer en local à la place",
       "cta_back": "Retour",
       "cta_retry": "Réessayer",
+      "cta_skip": "Passer cette étape",
+      "device_label": "Microphone",
+      "device_default": "Périphérique par défaut",
       "error": {
         "rate_limited_title": "Tu as atteint la limite d'essais gratuits",
         "rate_limited_body": "Crée un compte pour 60 minutes offertes — tu pourras tester sans contrainte.",


### PR DESCRIPTION
## Summary

Improves first-run onboarding on the three friction points raised:

1. **Mic test step had no device choice** → added a microphone selector (persists to `input_device_index`) in the try-it demo step.
2. **Could not skip the mic test** → added a "Passer cette étape" button so the demo is no longer a hard gate.
3. **Nothing explained what does what** → added a lightweight, sequential **guided tour** (custom engine, no new dependency) that spotlights real dashboard elements (dictation hero, history, notes, settings, account) with contextual bubbles. Replayable from *Settings → Appearance → "Revoir le tour guidé"*.

A new `tour_pending` setting (defaults `false`, so existing users get no surprise tour) is flipped on wizard completion to trigger the tour once.

## Notable bug fixes found while building the tour

- **Spotlight showed an empty black box for every step** — root cause: the tour overlay carried `vt-app` for its design tokens, but `.vt-app` also sets an opaque `background: var(--vt-bg)`. On a full-screen `fixed inset-0` container that painted a solid dark fill over the whole dashboard; the spotlight box-shadow only cuts the *dim*, not that background, so the hole revealed the container's own fill. Fixed by forcing the container `background: transparent`.
- **Tour buttons unclickable / leftover dark veil** — the onboarding Radix dialog, unmounted while still `open`, leaves `body { pointer-events: none }` and an orphaned dim overlay behind. The tour now clears the body lock and removes any orphaned `[data-onboarding-overlay]` on mount.
- **`markComplete` race** — two concurrent `updateSetting` calls could drop a flag (leaving `onboarding_completed` false → wizard re-shows on next launch). Now writes both flags atomically via `updateSettings`.
- Bubble viewport clamping + accent ring so the bubble never gets cut off at a screen edge.

## Tests

- `pnpm exec tsc --noEmit` — clean
- `pnpm exec vitest run` — 389 passed (incl. new tour sequencing, bubble-clamping, transparent-container, orphaned-veil, and atomic-markComplete regression tests)

## Manual verification

- Fresh onboarding → tour shows once on Accueil, spotlights each anchor with the real card visible underneath, dashboard dimmed 60% behind.
- Replay from Settings works; tour does not reappear after completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)