### PR TITLE
feat: streaming mode — live transcription (cloud-only)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
+## [Unreleased]
+
+### Added
+- **Streaming mode (live transcription)** — Lexena Cloud exclusive. When enabled (Settings → Dictation → Transcription), speech is segmented at natural pauses on the Rust side and each segment is transcribed while you keep talking: the text appears sentence by sentence in the mini window (in place of the visualizer) and in the home hero card (teleprompter style), ~1-2 s after each pause. On stop, the assembled text goes through the unchanged pipeline (AI post-process, snippets, history, auto-paste). Works with the toggle hotkey, push-to-talk and the record button; cancel (Escape) discards everything. Billing is identical to batch (sum of segment durations through the existing `/transcribe` endpoint); quota/auth errors stop the recording cleanly, isolated network failures skip a segment with a warning.
+
+---
+
 ## [3.0.0] - 2026-06-30
 
 > Major release. Voice Tool becomes **Lexena**. The app gains user accounts, cloud sync (settings, vocabulary, snippets, **notes and folders**), an optional **managed cloud transcription** service (Lexena Cloud), public note sharing and a redesigned home. The trust promise stays intact: **the fully local, account-less, offline mode remains free and fully functional** — and Lexena no longer requires any third-party API key.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -196,6 +196,30 @@ Located in `lib.rs:633-729` and `transcription.rs`:
 - `paste_text_to_active_window()` simulates Ctrl+V using enigo library
 - 50ms delay between clipboard write and paste for reliability
 
+#### Streaming Mode (live transcription, cloud-only)
+
+Located in `src-tauri/src/streaming.rs` + `src/hooks/useStreamingSession.ts`:
+
+- Setting `streaming_mode` (default false), effective only when provider is LexenaCloud
+  and the user is cloud-eligible; `CloudContext` pushes the combined flag to Rust via
+  `set_streaming_enabled` (same pattern as `set_cloud_gate`)
+- Rust: the audio callback feeds an optional tap (`AudioRecorder.chunk_tap`) into a
+  worker thread running `SpeechSegmenter` (pure state machine, 20ms RMS windows,
+  adaptive threshold, cuts at ≥600ms pauses, min 1.4s / force-cut 15s, click guard);
+  segments emitted as `streaming-chunk` events; `streaming-session-started/-end/-cancelled`
+  frame the session. Wired in both start paths (command + hotkey), never in the mic-test
+  monitor. On hotkey stop with an active session, `audio-captured` is NOT emitted
+- Frontend: `useStreamingSession` uploads chunks sequentially through the existing
+  `transcribeCloud` (billing/quota unchanged, idempotency key per chunk), assembles
+  ordered text (`src/lib/streaming/assembler.ts` + `session.ts`, both unit-tested),
+  broadcasts `streaming-transcript` (consumed by the mini window and the home hero card),
+  and on session end hands the text to the standard finalization (post-process →
+  snippets → history entry with `isStreaming: true` → paste)
+- Error policy: quota/auth → abort + stop recording; isolated network failure → chunk
+  skipped (warning toast at the end); >2 consecutive failures → abort
+- Design spec: `docs/superpowers/specs/2026-07-02-streaming-transcription-design.md`;
+  E2E checklist: `docs/v3/streaming-e2e-checklist.md`
+
 #### Auto-Update System
 
 Located in `updater.rs`:

--- a/docs/superpowers/plans/2026-07-02-streaming-transcription.md
+++ b/docs/superpowers/plans/2026-07-02-streaming-transcription.md
@@ -1,0 +1,259 @@
+# Streaming Transcription Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Live sentence-by-sentence transcription while recording (cloud-only), via Rust-side silence segmentation + per-segment upload to the existing `/transcribe` worker endpoint.
+
+**Architecture:** Rust taps the cpal audio callback into a segmenter worker thread that cuts speech at natural pauses and emits `streaming-chunk` events. The frontend uploads each chunk through the existing `transcribeCloud()` client (sequential queue), assembles ordered text, broadcasts `streaming-transcript` for live display (mini window + dashboard), and on session end pushes the assembled text through the unchanged finalization pipeline (post-process → snippets → history → paste).
+
+**Tech Stack:** Rust (cpal, std::sync::mpsc, tauri events), React 19 + TS (Tauri invoke/listen), Vitest, cargo test.
+
+**Spec:** `docs/superpowers/specs/2026-07-02-streaming-transcription-design.md`
+
+## Global Constraints
+
+- Batch behavior strictly unchanged when `streaming_mode = false` (default) and for provider Local.
+- No server/worker changes; every chunk is a normal `/transcribe` request billed as today.
+- All UI strings via react-i18next (fr + en). CHANGELOG in English. Conventional commits.
+- No new Rust/npm dependencies.
+- Rust build commands need: `export PATH="$PATH:/c/Program Files/CMake/bin"` and `LIBCLANG_PATH="C:/Program Files/LLVM/bin"`; use `--no-default-features` (documented CPU fallback) and `CARGO_TARGET_DIR=C:/Users/nolyo/www/voice-tool/src-tauri/target` to reuse the main checkout's cache.
+- Event payload keys are camelCase (matches `audio-captured` precedent).
+
+## Event Contract (produced by Task 2, consumed by Tasks 5/7)
+
+| Event | Payload | Emitter |
+|---|---|---|
+| `streaming-session-started` | `{ sessionId: number, sampleRate: number }` | Rust, tap installed |
+| `streaming-chunk` | `{ sessionId, chunkIndex, samples: number[], sampleRate, startMs, endMs }` | Rust worker |
+| `streaming-session-end` | `{ sessionId, totalChunks }` | Rust worker (after flush) |
+| `streaming-session-cancelled` | `{ sessionId }` | Rust worker (Escape) |
+| `streaming-transcript` | `{ sessionId, text }` | Frontend (assembled so far) |
+
+---
+
+### Task 1: Rust `SpeechSegmenter` (pure state machine) + unit tests
+
+**Files:**
+- Create: `src-tauri/src/streaming.rs` (segmenter part only)
+- Modify: `src-tauri/src/lib.rs` (add `mod streaming;` next to `mod audio_trim;`)
+
+**Interfaces (Produces):**
+```rust
+pub struct SegmenterConfig { /* all ms fields u32, thresholds f32 */
+    pub sample_rate: u32,
+    pub window_ms: u32,          // 20
+    pub silence_gap_ms: u32,     // 600  — silence run that triggers a cut
+    pub min_segment_ms: u32,     // 1400 — no silence-cut before this
+    pub max_segment_ms: u32,     // 15000 — force cut
+    pub force_cut_lookback_ms: u32, // 2000 — search window for min-RMS forced cut
+    pub tail_padding_ms: u32,    // 250 — trailing silence kept on cut
+    pub pre_roll_ms: u32,        // 250 — leading silence kept before first speech
+    pub threshold_fraction: f32, // 0.10 (of running peak RMS)
+    pub min_threshold: f32,      // 0.004
+    pub max_threshold: f32,      // 0.020
+    pub noise_floor_peak: f32,   // 0.010 — below ⇒ nothing is speech
+}
+impl SegmenterConfig { pub fn new(sample_rate: u32) -> Self /* defaults above */ }
+
+pub struct Segment { pub samples: Vec<i16>, pub start_ms: u64, pub end_ms: u64 }
+
+pub struct SpeechSegmenter { /* private */ }
+impl SpeechSegmenter {
+    pub fn new(config: SegmenterConfig) -> Self;
+    /// Feed a batch of mono i16 samples; returns 0..n completed segments.
+    pub fn push(&mut self, samples: &[i16]) -> Vec<Segment>;
+    /// End of stream: returns the trailing segment if it contains speech.
+    pub fn flush(&mut self) -> Option<Segment>;
+}
+```
+
+**Algorithm (internal):** accumulate incoming samples; process complete 20 ms windows. Per window: RMS (same normalization as `audio_trim::rms`); update running peak; `threshold = (peak * threshold_fraction).clamp(min, max)`; window is speech iff `peak >= noise_floor_peak && rms > threshold`. State: `buffer: Vec<i16>`, `buffer_start_ms`, `has_speech`, `speech_windows: u32`, `silence_run_ms`, `total_ms`. Rules:
+1. Silence window while `!has_speech`: keep buffer as pre-roll only — truncate front so buffer ≤ `pre_roll_ms` (advance `buffer_start_ms` accordingly). Memory stays bounded during long pauses.
+2. Speech window: append, `has_speech = true`, `speech_windows += 1`, `silence_run_ms = 0`.
+3. Silence window while `has_speech`: append, `silence_run_ms += window_ms`; if `silence_run_ms >= silence_gap_ms` and segment duration ≥ `min_segment_ms` → **cut**: emit `buffer[..len - (silence_run_ms - tail_padding_ms)]` worth of samples (keep `tail_padding_ms` of the silence tail); the segment counts only if `speech_windows >= 2` (else discard, click guard). Remaining silence is dropped; next buffer starts empty at current position.
+4. Segment duration ≥ `max_segment_ms` with speech → **force cut** at the min-RMS window inside the last `force_cut_lookback_ms`; remainder (after the cut point) is carried over as the start of the next buffer with `has_speech = true`, `speech_windows = 1`.
+5. `flush()`: if `has_speech && speech_windows >= 2` emit remaining buffer (no min-duration requirement), else `None`.
+
+- [x] **Step 1: Write failing tests** in `#[cfg(test)] mod tests` (reuse the `silence()/speech()` generators pattern from `audio_trim.rs`, SR = 48 000):
+  - `cuts_at_natural_pause`: 3 s speech + 1 s silence + 2 s speech + `flush` → 2 segments; first ends ≈ 3 s + tail padding (assert `end_ms` in [3000, 3600]); second contains the later speech.
+  - `no_cut_before_min_duration`: 0.8 s speech + 1 s silence + 1 s speech + flush → 1 segment min_segment prevents early cut) — assert single segment spans everything up to flush.
+  - `pure_silence_emits_nothing`: 10 s silence → push returns empty, flush → None.
+  - `isolated_click_discarded`: 2 s silence + 20 ms speech + 2 s silence + flush → no segment.
+  - `force_cut_on_long_speech`: 20 s continuous speech → at least one segment emitted before flush; every segment ≤ 15.5 s.
+  - `speech_is_contiguous_across_cuts`: total speech samples across segments + flush ≥ total speech samples fed (no speech lost; compare sample counts with tolerance of a few windows).
+  - `flush_returns_short_tail`: 3 s speech + cut-triggering silence + 0.6 s speech + flush → flush yields the short tail.
+  - `long_pause_bounded_memory`: 60 s silence pushed in batches → internal buffer stays ≤ pre_roll (expose via `#[cfg(test)] fn buffered_len(&self)`).
+- [x] **Step 2: Run** `cargo test --no-default-features streaming` → FAIL (module skeleton compiles, tests fail or don't compile yet — write skeleton first so failure is assertions, not syntax).
+- [x] **Step 3: Implement** the segmenter per the algorithm above.
+- [x] **Step 4: Run** same command → PASS (all 8 + existing suite untouched).
+- [x] **Step 5: Commit** `feat: add speech segmenter for streaming transcription`
+
+### Task 2: Rust tap + streaming runtime + command/hotkey wiring
+
+**Files:**
+- Modify: `src-tauri/src/audio.rs` (chunk tap + `current_sample_rate()`)
+- Modify: `src-tauri/src/streaming.rs` (TapMsg, worker, session helpers)
+- Modify: `src-tauri/src/state.rs` (`streaming: Mutex<StreamingRuntime>`)
+- Modify: `src-tauri/src/commands/settings.rs` (`set_streaming_enabled`)
+- Modify: `src-tauri/src/commands/recording.rs` (start/stop wiring)
+- Modify: `src-tauri/src/hotkeys.rs` (start/stop/cancel wiring + skip `audio-captured`)
+- Modify: `src-tauri/src/lib.rs` (register `set_streaming_enabled`)
+
+**Interfaces (Produces):**
+```rust
+// streaming.rs
+pub enum TapMsg { Samples(Vec<i16>), Finish, Abort }
+pub(crate) struct StreamingRuntime { pub enabled: bool, session_seq: u64, tap: Option<std::sync::mpsc::Sender<TapMsg>> }
+/// After recorder.start_recording() succeeded. Installs tap + spawns worker when enabled.
+pub(crate) fn maybe_start_streaming_session<R: tauri::Runtime>(state: &AppState, recorder: &mut AudioRecorder, app_handle: &AppHandle<R>);
+/// Sends Finish (stop) or Abort (cancel); returns true if a session was active.
+pub(crate) fn end_streaming_session(state: &AppState, recorder: &mut AudioRecorder, abort: bool) -> bool;
+// audio.rs
+impl AudioRecorder { pub fn set_chunk_tap(&mut self, tap: Option<Sender<TapMsg>>); pub fn current_sample_rate(&self) -> u32; }
+// commands/settings.rs
+#[tauri::command] pub fn set_streaming_enabled(state: State<AppState>, enabled: bool) -> Result<(), String>;
+```
+
+Wiring rules:
+- Callback (`build_input_stream`): after mono conversion and (not monitor_only) buffering, `if let Some(tx) = tap { let _ = tx.send(TapMsg::Samples(samples.clone())); }` — lock the tap mutex once per callback, ignore send errors (worker gone).
+- Worker thread (std::thread): owns `SpeechSegmenter`; on `Samples` push + emit each `Segment` as `streaming-chunk` (chunkIndex counter); on `Finish` flush → maybe emit last chunk → emit `streaming-session-end`; on `Abort` or channel disconnect-without-Finish → emit `streaming-session-cancelled` (disconnect after Finish already returned). Emits via `AppHandle` (`serde_json::json!` camelCase payloads).
+- `commands/recording.rs::start_recording`: after successful `recorder.start_recording(...)`, call `maybe_start_streaming_session(...)` (recorder still locked). Same in `hotkeys.rs::start_recording_shortcut`. **Not** in `start_audio_monitor` (mic test must never stream).
+- `commands/recording.rs::stop_recording`: after `recorder.stop_recording(...)`, `end_streaming_session(state, &mut recorder, false)`.
+- `hotkeys.rs::stop_recording_shortcut`: same; return the flag so the record/PTT handlers **skip `emit_audio_samples` when a streaming session was active**.
+- `hotkeys.rs::cancel_recording_shortcut`: `end_streaming_session(..., true)`.
+- `set_streaming_enabled` only flips `StreamingRuntime.enabled` (pattern of `set_cloud_gate`).
+
+- [x] **Step 1: Implement** all of the above (no practical unit test for cpal wiring; the segmenter is already covered — keep worker logic thin).
+- [x] **Step 2: Run** `cargo check --no-default-features` then `cargo test --no-default-features` → PASS, no warnings introduced.
+- [x] **Step 3: Commit** `feat: wire streaming session tap into recording paths`
+
+### Task 3: Frontend assembler (pure) + Vitest
+
+**Files:**
+- Create: `src/lib/streaming/assembler.ts`
+- Test: `src/lib/streaming/assembler.test.ts`
+
+**Interfaces (Produces):**
+```ts
+export class TranscriptAssembler {
+  upsert(index: number, text: string): void;
+  markFailed(index: number): void;
+  assembled(): string;          // ordered join, single spaces, trimmed
+  get okCount(): number;
+  get failedCount(): number;
+}
+```
+
+- [x] **Step 1: Failing tests**: ordered join out-of-order upserts; gap (missing index) skipped; failed chunk excluded from join but counted; empty/whitespace chunk text ignored in join; double upsert same index overwrites.
+- [x] **Step 2:** `pnpm vitest run src/lib/streaming` → FAIL.
+- [x] **Step 3: Implement** with a `Map<number, string>`.
+- [x] **Step 4:** `pnpm vitest run src/lib/streaming` → PASS.
+- [x] **Step 5: Commit** `feat: add streaming transcript assembler`
+
+### Task 4: Frontend session queue + error policy + Vitest
+
+**Files:**
+- Create: `src/lib/streaming/session.ts`
+- Test: `src/lib/streaming/session.test.ts`
+
+**Interfaces (Produces):**
+```ts
+export interface StreamingChunkPayload { sessionId: number; chunkIndex: number; samples: number[]; sampleRate: number; startMs: number; endMs: number; }
+export type ChunkTransport = (chunk: StreamingChunkPayload, jwt: string, language?: string) => Promise<{ text: string; duration_ms: number }>;
+export interface StreamingOutcome { text: string; billedMs: number; chunksOk: number; chunksFailed: number; aborted: boolean; }
+export type FatalReason = "quota" | "auth" | "network";
+export interface StreamingSessionOptions {
+  sessionId: number; language?: string;
+  getJwt: () => Promise<string | undefined>;
+  transport: ChunkTransport;
+  onTranscript: (assembledText: string) => void;
+  onFatal: (reason: FatalReason, error: unknown) => void; // caller aborts recording
+  maxConsecutiveFailures?: number; // default 2
+}
+export class StreamingUploadSession {
+  constructor(opts: StreamingSessionOptions);
+  enqueue(chunk: StreamingChunkPayload): void;   // sequential pump, 1 in flight
+  finish(): Promise<StreamingOutcome>;           // resolves after queue drains
+  abort(): void;                                 // drops pending work
+  get active(): boolean;
+}
+```
+Error policy (in pump): missing JWT → `onFatal("auth")` + abort. `CloudApiError.isQuotaIssue()` → `onFatal("quota")` + abort. `.isAuthIssue()` → `onFatal("auth")` + abort. Any other error → `markFailed(index)`, increment consecutive-failure counter; when it exceeds `maxConsecutiveFailures` → `onFatal("network")` + abort; a success resets the counter. (`transcribeCloud` already retries transient network errors internally.)
+
+- [x] **Step 1: Failing tests** with an injected fake transport (no Tauri imports): resolves in order with out-of-order transport latencies (sequentiality asserted via in-flight counter); `finish()` waits for queued uploads; quota error → onFatal("quota") + aborted outcome; 3 consecutive network failures (default max 2) → onFatal("network"); 1 failure then success → no fatal, failed chunk skipped in text, billedMs sums only ok chunks; abort() drops queue.
+- [x] **Step 2:** run → FAIL. **Step 3: Implement** (promise-chain pump). **Step 4:** run → PASS.
+- [x] **Step 5: Commit** `feat: add streaming upload session with error policy`
+
+### Task 5: `useStreamingSession` hook + `useRecordingWorkflow` integration
+
+**Files:**
+- Create: `src/hooks/useStreamingSession.ts`
+- Modify: `src/hooks/useRecordingWorkflow.ts`
+- Modify: `src/components/Dashboard.tsx` (pass-through of `liveTranscript`/`isStreamingSession` — final render location decided in Task 7)
+
+**Interfaces (Produces):**
+```ts
+// useStreamingSession({ settings, onFinalize, onEmpty }) → { liveTranscript, isStreamingSession }
+// onFinalize(text: string, billedSeconds: number, chunksFailed: number): Promise<void>
+// onEmpty(): void  — session ended with zero speech chunks
+```
+Behavior:
+- Listens `streaming-session-started` → new `StreamingUploadSession` (transport wraps `transcribeCloud` with `idempotencyKey = "${sessionId}-${chunkIndex}"`; `getJwt` reads `supabase.auth.getSession()`), resets `liveTranscript`.
+- `streaming-chunk` → `enqueue`; `onTranscript` → `setLiveTranscript` + `emit("streaming-transcript", { sessionId, text })`.
+- `streaming-session-end` → `emit("transcription-start", { provider: "Cloud" })`, `await finish()`; zero ok chunks → `onEmpty()`; else `onFinalize(text, billedMs/1000, chunksFailed)`.
+- `streaming-session-cancelled` → `abort()`, reset.
+- `onFatal` → toast the existing cloud i18n keys (`cloud:errors.quota_exhausted` / `errors.auth_expired` / generic network), `emit("transcription-error", ...)`, and `invoke("stop_recording", { silenceThreshold: settings.silence_threshold })` to stop the mic (guarded so a stop already in progress is fine).
+- Ref-trampoline pattern for callbacks (same as existing listeners); sessionId guards stale events.
+
+`useRecordingWorkflow` changes:
+- Instantiate the hook; `onFinalize` runs: `setIsTranscribing(true)` → `maybePostProcessCloud` (same eligibility as cloud batch) → `handleTranscriptionFinal(text, "whisper", "", 0, originalText, undefined, ppCost, billedSeconds, "Cloud")` → `emit("transcription-success", { text })` → `setIsTranscribing(false)`; `chunksFailed > 0` → `toast.warning(t("streaming.partialLoss"))`.
+- `onEmpty` → existing `noSound` toast + `transcription-error` emit.
+- Button stop path: when `isStreamingSessionRef.current`, skip the `transcribeAudio(...)` call **and** the silent-toast (session events handle both).
+- `audio-captured` listener: `if (isStreamingSessionRef.current) return;` defensive guard (Rust already skips the emit).
+- `isStreaming: true` on the history entry: extend `AddTranscription` signature and `useTranscriptionHistory.addTranscription` with `isStreaming?: boolean` (last param) and set it from `onFinalize`.
+- Return `{ liveTranscript, isStreamingSession }` from `useRecordingWorkflow`.
+
+- [x] **Step 1: Implement** hook + integration.
+- [x] **Step 2:** `pnpm build` (tsc) → PASS; `pnpm vitest run` → suite PASS.
+- [x] **Step 3: Commit** `feat: orchestrate streaming uploads and finalization in recording workflow`
+
+### Task 6: Setting + gate push + Settings UI + i18n
+
+**Files:**
+- Modify: `src/lib/settings.ts` (`streaming_mode: boolean`, default `false`)
+- Modify: `src/contexts/CloudContext.tsx` (push `set_streaming_enabled` alongside `set_cloud_gate`: `enabled = settings.streaming_mode && mode === "cloud"`)
+- Modify: `src/components/settings/sections/TranscriptionSection.tsx` (toggle; teaser row disabled + Cloud badge when provider Local or ineligible)
+- Modify: `src/locales/fr.json`, `src/locales/en.json`
+
+i18n keys (translation ns): `settings.transcription.streaming.title`, `.description`, `.cloudOnly` (teaser hint), and top-level `streaming.partialLoss` (toast). FR + EN.
+
+- [x] **Step 1: Implement** (follow the section's existing toggle/PickerCard patterns; reuse eligibility signals already present in the section).
+- [x] **Step 2:** `pnpm build` → PASS. Grep check: no hardcoded UI strings.
+- [x] **Step 3: Commit** `feat: add streaming mode setting with cloud-exclusive UI`
+
+### Task 7: Live display — mini window + dashboard
+
+**Files:**
+- Modify: `src/hooks/useMiniWindowState.ts` (listen `streaming-transcript` → `liveTranscript`; reset on `recording-state` true)
+- Modify: `src/components/mini-window/MiniShell.tsx` (+ new `src/components/mini-window/MiniLiveTranscript.tsx`): while `status === "recording"` and `liveTranscript` non-empty, render one-line tail of the live text (CSS `direction: rtl`-safe tail or JS tail-slice, left fade mask, `aria-live="polite"`), sharing the row with the visualizer + timer.
+- Modify: dashboard recording surface (`AccueilTab`/`RecordingCard` — pick the component that renders the recording state) to show the growing live transcript while `isStreamingSession`.
+
+- [x] **Step 1: Implement** mini + dashboard live views (i18n for any label).
+- [x] **Step 2:** `pnpm build` + `pnpm vitest run` → PASS.
+- [x] **Step 3: Commit** `feat: live transcript display in mini window and dashboard`
+
+### Task 8: Docs, verification, PR
+
+**Files:**
+- Modify: `CHANGELOG.md` (English, Unreleased), `CLAUDE.md` (short streaming section)
+- Create: `docs/v3/streaming-e2e-checklist.md` (button, hotkey toggle, PTT, cancel, quota exhausted, offline mid-dictation, mini live text, final paste, batch parity when disabled)
+
+- [x] **Step 1:** Full verification: `cargo test --no-default-features`, `cargo check --no-default-features`, `pnpm build`, `pnpm vitest run` → all PASS (paste outputs in PR).
+- [x] **Step 2:** Self code-review of the full diff (`git diff main`).
+- [x] **Step 3:** Commit docs `docs: changelog + e2e checklist for streaming mode`, push branch, open PR to `main` (gh CLI) with full description — no merge.
+
+## Self-Review Notes
+
+- Spec §3.2 covered by Tasks 1-2; §3.3 by Tasks 3-6; mini/dashboard by Task 7; §6 tests by Tasks 1/3/4; §9 by Task 8.
+- Type checks: `TapMsg` shared audio.rs ↔ streaming.rs (exported from streaming.rs); `StreamingChunkPayload` field names match the Rust `json!` payload exactly (camelCase); `AddTranscription` extension is additive-optional (no call-site breakage).
+- Deliberately not planned: settings sync of `streaming_mode`, local streaming, live insertion (spec §7).

--- a/docs/superpowers/specs/2026-07-02-streaming-transcription-design.md
+++ b/docs/superpowers/specs/2026-07-02-streaming-transcription-design.md
@@ -1,0 +1,267 @@
+# Mode streaming — transcription en continu (cloud-first)
+
+**Date** : 2026-07-02 (nuit, session autonome)
+**Statut** : validé (auto-approbation — mandat d'autonomie explicite donné par Yohann)
+**Branche** : `feat/streaming-transcription`
+
+## 1. Objectif
+
+Aujourd'hui, Lexena transcrit en batch : l'utilisateur parle, arrête l'enregistrement,
+puis attend que tout l'audio soit transcrit d'un bloc. Le mode streaming affiche le
+texte **pendant** que l'utilisateur parle, phrase par phrase, avec 1 à 2 secondes de
+latence après chaque pause naturelle.
+
+Objectif produit : le streaming est **exclusif à Lexena Cloud**. C'est un argument
+concret d'abonnement — l'utilisateur local voit la feature (teaser désactivé dans les
+settings), l'utilisateur cloud la vit. Aligné avec la stratégie business v3
+(local = gratuit, cloud = trial 60 min puis abo).
+
+## 2. Approches considérées
+
+### A. OpenAI Realtime API (WebSocket, deltas mot à mot) — écartée pour ce lot
+
+- Latence minimale (deltas par mot), le « vrai » streaming.
+- **Bloquant** : nécessite un endpoint serveur qui minte un token éphémère
+  (`POST /v1/realtime/client_secrets`) car la clé OpenAI vit sur le worker
+  `api.lexena.app` — dont le repo n'est pas présent sur cette machine.
+- **Bloquant produit** : l'audio partirait en direct vers OpenAI sans passer par le
+  worker → le billing/quota/trial (comptés par requête `/transcribe` côté serveur)
+  serait contourné. Il faudrait un système de comptage de session complet côté worker.
+- Coût : gpt-4o-transcribe realtime est facturé plus cher que le batch.
+
+### B. Segmentation aux silences + endpoint `/transcribe` existant — **retenue**
+
+- Rust segmente l'audio live aux pauses naturelles (VAD par fenêtres RMS, même
+  famille d'algorithme que `audio_trim.rs`), le frontend envoie chaque segment à
+  l'endpoint `/transcribe` existant dès qu'il est coupé.
+- Le texte apparaît phrase par phrase, ~1-2 s après chaque pause. Granularité
+  « phrase » et non « mot », mais l'effet dictée-live est là.
+- **Zéro changement serveur** : billing, quotas, trial, idempotence, rate-limits —
+  tout le pipeline actuel reste la source de vérité. Chaque segment est une requête
+  `/transcribe` normale, facturée à la durée comme aujourd'hui (la somme des durées
+  des segments = la durée de l'enregistrement, donc coût identique au batch).
+- Livrable de bout en bout cette nuit, testable, sans dépendance externe.
+
+### C. Segmentation côté frontend (polling des samples) — écartée
+
+- Obligerait à faire transiter tout l'audio en continu par l'IPC, avec des timers JS
+  peu fiables quand la fenêtre est cachée. Le Rust possède déjà le callback audio.
+
+**Décision** : B maintenant, avec des frontières de modules qui permettent de brancher
+A plus tard (le transport d'un segment est isolé ; passer à un transport WebSocket ne
+touchera ni la segmentation ni l'assemblage ni l'UI). Prérequis pour A documentés en §10.
+
+## 3. Architecture retenue
+
+```
+┌────────────────────────── Rust ──────────────────────────┐
+│ audio.rs (callback cpal)                                  │
+│   └─ tap optionnel ── mpsc ──► streaming.rs worker thread │
+│                                 SpeechSegmenter (pur)     │
+│                                 émet les événements Tauri │
+└───────────────────────────────┬───────────────────────────┘
+              "streaming-chunk" │ { sessionId, chunkIndex,
+                                │   samples, sampleRate, … }
+┌───────────────────────────────▼── Frontend ───────────────┐
+│ useStreamingSession (hook, fenêtre main)                   │
+│   file d'upload séquentielle ──► transcribeCloud() (exist.)│
+│   assembler (pur) : index → texte, texte assemblé ordonné  │
+│   émet "streaming-transcript" ──► MiniWindow + Dashboard   │
+│   à la fin : finalisation via le pipeline existant         │
+│   (post-process → snippets → historique → collage)         │
+└────────────────────────────────────────────────────────────┘
+```
+
+### 3.1 Répartition des responsabilités
+
+- **Rust = capture + segmentation** (il possède le callback audio, thread fiable
+  même fenêtre cachée). Il n'upload PAS : pas de JWT à pousser côté Rust, pas de
+  duplication du client cloud.
+- **Frontend = upload + assemblage + finalisation**. Réutilise `transcribeCloud`
+  (retry réseau, mapping `CloudApiError`, i18n des erreurs), le JWT est frais à
+  chaque segment via `supabase.auth.getSession()`. Précédent établi : l'événement
+  `audio-captured` fait déjà transiter des enregistrements entiers par l'IPC ; les
+  segments sont plus petits.
+
+### 3.2 Rust — nouveau module `src-tauri/src/streaming.rs`
+
+**`SpeechSegmenter`** — machine à états pure (unités testables sans audio réel) :
+
+- Entrée : lots de samples i16 mono (tels que produits par le callback).
+- Fenêtres RMS de 20 ms (même primitive que `audio_trim.rs`).
+- Seuil adaptatif : fraction du pic RMS observé depuis le début de la session
+  (10 %, clampé [0.004, 0.020]) — robuste au gain micro, cohérent avec `audio_trim`.
+- **Coupe** quand : ≥ 600 ms consécutives sous le seuil ET le segment courant
+  contient de la parole ET dure ≥ 1,4 s. Le point de coupe garde ~250 ms de silence
+  en fin de segment (padding), le reste du silence ouvre le segment suivant —
+  aucun sample de **parole** n'est jamais perdu (seul du silence pur peut être
+  jeté, cf. ci-dessous).
+- **Coupe forcée** à 15 s même sans pause (monologue rapide) : on coupe à la fenêtre
+  de RMS minimal des 2 dernières secondes pour minimiser le risque de couper un mot.
+- **Silence pur** : un segment sans aucune fenêtre de parole n'est jamais émis
+  (pas de requête facturée pour du silence, pas d'hallucination Whisper) ; son buffer
+  est jeté au fil de l'eau (borné en mémoire).
+- `flush()` à l'arrêt : émet la queue si elle contient de la parole.
+
+**Tap audio** (`audio.rs`) : `AudioRecorder` gagne un
+`chunk_tap: Arc<Mutex<Option<mpsc::Sender<TapMsg>>>>`. Dans le callback, après la
+conversion mono, si le tap est actif → `send(TapMsg::Samples(...))` (clone borné,
+non bloquant). `TapMsg::{Samples, Finish, Abort}` — `Finish` déclenche flush + fin de
+session, `Abort` (annulation Échap) jette tout.
+
+**Worker thread** : reçoit les `TapMsg`, nourrit le segmenter, émet :
+
+- `streaming-chunk` `{ sessionId, chunkIndex, samples, sampleRate, startMs, endMs }`
+- `streaming-session-end` `{ sessionId, totalChunks }` (après flush sur `Finish`)
+- `streaming-session-cancelled` `{ sessionId }` (sur `Abort`)
+
+**État & branchement** : `AppState.streaming: Mutex<StreamingRuntime>`
+`{ enabled: bool, session_seq: u64, tap: Option<Sender<TapMsg>> }`.
+
+- Commande `set_streaming_enabled(enabled: bool)` — poussée par le frontend
+  (même patron que `set_cloud_gate`) quand `streaming_mode && provider == LexenaCloud
+  && eligible` change.
+- Les **deux** chemins de démarrage (commande `start_recording` ET
+  `start_recording_shortcut` des hotkeys) passent par un helper commun qui, si
+  `enabled`, installe le tap et démarre le worker (session_seq++).
+- Les chemins d'arrêt (`stop_recording`, hotkey stop, PTT release) envoient `Finish`
+  et retirent le tap ; l'annulation envoie `Abort`.
+- Quand une session streaming était active, le chemin hotkey **n'émet pas**
+  `audio-captured` (les segments sont déjà partis) — le buffer batch reste rempli
+  (filet de sécurité et détection de silence inchangée).
+
+### 3.3 Frontend
+
+**`src/lib/streaming/assembler.ts`** (pur, testé Vitest) : `Map<index, text>` +
+`assembled()` (jointure ordonnée, ignore les index manquants), `markFailed(index)`,
+compteurs (chunks ok/échoués, durée facturée cumulée).
+
+**`src/lib/streaming/session.ts`** (logique de session, transport injecté, testé
+Vitest) : file d'upload **séquentielle** (1 requête en vol, préserve l'ordre et
+lisse le débit vers le worker), retry porté par `transcribeCloud` existant ;
+politique d'erreur :
+
+- `quota_exhausted` / `auth` → **abort de session** : on arrête l'enregistrement
+  proprement (`invoke("stop_recording")`), toast i18n existant, événement
+  `transcription-error`.
+- Erreur réseau/5xx persistante sur un segment → segment marqué perdu, on continue ;
+  ≥ 2 échecs consécutifs → abort. À la fin, si des segments manquent, toast
+  d'avertissement (le texte assemblé reste utilisable).
+
+**`src/hooks/useStreamingSession.ts`** : écoute `streaming-chunk` /
+`streaming-session-end` / `streaming-session-cancelled`, pilote la session, émet
+`streaming-transcript` `{ sessionId, text }` à chaque segment transcrit (consommé par
+le mini window et le Dashboard), expose `{ liveTranscript, isStreamingSession }`.
+
+**Intégration `useRecordingWorkflow`** : le hook streaming lui est subordonné —
+à `streaming-session-end` + file vidée, le texte assemblé entre dans le pipeline de
+finalisation **existant** : post-process cloud (sur le texte complet), substitution
+snippets, `addTranscription(..., isStreaming: true, duration = Σ durées facturées,
+transcriptionProvider = "Cloud")`, collage selon `insertion_mode`, événement
+`transcription-success`. Quand une session streaming est active, `transcribeAudio`
+batch est court-circuité (bouton) et `audio-captured` n'arrive pas (hotkey, cf. §3.2).
+Zéro segment transcrit (tout silence) → même UX que le batch silencieux (toast
+`noSound`).
+
+**Settings** : nouvelle clé `streaming_mode: boolean` (défaut `false`) dans
+`AppSettings` + `DEFAULT_SETTINGS`. UI dans `TranscriptionSection` :
+
+- Provider LexenaCloud : toggle actif « Transcription en continu » + description.
+- Provider Local : rangée teaser désactivée avec chip « Lexena Cloud » (l'upsell).
+- Poussée vers Rust : `CloudContext` (là où `set_cloud_gate` est déjà invoqué)
+  invoque aussi `set_streaming_enabled`.
+- Pas de sync cloud de cette clé pour ce lot (hors des 9 scalaires — à ajouter plus
+  tard si demandé).
+
+**Mini window (le « wow »)** : `useMiniWindowState` écoute `streaming-transcript` →
+`liveTranscript`. Pendant `status === "recording"` avec `liveTranscript` non vide,
+`MiniShell` affiche la **queue du texte live** (dernier ~fragment, une ligne, fondu à
+gauche) entre le visualiseur et le timer. Reset à chaque nouvel enregistrement.
+Aucun redimensionnement de fenêtre (comportement prévisible).
+
+**Dashboard** : pendant une session streaming, le texte live s'affiche dans la zone
+d'enregistrement (AccueilTab/RecordingCard — composant précis choisi à
+l'implémentation), il grandit au fil de la dictée.
+
+### 3.4 Ce qui ne change pas
+
+- Le buffer batch d'`AudioRecorder` continue de tout accumuler (silence detection,
+  parité de comportement, filet de sécurité).
+- Provider Local : strictement aucun changement de comportement.
+- Post-process, snippets, dictionnaire, historique, repaste : inchangés — le
+  streaming se branche en amont, la finalisation est commune.
+- Worker `api.lexena.app` : aucun changement.
+
+## 4. Cas limites & décisions
+
+| Cas | Décision |
+|---|---|
+| PTT + streaming | Fonctionne naturellement (session courte, souvent 1 segment au flush). |
+| Annulation (Échap) | `Abort` : rien n'est finalisé, segments déjà transcrits jetés (déjà facturés — assumé, ils sont courts ; identique à l'annulation batch où l'audio est perdu). |
+| JWT expirant en cours de session | Chaque segment relit la session Supabase (refresh automatique par le client). |
+| Quota épuisé en cours de dictée | Abort + arrêt de l'enregistrement + toast quota existant. |
+| Segment perdu (réseau) | Trou dans le texte + toast d'avertissement en fin ; ≥2 échecs consécutifs → abort. |
+| Très longue pause (réflexion) | Aucun segment émis pendant le silence, mémoire bornée, la session continue. |
+| Fenêtre main fermée (tray) | Cachée, pas fermée — les listeners tournent. Comportement identique au flux `audio-captured` actuel. |
+| `translate_mode` / `smart_formatting` | Même traitement que le chemin cloud batch actuel (non envoyés au worker). |
+| Streaming activé puis provider → Local | `set_streaming_enabled(false)` poussé ; les enregistrements suivants sont batch. |
+| Coupe en plein mot (coupe forcée 15 s) | Risque résiduel accepté, minimisé par la recherche de RMS minimal ; les pauses naturelles dominent très largement en dictée réelle. |
+
+## 5. Risques identifiés (à valider avant merge/beta)
+
+1. **Rate-limit du worker** sur `/transcribe` : une dictée envoie ~4-6 req/min au
+   lieu d'une. La file séquentielle lisse le débit. **À vérifier côté worker avant
+   la beta** (repo non accessible cette nuit).
+2. **Qualité de transcription par segment** : Whisper perd le contexte inter-segments
+   (prompt continu impossible via l'endpoint actuel). Acceptable pour de la dictée ;
+   le post-process sur le texte complet rattrape la ponctuation/cohérence.
+3. **Facturation** : coût identique au batch (somme des durées). Si le worker applique
+   un minimum par requête, léger surcoût — à vérifier en même temps que le point 1.
+
+## 6. Tests
+
+- **Rust** (`streaming.rs`, style `audio_trim.rs`) : coupe aux silences, min/max de
+  durée, contiguïté des segments, silence pur jamais émis, flush, coupe forcée au
+  RMS minimal, abort.
+- **Vitest** : `assembler` (ordre, trous, jointure), `session` (file séquentielle,
+  politique d'erreur quota/réseau/abort, fin de session avec uploads en vol) via
+  transport injecté.
+- **E2E manuel** (checklist `docs/v3/streaming-e2e-checklist.md`) : à dérouler par
+  Yohann au réveil (`pnpm tauri dev`) — bouton, hotkey, PTT, annulation, quota,
+  mini window, collage final.
+
+## 7. Hors scope (volontairement)
+
+- **Insertion continue au curseur** (le texte se tape en live dans l'app cible) —
+  phase 2 naturelle, nécessite une réflexion undo/fenêtre active.
+- **Streaming local** (whisper par segments) — l'architecture segmenter/événements le
+  permet, mais produit veut le cloud d'abord.
+- **Transport OpenAI Realtime** (deltas mot à mot) — cf. §10.
+- Sync cloud de `streaming_mode`.
+
+## 8. Fichiers touchés (prévision)
+
+- Rust : `streaming.rs` (nouveau), `audio.rs` (tap), `state.rs`,
+  `commands/recording.rs`, `commands/settings.rs` (set_streaming_enabled),
+  `hotkeys.rs`, `lib.rs` (enregistrements).
+- Frontend : `lib/streaming/{assembler,session}.ts` (+ tests), 
+  `hooks/useStreamingSession.ts`, `useRecordingWorkflow.ts` (branchement),
+  `useMiniWindowState.ts`, `mini-window/MiniShell.tsx` (+ live line),
+  `settings/sections/TranscriptionSection.tsx`, `lib/settings.ts`,
+  `contexts/CloudContext.tsx`, `locales/{fr,en}.json`.
+- Docs : ce spec, le plan, checklist E2E, CHANGELOG (anglais), CLAUDE.md.
+
+## 9. Critères de succès
+
+- `cargo check` + `cargo test` (Rust) et `pnpm build` + `vitest run` (front) verts.
+- Comportement batch strictement inchangé quand `streaming_mode = false` (défaut).
+- PR ouverte sur `main` avec description complète — **pas de merge automatique**.
+
+## 10. Évolution vers OpenAI Realtime (quand le repo worker sera dispo)
+
+1. Worker : endpoint `POST /realtime-token` (auth JWT + éligibilité) qui crée un
+   client secret éphémère (`POST /v1/realtime/client_secrets`, session type
+   `transcription`, modèle `gpt-4o-mini-transcribe`) + comptage d'usage par session.
+2. Desktop : un transport WebSocket (tokio-tungstenite) remplace la file d'upload —
+   la segmentation Rust, l'assembleur et toute l'UI restent identiques (les deltas
+   arrivent juste plus vite et plus fins).

--- a/docs/v3/streaming-e2e-checklist.md
+++ b/docs/v3/streaming-e2e-checklist.md
@@ -1,0 +1,60 @@
+# Checklist E2E — Mode streaming (transcription en continu)
+
+> À dérouler manuellement (`pnpm tauri dev`) avant merge de `feat/streaming-transcription`.
+> Prérequis : compte connecté + éligible cloud (trial ou abo), provider **Lexena Cloud**,
+> setting **Transcription en continu** activé (Réglages → Dictée → Transcription).
+
+## Activation & gating
+
+- [ ] 1. Provider **Local** : la rangée « Transcription en continu » est désactivée avec
+  le badge « Exclusif Lexena Cloud » ; impossible de l'activer.
+- [ ] 2. Provider **LexenaCloud** + éligible : le toggle s'active et persiste après
+  redémarrage de l'app.
+- [ ] 3. Streaming activé puis retour provider **Local** : l'enregistrement suivant est
+  un batch local classique (aucun événement streaming, aucune requête cloud).
+
+## Dictée nominale
+
+- [ ] 4. **Bouton** (carte héro Accueil) : démarrer, dicter 3-4 phrases avec des pauses
+  naturelles. Le texte apparaît phrase par phrase dans la carte héro (~1-2 s après
+  chaque pause). Stop → l'entrée d'historique contient le texte complet, provider
+  « Cloud », et le collage suit `insertion_mode`.
+- [ ] 5. **Hotkey toggle** (Ctrl+F11) avec fenêtre principale cachée (tray) : le mini
+  window affiche le texte live à la place du visualiseur (point rouge + timer
+  restent). Second Ctrl+F11 → succès, texte collé, entrée d'historique unique
+  (pas de double transcription).
+- [ ] 6. **PTT** (Ctrl+F12 maintenu) : phrase courte, relâcher. Un seul segment (flush),
+  résultat identique au batch.
+- [ ] 7. **Monologue long** (> 15 s sans pause) : coupe forcée — le texte arrive par
+  blocs, pas de mot manifestement coupé en deux dans le résultat final.
+- [ ] 8. **Post-process activé** : le texte live reste brut pendant la dictée ; à l'arrêt,
+  la phase violette « post-traitement » s'affiche et le texte final est reformulé.
+  `originalText` visible dans les détails de la transcription.
+
+## Cas limites
+
+- [ ] 9. **Silence total** (enregistrer 5 s sans parler) : aucun chunk envoyé (vérifier
+  les logs Rust : « 0 chunks »), toast « Aucun son détecté », pas d'entrée d'historique.
+- [ ] 10. **Annulation** (Échap pendant la dictée) : rien n'est collé, aucune entrée
+  d'historique, mini window se cache, session marquée cancelled dans les logs.
+- [ ] 11. **Longue pause** (parler, se taire 20 s, reparler) : pas de chunk pendant le
+  silence, la dictée reprend correctement, texte complet à la fin.
+- [ ] 12. **Coupure réseau en cours de dictée** (couper le Wi-Fi après la 1re phrase) :
+  après 3 échecs consécutifs, toast d'erreur, l'enregistrement s'arrête proprement.
+  Réactiver le réseau → l'app reste fonctionnelle (batch suivant OK).
+- [ ] 13. **Micro-test des settings** (Réglages → Audio → test du micro) : ne déclenche
+  JAMAIS de session streaming (aucun log « Streaming session started »).
+- [ ] 14. **Streaming désactivé** (toggle off) : l'enregistrement cloud est un batch
+  classique — parité de comportement avec la version précédente.
+
+## Facturation & quotas
+
+- [ ] 15. Après une dictée streaming de ~1 min : l'usage du mois (Réglages → Compte)
+  augmente d'environ la durée réelle parlée (somme des segments, pas plus).
+- [ ] 16. Trial/quota épuisé (ou simulé) : toast quota existant, l'enregistrement
+  s'arrête, pas de boucle d'erreurs.
+
+## Rate-limit worker (à vérifier côté infra avant beta)
+
+- [ ] 17. Confirmer que le rate-limit `/transcribe` du worker tolère ~6 req/min/user
+  (dictée continue) — la file d'upload est séquentielle donc ≤ 1 req en vol.

--- a/src-tauri/src/audio.rs
+++ b/src-tauri/src/audio.rs
@@ -1,9 +1,12 @@
 use anyhow::{Result, anyhow};
 use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use cpal::{Device, Host, Stream, StreamConfig};
+use std::sync::mpsc::Sender;
 use std::sync::{Arc, Mutex};
 use tauri::Emitter;
 use tracing::{debug, info};
+
+use crate::streaming::TapMsg;
 
 /// Represents an audio recording session
 pub struct AudioRecorder {
@@ -12,6 +15,11 @@ pub struct AudioRecorder {
     is_recording: Arc<Mutex<bool>>,
     stream_id: Arc<Mutex<u64>>, // Counter to identify current stream
     monitor_only: Arc<Mutex<bool>>, // When true, callback emits levels but skips buffering
+    /// Optional streaming tap: when set, the callback forwards each mono
+    /// sample batch to the streaming segmenter worker (see `streaming.rs`).
+    /// Installed/removed by the recording control paths, never by the
+    /// mic-test monitor.
+    chunk_tap: Arc<Mutex<Option<Sender<TapMsg>>>>,
 }
 
 /// Information about an audio device
@@ -39,7 +47,18 @@ impl AudioRecorder {
             is_recording: Arc::new(Mutex::new(false)),
             stream_id: Arc::new(Mutex::new(0)),
             monitor_only: Arc::new(Mutex::new(false)),
+            chunk_tap: Arc::new(Mutex::new(None)),
         }
+    }
+
+    /// Install or remove the streaming tap consumed by the audio callback.
+    pub fn set_chunk_tap(&mut self, tap: Option<Sender<TapMsg>>) {
+        *self.chunk_tap.lock().unwrap() = tap;
+    }
+
+    /// Sample rate of the current (or last) stream.
+    pub fn current_sample_rate(&self) -> u32 {
+        *self.sample_rate.lock().unwrap()
     }
 
     /// Get list of available input devices
@@ -289,6 +308,7 @@ impl AudioRecorder {
     {
         let channels = config.channels as usize;
         let err_fn = |err| eprintln!("Audio stream error: {}", err);
+        let chunk_tap = self.chunk_tap.clone();
 
         let stream = device.build_input_stream(
             config,
@@ -338,8 +358,15 @@ impl AudioRecorder {
                 // mic-test feature in settings to visualize input level without
                 // accumulating samples).
                 if !*monitor_only.lock().unwrap() {
-                    let mut buf = buffer.lock().unwrap();
-                    buf.extend_from_slice(&samples);
+                    {
+                        let mut buf = buffer.lock().unwrap();
+                        buf.extend_from_slice(&samples);
+                    }
+                    // Streaming tap: forward the batch to the segmenter worker.
+                    // Send failures mean the worker is gone — ignore.
+                    if let Some(tx) = chunk_tap.lock().unwrap().as_ref() {
+                        let _ = tx.send(TapMsg::Samples(samples.clone()));
+                    }
                 }
 
                 // Emit audio level event for visualization

--- a/src-tauri/src/audio_trim.rs
+++ b/src-tauri/src/audio_trim.rs
@@ -130,7 +130,7 @@ fn window_rms(samples: &[i16], window_idx: usize, window_size: usize) -> f32 {
     rms(&samples[start..end])
 }
 
-fn rms(samples: &[i16]) -> f32 {
+pub(crate) fn rms(samples: &[i16]) -> f32 {
     if samples.is_empty() {
         return 0.0;
     }

--- a/src-tauri/src/commands/recording.rs
+++ b/src-tauri/src/commands/recording.rs
@@ -32,6 +32,11 @@ pub fn start_recording(
             e.to_string()
         });
 
+    if result.is_ok() {
+        crate::streaming::maybe_start_streaming_session(state.inner(), &mut recorder, &app_handle);
+    }
+    drop(recorder);
+
     let _ = app_handle.emit("recording-state", true);
 
     if result.is_ok() {
@@ -58,6 +63,10 @@ pub fn stop_recording(
         tracing::error!("Failed to stop recording: {}", e);
         e.to_string()
     });
+
+    // Close the streaming session, if one was opened for this recording. The
+    // worker flushes its tail segment and emits `streaming-session-end`.
+    let _ = crate::streaming::end_streaming_session(state.inner(), &mut recorder, false);
 
     if let Ok(ref recording) = result {
         if recording.is_silent {

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -212,3 +212,20 @@ pub fn set_cloud_gate(
     *guard = CloudGate { provider, eligible };
     Ok(())
 }
+
+/// Push the renderer's streaming-mode snapshot into `AppState.streaming`.
+/// True only when the user enabled the streaming setting, picked LexenaCloud
+/// AND is cloud-eligible (the renderer's `CloudContext` owns that logic).
+/// Both recording start paths (command + hotkey) read it to decide whether to
+/// open a streaming session alongside the regular batch buffer.
+#[tauri::command]
+pub fn set_streaming_enabled(state: State<AppState>, enabled: bool) -> Result<(), String> {
+    let mut guard = state
+        .inner()
+        .streaming
+        .lock()
+        .map_err(|e| format!("streaming lock poisoned: {}", e))?;
+    guard.enabled = enabled;
+    tracing::info!("Streaming mode enabled: {}", enabled);
+    Ok(())
+}

--- a/src-tauri/src/hotkeys.rs
+++ b/src-tauri/src/hotkeys.rs
@@ -158,6 +158,11 @@ fn start_recording_shortcut<R: Runtime>(app_handle: &AppHandle<R>) -> bool {
         }
         match recorder.start_recording(None, app_handle.clone()) {
             Ok(_) => {
+                crate::streaming::maybe_start_streaming_session(
+                    state.inner(),
+                    &mut recorder,
+                    app_handle,
+                );
                 drop(recorder);
                 let _ = app_handle.emit("recording-state", true);
                 register_cancel_shortcut(app_handle);
@@ -176,7 +181,12 @@ fn start_recording_shortcut<R: Runtime>(app_handle: &AppHandle<R>) -> bool {
     }
 }
 
-fn stop_recording_shortcut<R: Runtime>(app_handle: &AppHandle<R>) -> Option<RecordingResult> {
+/// Stop the hotkey-triggered recording. The boolean is true when a streaming
+/// session was active for this recording — in that case the caller must NOT
+/// emit `audio-captured` (chunks were already shipped to the renderer).
+fn stop_recording_shortcut<R: Runtime>(
+    app_handle: &AppHandle<R>,
+) -> Option<(RecordingResult, bool)> {
     let state: State<AppState> = app_handle.state();
 
     let silence_threshold = 0.005;
@@ -185,7 +195,10 @@ fn stop_recording_shortcut<R: Runtime>(app_handle: &AppHandle<R>) -> Option<Reco
         if !recorder.is_recording() {
             None
         } else {
-            Some(recorder.stop_recording(silence_threshold))
+            let stopped = recorder.stop_recording(silence_threshold);
+            let streaming_was_active =
+                crate::streaming::end_streaming_session(state.inner(), &mut recorder, false);
+            Some((stopped, streaming_was_active))
         }
     } else {
         None
@@ -196,8 +209,8 @@ fn stop_recording_shortcut<R: Runtime>(app_handle: &AppHandle<R>) -> Option<Reco
     unregister_post_process_toggle_shortcut(app_handle);
 
     match result {
-        Some(Ok(recording)) => Some(recording),
-        Some(Err(err)) => {
+        Some((Ok(recording), streaming_was_active)) => Some((recording, streaming_was_active)),
+        Some((Err(err), _)) => {
             eprintln!("Error stopping recording: {}", err);
             None
         }
@@ -214,6 +227,8 @@ fn cancel_recording_shortcut<R: Runtime>(app_handle: &AppHandle<R>) {
             return;
         }
         let _ = recorder.stop_recording(silence_threshold);
+        // Abort the streaming session: nothing must be finalized.
+        let _ = crate::streaming::end_streaming_session(state.inner(), &mut recorder, true);
     }
 
     let _ = app_handle.emit("recording-state", false);
@@ -520,8 +535,10 @@ pub(crate) fn apply_hotkeys<R: Runtime>(
         let handler = move |app: &AppHandle<R>, _shortcut: &Shortcut, event: ShortcutEvent| {
             if event.state == ShortcutState::Pressed {
                 if is_recorder_active(app) {
-                    if let Some(recording) = stop_recording_shortcut(app) {
-                        emit_audio_samples(app, recording);
+                    if let Some((recording, streaming_was_active)) = stop_recording_shortcut(app) {
+                        if !streaming_was_active {
+                            emit_audio_samples(app, recording);
+                        }
                     }
                 } else {
                     show_mini_window(app);
@@ -553,8 +570,10 @@ pub(crate) fn apply_hotkeys<R: Runtime>(
                     }
                 }
                 ShortcutState::Released => {
-                    if let Some(recording) = stop_recording_shortcut(app) {
-                        emit_audio_samples(app, recording);
+                    if let Some((recording, streaming_was_active)) = stop_recording_shortcut(app) {
+                        if !streaming_was_active {
+                            emit_audio_samples(app, recording);
+                        }
                     }
                 }
             };

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -11,6 +11,7 @@ mod logs;
 mod notes;
 mod profiles;
 mod state;
+mod streaming;
 mod sync;
 mod transcription;
 mod transcription_local;

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -121,6 +121,7 @@ pub fn run() {
             commands::settings::set_translate_mode,
             commands::settings::set_post_process_enabled,
             commands::settings::set_cloud_gate,
+            commands::settings::set_streaming_enabled,
             commands::model::download_local_model,
             commands::model::check_local_model_exists,
             commands::model::any_local_model_exists,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -59,6 +59,9 @@ pub struct AppState {
     /// Cloud routing snapshot pushed by the renderer; used by hotkey handlers
     /// to refuse `start_recording` when LexenaCloud is selected but ineligible.
     pub(crate) cloud_gate: Mutex<CloudGate>,
+    /// Streaming-mode runtime: enabled snapshot pushed by the renderer plus
+    /// the tap of the currently active streaming session, if any.
+    pub(crate) streaming: Mutex<crate::streaming::StreamingRuntime>,
 }
 
 pub(crate) fn create_app_state() -> AppState {
@@ -77,5 +80,6 @@ pub(crate) fn create_app_state() -> AppState {
         active_profile_id: Mutex::new(String::new()),
         auth: Mutex::new(crate::auth::AuthState::new()),
         cloud_gate: Mutex::new(CloudGate::default()),
+        streaming: Mutex::new(crate::streaming::StreamingRuntime::new()),
     }
 }

--- a/src-tauri/src/streaming.rs
+++ b/src-tauri/src/streaming.rs
@@ -1,0 +1,465 @@
+//! Real-time speech segmentation for streaming transcription.
+//!
+//! While a streaming session is active, the audio callback feeds mono i16
+//! samples into a worker thread that runs a [`SpeechSegmenter`]: a pure state
+//! machine that cuts the live signal into segments at natural pauses. Each
+//! segment is shipped to the renderer as a `streaming-chunk` event and
+//! transcribed through the regular cloud pipeline while the user keeps
+//! talking.
+//!
+//! The detector shares its philosophy with `audio_trim`: fixed 20 ms RMS
+//! windows and an adaptive threshold derived from the running peak RMS of the
+//! session (10% of peak, clamped), so it is robust to mic gain and distance.
+//! Segmentation rules:
+//!
+//! - a cut happens after `silence_gap_ms` of continuous silence, but never
+//!   before the segment reaches `min_segment_ms`;
+//! - a segment that reaches `max_segment_ms` without a pause is force-cut at
+//!   the quietest 20 ms window of the last `force_cut_lookback_ms` (best
+//!   effort to avoid slicing a word in half), the remainder carries over;
+//! - `tail_padding_ms` of trailing silence is kept on each cut, and up to
+//!   `pre_roll_ms` of leading silence is kept before the first speech window
+//!   (attack), so no speech sample is ever dropped — only pure silence is;
+//! - segments with fewer than two speech windows are discarded (click guard,
+//!   same rationale as `audio_trim`), and pure silence never leaves the
+//!   segmenter: memory stays bounded during long pauses.
+
+use crate::audio_trim::rms;
+
+pub struct SegmenterConfig {
+    pub sample_rate: u32,
+    pub window_ms: u32,
+    /// Continuous silence that triggers a cut.
+    pub silence_gap_ms: u32,
+    /// No silence-cut before the segment reaches this duration.
+    pub min_segment_ms: u32,
+    /// Force cut at this duration even without a pause.
+    pub max_segment_ms: u32,
+    /// Search window (from the end) for the quietest force-cut point.
+    pub force_cut_lookback_ms: u32,
+    /// Trailing silence kept on a silence-cut.
+    pub tail_padding_ms: u32,
+    /// Leading silence kept before the first speech window of a segment.
+    pub pre_roll_ms: u32,
+    /// Speech threshold as a fraction of the running peak window RMS.
+    pub threshold_fraction: f32,
+    pub min_threshold: f32,
+    pub max_threshold: f32,
+    /// Below this running peak, the signal is too weak to contain speech.
+    pub noise_floor_peak: f32,
+}
+
+impl SegmenterConfig {
+    pub fn new(sample_rate: u32) -> Self {
+        Self {
+            sample_rate,
+            window_ms: 20,
+            silence_gap_ms: 600,
+            min_segment_ms: 1400,
+            max_segment_ms: 15_000,
+            force_cut_lookback_ms: 2_000,
+            tail_padding_ms: 250,
+            pre_roll_ms: 250,
+            threshold_fraction: 0.10,
+            min_threshold: 0.004,
+            max_threshold: 0.020,
+            noise_floor_peak: 0.010,
+        }
+    }
+}
+
+/// A contiguous run of audio containing speech, ready for transcription.
+pub struct Segment {
+    pub samples: Vec<i16>,
+    pub start_ms: u64,
+    pub end_ms: u64,
+}
+
+pub struct SpeechSegmenter {
+    config: SegmenterConfig,
+    /// Samples per RMS window.
+    window_size: usize,
+    /// Incoming samples not yet forming a complete window.
+    pending: Vec<i16>,
+    /// Current segment under construction.
+    buffer: Vec<i16>,
+    /// Absolute sample index of `buffer[0]` since session start.
+    buffer_start_sample: u64,
+    /// Absolute samples processed (whole windows only).
+    total_samples: u64,
+    peak_rms: f32,
+    has_speech: bool,
+    speech_windows: u32,
+    silence_run_ms: u32,
+}
+
+impl SpeechSegmenter {
+    pub fn new(config: SegmenterConfig) -> Self {
+        let window_size =
+            ((config.sample_rate as u64 * config.window_ms as u64) / 1000).max(1) as usize;
+        Self {
+            config,
+            window_size,
+            pending: Vec::new(),
+            buffer: Vec::new(),
+            buffer_start_sample: 0,
+            total_samples: 0,
+            peak_rms: 0.0,
+            has_speech: false,
+            speech_windows: 0,
+            silence_run_ms: 0,
+        }
+    }
+
+    /// Feed a batch of mono i16 samples; returns 0..n completed segments.
+    pub fn push(&mut self, samples: &[i16]) -> Vec<Segment> {
+        self.pending.extend_from_slice(samples);
+        let ws = self.window_size;
+        let full_windows = self.pending.len() / ws;
+        if full_windows == 0 {
+            return Vec::new();
+        }
+        let drained: Vec<i16> = self.pending.drain(..full_windows * ws).collect();
+
+        let mut out = Vec::new();
+        for window in drained.chunks_exact(ws) {
+            if let Some(segment) = self.process_window(window) {
+                out.push(segment);
+            }
+        }
+        out
+    }
+
+    /// End of stream: returns the trailing segment if it contains speech.
+    pub fn flush(&mut self) -> Option<Segment> {
+        // Fold the incomplete trailing window into the buffer when it belongs
+        // to an active utterance; otherwise it is silence-adjacent noise.
+        if self.has_speech && !self.pending.is_empty() {
+            let pending = std::mem::take(&mut self.pending);
+            self.buffer.extend_from_slice(&pending);
+            self.total_samples += pending.len() as u64;
+        } else {
+            self.pending.clear();
+        }
+
+        let segment = if self.has_speech && self.speech_windows >= 2 {
+            let start_sample = self.buffer_start_sample;
+            let len = self.buffer.len() as u64;
+            Some(Segment {
+                samples: std::mem::take(&mut self.buffer),
+                start_ms: self.sample_to_ms(start_sample),
+                end_ms: self.sample_to_ms(start_sample + len),
+            })
+        } else {
+            None
+        };
+        self.reset_buffer();
+        segment
+    }
+
+    fn process_window(&mut self, window: &[i16]) -> Option<Segment> {
+        let window_start_sample = self.total_samples;
+        self.total_samples += window.len() as u64;
+        if self.buffer.is_empty() {
+            self.buffer_start_sample = window_start_sample;
+        }
+
+        let r = rms(window);
+        if r > self.peak_rms {
+            self.peak_rms = r;
+        }
+        let threshold = (self.peak_rms * self.config.threshold_fraction)
+            .clamp(self.config.min_threshold, self.config.max_threshold);
+        let is_speech = self.peak_rms >= self.config.noise_floor_peak && r > threshold;
+
+        if is_speech {
+            self.buffer.extend_from_slice(window);
+            self.has_speech = true;
+            self.speech_windows += 1;
+            self.silence_run_ms = 0;
+        } else if self.has_speech {
+            self.buffer.extend_from_slice(window);
+            self.silence_run_ms += self.config.window_ms;
+        } else {
+            // No speech yet: keep only a bounded pre-roll of leading silence
+            // so the eventual segment preserves the attack of the first word.
+            self.buffer.extend_from_slice(window);
+            let max_pre_roll = self.ms_to_samples(self.config.pre_roll_ms);
+            if self.buffer.len() > max_pre_roll {
+                let excess = self.buffer.len() - max_pre_roll;
+                self.buffer.drain(..excess);
+                self.buffer_start_sample += excess as u64;
+            }
+            return None;
+        }
+
+        let segment_ms = self.sample_len_ms(self.buffer.len());
+        if self.has_speech
+            && self.silence_run_ms >= self.config.silence_gap_ms
+            && segment_ms >= self.config.min_segment_ms as u64
+        {
+            return self.cut_at_silence();
+        }
+        if self.has_speech && segment_ms >= self.config.max_segment_ms as u64 {
+            return self.force_cut();
+        }
+        None
+    }
+
+    /// Cut after a natural pause: keep `tail_padding_ms` of the trailing
+    /// silence, drop the rest of it (next segment starts fresh).
+    fn cut_at_silence(&mut self) -> Option<Segment> {
+        let silence_samples = self.ms_to_samples(self.silence_run_ms);
+        let keep_tail = self.ms_to_samples(self.config.tail_padding_ms);
+        let drop_len = silence_samples
+            .saturating_sub(keep_tail)
+            .min(self.buffer.len());
+        let cut_len = self.buffer.len() - drop_len;
+
+        let segment = if self.speech_windows >= 2 && cut_len > 0 {
+            Some(Segment {
+                samples: self.buffer[..cut_len].to_vec(),
+                start_ms: self.sample_to_ms(self.buffer_start_sample),
+                end_ms: self.sample_to_ms(self.buffer_start_sample + cut_len as u64),
+            })
+        } else {
+            None // click guard: too little speech to be worth a request
+        };
+        self.reset_buffer();
+        segment
+    }
+
+    /// Force cut a too-long segment at the quietest window of the lookback
+    /// range; the remainder carries over as the start of the next segment.
+    fn force_cut(&mut self) -> Option<Segment> {
+        let ws = self.window_size;
+        let lookback = self
+            .ms_to_samples(self.config.force_cut_lookback_ms)
+            .min(self.buffer.len());
+        let search_start = self.buffer.len() - lookback;
+
+        let mut best_idx = self.buffer.len().saturating_sub(ws);
+        let mut best_rms = f32::MAX;
+        let mut i = search_start;
+        while i + ws <= self.buffer.len() {
+            let r = rms(&self.buffer[i..i + ws]);
+            if r < best_rms {
+                best_rms = r;
+                best_idx = i;
+            }
+            i += ws;
+        }
+        // Cut in the middle of the quietest window.
+        let cut_at = (best_idx + ws / 2).min(self.buffer.len());
+
+        let segment = if self.speech_windows >= 2 && cut_at > 0 {
+            Some(Segment {
+                samples: self.buffer[..cut_at].to_vec(),
+                start_ms: self.sample_to_ms(self.buffer_start_sample),
+                end_ms: self.sample_to_ms(self.buffer_start_sample + cut_at as u64),
+            })
+        } else {
+            None
+        };
+
+        // Carry the remainder over: we are mid-speech by construction.
+        let carry: Vec<i16> = self.buffer[cut_at..].to_vec();
+        let carry_len = carry.len() as u64;
+        self.buffer = carry;
+        self.buffer_start_sample = self.total_samples - carry_len;
+        self.has_speech = !self.buffer.is_empty();
+        self.speech_windows = if self.buffer.is_empty() { 0 } else { 1 };
+        self.silence_run_ms = 0;
+        segment
+    }
+
+    fn reset_buffer(&mut self) {
+        self.buffer.clear();
+        self.buffer_start_sample = self.total_samples;
+        self.has_speech = false;
+        self.speech_windows = 0;
+        self.silence_run_ms = 0;
+    }
+
+    fn ms_to_samples(&self, ms: u32) -> usize {
+        (self.config.sample_rate as u64 * ms as u64 / 1000) as usize
+    }
+
+    fn sample_to_ms(&self, sample_index: u64) -> u64 {
+        sample_index * 1000 / self.config.sample_rate as u64
+    }
+
+    fn sample_len_ms(&self, len: usize) -> u64 {
+        len as u64 * 1000 / self.config.sample_rate as u64
+    }
+
+    #[cfg(test)]
+    pub fn buffered_len(&self) -> usize {
+        self.buffer.len() + self.pending.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::f32::consts::PI;
+
+    const SR: u32 = 48_000;
+
+    fn silence(duration_ms: u32) -> Vec<i16> {
+        let n = (SR as u64 * duration_ms as u64 / 1000) as usize;
+        vec![0i16; n]
+    }
+
+    /// Loud sine wave (~0.28 RMS, far above the 0.020 clamped threshold).
+    fn speech(duration_ms: u32) -> Vec<i16> {
+        let n = (SR as u64 * duration_ms as u64 / 1000) as usize;
+        let amplitude = (i16::MAX as f32) * 0.4;
+        (0..n)
+            .map(|i| {
+                let t = i as f32 / SR as f32;
+                (amplitude * (2.0 * PI * 440.0 * t).sin()) as i16
+            })
+            .collect()
+    }
+
+    fn feed(seg: &mut SpeechSegmenter, parts: &[&[i16]]) -> Vec<Segment> {
+        let mut out = Vec::new();
+        for p in parts {
+            out.extend(seg.push(p));
+        }
+        out
+    }
+
+    fn seg_ms(s: &Segment) -> u64 {
+        s.samples.len() as u64 * 1000 / SR as u64
+    }
+
+    #[test]
+    fn cuts_at_natural_pause() {
+        let mut seg = SpeechSegmenter::new(SegmenterConfig::new(SR));
+        let mut out = feed(&mut seg, &[&speech(3000), &silence(1000), &speech(2000)]);
+        if let Some(tail) = seg.flush() {
+            out.push(tail);
+        }
+        assert_eq!(out.len(), 2, "expected one silence-cut + one flush segment");
+        // First segment: 3s speech + ~250ms tail padding
+        assert!(
+            out[0].end_ms >= 3000 && out[0].end_ms <= 3600,
+            "first segment should end just after the speech, got end_ms={}",
+            out[0].end_ms
+        );
+        // Second segment holds the last 2s of speech
+        assert!(
+            seg_ms(&out[1]) >= 1900,
+            "second segment too short: {}ms",
+            seg_ms(&out[1])
+        );
+    }
+
+    #[test]
+    fn no_cut_before_min_duration() {
+        let mut seg = SpeechSegmenter::new(SegmenterConfig::new(SR));
+        // 500ms speech + 700ms silence: the gap exceeds silence_gap_ms but the
+        // segment is still under min_segment_ms, so no cut may happen.
+        let mut out = feed(&mut seg, &[&speech(500), &silence(700), &speech(1000)]);
+        if let Some(tail) = seg.flush() {
+            out.push(tail);
+        }
+        assert_eq!(out.len(), 1, "min_segment_ms must prevent an early cut");
+        assert!(
+            seg_ms(&out[0]) >= 2000,
+            "single segment should span both utterances, got {}ms",
+            seg_ms(&out[0])
+        );
+    }
+
+    #[test]
+    fn pure_silence_emits_nothing() {
+        let mut seg = SpeechSegmenter::new(SegmenterConfig::new(SR));
+        let out = feed(&mut seg, &[&silence(10_000)]);
+        assert!(out.is_empty());
+        assert!(seg.flush().is_none());
+    }
+
+    #[test]
+    fn isolated_click_discarded() {
+        let mut seg = SpeechSegmenter::new(SegmenterConfig::new(SR));
+        let mut out = feed(&mut seg, &[&silence(2000), &speech(20), &silence(2000)]);
+        if let Some(tail) = seg.flush() {
+            out.push(tail);
+        }
+        assert!(
+            out.is_empty(),
+            "a single 20ms blip must never produce a segment"
+        );
+    }
+
+    #[test]
+    fn force_cut_on_long_speech() {
+        let mut seg = SpeechSegmenter::new(SegmenterConfig::new(SR));
+        let mut out = feed(&mut seg, &[&speech(20_000)]);
+        assert!(
+            !out.is_empty(),
+            "20s of continuous speech must force-cut before flush"
+        );
+        if let Some(tail) = seg.flush() {
+            out.push(tail);
+        }
+        for s in &out {
+            assert!(
+                seg_ms(s) <= 15_500,
+                "no segment may exceed max_segment_ms (+tolerance), got {}ms",
+                seg_ms(s)
+            );
+        }
+    }
+
+    #[test]
+    fn speech_is_contiguous_across_cuts() {
+        let mut seg = SpeechSegmenter::new(SegmenterConfig::new(SR));
+        let speech_fed: usize = 5 * SR as usize; // 3s + 2s
+        let mut out = feed(&mut seg, &[&speech(3000), &silence(1000), &speech(2000)]);
+        if let Some(tail) = seg.flush() {
+            out.push(tail);
+        }
+        let total: usize = out.iter().map(|s| s.samples.len()).sum();
+        assert!(
+            total >= speech_fed,
+            "segments must retain all speech samples: kept {} of {}",
+            total,
+            speech_fed
+        );
+    }
+
+    #[test]
+    fn flush_returns_short_tail() {
+        let mut seg = SpeechSegmenter::new(SegmenterConfig::new(SR));
+        let out = feed(&mut seg, &[&speech(3000), &silence(1000), &speech(600)]);
+        assert_eq!(out.len(), 1, "the pause should have cut the first segment");
+        let tail = seg.flush();
+        assert!(
+            tail.is_some(),
+            "a short trailing utterance must not be lost at flush"
+        );
+        assert!(seg_ms(&tail.unwrap()) >= 500);
+    }
+
+    #[test]
+    fn long_pause_bounded_memory() {
+        let mut seg = SpeechSegmenter::new(SegmenterConfig::new(SR));
+        let batch = silence(500);
+        for _ in 0..120 {
+            // 60s of silence
+            let out = seg.push(&batch);
+            assert!(out.is_empty());
+        }
+        let max_pre_roll = (SR as u64 * 250 / 1000) as usize; // pre_roll_ms
+        let one_window = (SR as u64 * 20 / 1000) as usize;
+        assert!(
+            seg.buffered_len() <= max_pre_roll + one_window,
+            "silence must stay bounded to the pre-roll: buffered {} samples",
+            seg.buffered_len()
+        );
+    }
+}

--- a/src-tauri/src/streaming.rs
+++ b/src-tauri/src/streaming.rs
@@ -24,7 +24,13 @@
 //!   same rationale as `audio_trim`), and pure silence never leaves the
 //!   segmenter: memory stays bounded during long pauses.
 
+use std::sync::mpsc::{Receiver, Sender};
+
+use tauri::{AppHandle, Emitter, Runtime};
+
+use crate::audio::AudioRecorder;
 use crate::audio_trim::rms;
+use crate::state::AppState;
 
 pub struct SegmenterConfig {
     pub sample_rate: u32,
@@ -296,6 +302,188 @@ impl SpeechSegmenter {
     #[cfg(test)]
     pub fn buffered_len(&self) -> usize {
         self.buffer.len() + self.pending.len()
+    }
+}
+
+// ─── Streaming session runtime ──────────────────────────────────────────────
+
+/// Messages flowing from the audio callback (and the recording control paths)
+/// to the streaming worker thread.
+pub enum TapMsg {
+    Samples(Vec<i16>),
+    /// Recording stopped normally: flush the segmenter and end the session.
+    Finish,
+    /// Recording cancelled (Escape): drop everything, nothing is finalized.
+    Abort,
+}
+
+/// Streaming state held in [`AppState`]. `enabled` is a snapshot pushed by the
+/// renderer (`set_streaming_enabled`): true only when the user turned the
+/// streaming setting on, picked LexenaCloud AND is cloud-eligible.
+pub(crate) struct StreamingRuntime {
+    pub(crate) enabled: bool,
+    session_seq: u64,
+    tap: Option<Sender<TapMsg>>,
+}
+
+impl StreamingRuntime {
+    pub(crate) fn new() -> Self {
+        Self {
+            enabled: false,
+            session_seq: 0,
+            tap: None,
+        }
+    }
+}
+
+/// Open a streaming session if the renderer enabled streaming. Must be called
+/// right after `recorder.start_recording()` succeeded, with the recorder lock
+/// still held (both the command path and the hotkey path do this). Installs
+/// the audio-callback tap and spawns the segmenter worker.
+///
+/// Never called by the mic-test monitor path (`start_audio_monitor`), which
+/// must not stream.
+pub(crate) fn maybe_start_streaming_session<R: Runtime>(
+    state: &AppState,
+    recorder: &mut AudioRecorder,
+    app_handle: &AppHandle<R>,
+) {
+    let (session_id, sample_rate, rx) = {
+        let mut runtime = match state.streaming.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!("streaming runtime lock poisoned: {}", poisoned);
+                return;
+            }
+        };
+        if !runtime.enabled {
+            recorder.set_chunk_tap(None);
+            return;
+        }
+        runtime.session_seq += 1;
+        let session_id = runtime.session_seq;
+        let sample_rate = recorder.current_sample_rate();
+        let (tx, rx) = std::sync::mpsc::channel::<TapMsg>();
+        recorder.set_chunk_tap(Some(tx.clone()));
+        runtime.tap = Some(tx);
+        (session_id, sample_rate, rx)
+    };
+
+    let handle = app_handle.clone();
+    std::thread::spawn(move || run_streaming_worker(handle, rx, session_id, sample_rate));
+
+    let _ = app_handle.emit(
+        "streaming-session-started",
+        serde_json::json!({ "sessionId": session_id, "sampleRate": sample_rate }),
+    );
+    tracing::info!(
+        "Streaming session {} started ({} Hz)",
+        session_id,
+        sample_rate
+    );
+}
+
+/// Close the active streaming session, if any. `abort = true` on cancel
+/// (Escape): the worker discards everything instead of flushing. Returns
+/// whether a session was active — the hotkey stop path uses this to skip the
+/// batch `audio-captured` emission (chunks were already shipped).
+pub(crate) fn end_streaming_session(
+    state: &AppState,
+    recorder: &mut AudioRecorder,
+    abort: bool,
+) -> bool {
+    let tap = {
+        let mut runtime = match state.streaming.lock() {
+            Ok(guard) => guard,
+            Err(poisoned) => {
+                tracing::warn!("streaming runtime lock poisoned: {}", poisoned);
+                return false;
+            }
+        };
+        runtime.tap.take()
+    };
+    recorder.set_chunk_tap(None);
+
+    match tap {
+        Some(tx) => {
+            let _ = tx.send(if abort { TapMsg::Abort } else { TapMsg::Finish });
+            true
+        }
+        None => false,
+    }
+}
+
+fn emit_chunk<R: Runtime>(
+    app_handle: &AppHandle<R>,
+    session_id: u64,
+    sample_rate: u32,
+    chunk_index: &mut u32,
+    segment: Segment,
+) {
+    tracing::info!(
+        "Streaming session {}: chunk {} ready ({} samples, {}..{} ms)",
+        session_id,
+        chunk_index,
+        segment.samples.len(),
+        segment.start_ms,
+        segment.end_ms
+    );
+    let _ = app_handle.emit(
+        "streaming-chunk",
+        serde_json::json!({
+            "sessionId": session_id,
+            "chunkIndex": *chunk_index,
+            "samples": segment.samples,
+            "sampleRate": sample_rate,
+            "startMs": segment.start_ms,
+            "endMs": segment.end_ms,
+        }),
+    );
+    *chunk_index += 1;
+}
+
+fn run_streaming_worker<R: Runtime>(
+    app_handle: AppHandle<R>,
+    rx: Receiver<TapMsg>,
+    session_id: u64,
+    sample_rate: u32,
+) {
+    let mut segmenter = SpeechSegmenter::new(SegmenterConfig::new(sample_rate));
+    let mut chunk_index: u32 = 0;
+
+    loop {
+        match rx.recv() {
+            Ok(TapMsg::Samples(samples)) => {
+                for segment in segmenter.push(&samples) {
+                    emit_chunk(&app_handle, session_id, sample_rate, &mut chunk_index, segment);
+                }
+            }
+            Ok(TapMsg::Finish) => {
+                if let Some(segment) = segmenter.flush() {
+                    emit_chunk(&app_handle, session_id, sample_rate, &mut chunk_index, segment);
+                }
+                let _ = app_handle.emit(
+                    "streaming-session-end",
+                    serde_json::json!({ "sessionId": session_id, "totalChunks": chunk_index }),
+                );
+                tracing::info!(
+                    "Streaming session {} finished ({} chunks)",
+                    session_id,
+                    chunk_index
+                );
+                return;
+            }
+            // Abort, or every sender dropped without a Finish (e.g. a new
+            // recording superseded this session): nothing must be finalized.
+            Ok(TapMsg::Abort) | Err(_) => {
+                let _ = app_handle.emit(
+                    "streaming-session-cancelled",
+                    serde_json::json!({ "sessionId": session_id }),
+                );
+                tracing::info!("Streaming session {} cancelled", session_id);
+                return;
+            }
+        }
     }
 }
 

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -99,13 +99,17 @@ export default function Dashboard() {
   const { logs, clearLogs } = useAppLogs();
   const isCompact = useIsCompactLayout(sidebarCollapsed);
 
-  const { isRecording, isTranscribing, handleToggleRecording } =
-    useRecordingWorkflow({
-      settings,
-      addTranscription,
-      onTranscriptionAdded: setSelectedTranscription,
-      latestHistoryText: transcriptions[0]?.text,
-    });
+  const {
+    isRecording,
+    isTranscribing,
+    handleToggleRecording,
+    liveTranscript,
+  } = useRecordingWorkflow({
+    settings,
+    addTranscription,
+    onTranscriptionAdded: setSelectedTranscription,
+    latestHistoryText: transcriptions[0]?.text,
+  });
 
   const {
     openNoteIds,
@@ -387,6 +391,7 @@ export default function Dashboard() {
                       historyCount={transcriptions.length}
                       isRecording={isRecording}
                       isTranscribing={isTranscribing}
+                      liveTranscript={liveTranscript}
                       onToggleRecording={handleToggleRecording}
                       onOpenNote={handleOpenNoteFromSidebar}
                       onCreateNote={() => handleCreateNoteFromSidebar(null)}

--- a/src/components/dashboard/home/HeroDictationCard.tsx
+++ b/src/components/dashboard/home/HeroDictationCard.tsx
@@ -7,6 +7,8 @@ import { HotkeyTokens } from "@/components/common/HotkeyTokens";
 interface HeroDictationCardProps {
   isRecording: boolean;
   isTranscribing?: boolean;
+  /** Assembled live transcript of the active streaming session ("" if none). */
+  liveTranscript?: string;
   onToggleRecording: () => void;
 }
 
@@ -24,6 +26,7 @@ const WAVE_BARS = Array.from({ length: 40 }, (_, i) => i);
 export function HeroDictationCard({
   isRecording,
   isTranscribing = false,
+  liveTranscript = "",
   onToggleRecording,
 }: HeroDictationCardProps) {
   const { t } = useTranslation();
@@ -76,24 +79,36 @@ export function HeroDictationCard({
         </div>
       </div>
 
-      {/* Live / idle waveform */}
-      <div className="flex items-center gap-[3px] h-10 my-5" aria-hidden="true">
-        {WAVE_BARS.map((i) => (
-          <span
-            key={i}
-            className="flex-1 max-w-[5px] min-w-[3px] rounded-full vt-anim-wave-bar"
-            style={{
-              height: `${28 + WAVE_HEIGHTS[i % WAVE_HEIGHTS.length] * 12}px`,
-              background: isRecording
-                ? "var(--vt-accent)"
-                : "color-mix(in oklab, var(--vt-accent) 38%, transparent)",
-              opacity: isRecording ? 1 : 0.6,
-              animationDelay: `${(i * 0.04).toFixed(2)}s`,
-              animationDuration: isRecording ? "0.7s" : "1.8s",
-            }}
-          />
-        ))}
-      </div>
+      {/* Streaming: teleprompter-style live transcript. Otherwise the
+          live / idle decorative waveform. */}
+      {isRecording && liveTranscript ? (
+        <div
+          className="my-5 min-h-10 max-h-28 overflow-hidden flex flex-col justify-end"
+          aria-live="polite"
+        >
+          <p className="text-[13.5px] leading-relaxed text-[var(--vt-fg-2)] whitespace-pre-wrap">
+            {liveTranscript}
+          </p>
+        </div>
+      ) : (
+        <div className="flex items-center gap-[3px] h-10 my-5" aria-hidden="true">
+          {WAVE_BARS.map((i) => (
+            <span
+              key={i}
+              className="flex-1 max-w-[5px] min-w-[3px] rounded-full vt-anim-wave-bar"
+              style={{
+                height: `${28 + WAVE_HEIGHTS[i % WAVE_HEIGHTS.length] * 12}px`,
+                background: isRecording
+                  ? "var(--vt-accent)"
+                  : "color-mix(in oklab, var(--vt-accent) 38%, transparent)",
+                opacity: isRecording ? 1 : 0.6,
+                animationDelay: `${(i * 0.04).toFixed(2)}s`,
+                animationDuration: isRecording ? "0.7s" : "1.8s",
+              }}
+            />
+          ))}
+        </div>
+      )}
 
       <div className="grid gap-2 mt-auto">
         <HeroKeyRow

--- a/src/components/dashboard/tabs/AccueilTab.tsx
+++ b/src/components/dashboard/tabs/AccueilTab.tsx
@@ -14,6 +14,8 @@ interface AccueilTabProps {
   historyCount: number;
   isRecording: boolean;
   isTranscribing: boolean;
+  /** Assembled live transcript of the active streaming session ("" if none). */
+  liveTranscript?: string;
   onToggleRecording: () => void;
   onOpenNote: (note: NoteMeta) => void;
   onCreateNote: () => void;
@@ -35,6 +37,7 @@ export function AccueilTab({
   historyCount,
   isRecording,
   isTranscribing,
+  liveTranscript,
   onToggleRecording,
   onOpenNote,
   onCreateNote,
@@ -56,6 +59,7 @@ export function AccueilTab({
           <HeroDictationCard
             isRecording={isRecording}
             isTranscribing={isTranscribing}
+            liveTranscript={liveTranscript}
             onToggleRecording={onToggleRecording}
           />
           <div className="grid grid-rows-[auto_1fr] gap-4 min-w-0">

--- a/src/components/mini-window/MiniLiveTranscript.tsx
+++ b/src/components/mini-window/MiniLiveTranscript.tsx
@@ -1,0 +1,34 @@
+interface MiniLiveTranscriptProps {
+  text: string;
+}
+
+/** Longest tail of the live transcript that fits one mini-window line. */
+const TAIL_CHARS = 90;
+
+/**
+ * One-line live transcript shown in place of the visualizer while a streaming
+ * session is recording. Displays the tail of the text (the words just spoken)
+ * with a left fade so the cut never looks abrupt.
+ */
+export function MiniLiveTranscript({ text }: MiniLiveTranscriptProps) {
+  const tail = text.length > TAIL_CHARS ? `…${text.slice(-TAIL_CHARS)}` : text;
+
+  return (
+    <div
+      className="flex-1 min-w-0 overflow-hidden"
+      aria-live="polite"
+      data-tauri-drag-region
+    >
+      <p
+        className="text-xs text-vt-fg-2 whitespace-nowrap text-right"
+        style={{
+          maskImage: "linear-gradient(to right, transparent 0, black 16px)",
+          WebkitMaskImage:
+            "linear-gradient(to right, transparent 0, black 16px)",
+        }}
+      >
+        {tail}
+      </p>
+    </div>
+  );
+}

--- a/src/components/mini-window/MiniShell.tsx
+++ b/src/components/mini-window/MiniShell.tsx
@@ -4,6 +4,7 @@ import { useMiniWindowState } from "@/hooks/useMiniWindowState";
 import { useMiniWindowSize } from "@/hooks/useMiniWindowSize";
 import { MiniVisualizer } from "./MiniVisualizer";
 import { MiniHeader } from "./MiniHeader";
+import { MiniLiveTranscript } from "./MiniLiveTranscript";
 import { MiniTranscriptPreview } from "./MiniTranscriptPreview";
 
 export function MiniShell() {
@@ -22,6 +23,7 @@ export function MiniShell() {
     waveformCapacity,
     showTranscriptPreview,
     lastTranscript,
+    liveTranscript,
     language,
     provider,
   } = useMiniWindowState();
@@ -83,13 +85,19 @@ export function MiniShell() {
             className="flex flex-1 items-center gap-2 min-h-0"
             data-tauri-drag-region
           >
-            <MiniVisualizer
-              mode={visualizerMode}
-              audioLevel={audioLevel}
-              isRecording={isRecording}
-              waveformCapacity={waveformCapacity}
-              barMaxHeight={barMaxHeight}
-            />
+            {status === "recording" && liveTranscript ? (
+              // Streaming session: the words just spoken replace the
+              // visualizer — the text itself is the recording feedback.
+              <MiniLiveTranscript text={liveTranscript} />
+            ) : (
+              <MiniVisualizer
+                mode={visualizerMode}
+                audioLevel={audioLevel}
+                isRecording={isRecording}
+                waveformCapacity={waveformCapacity}
+                barMaxHeight={barMaxHeight}
+              />
+            )}
             <MiniHeader
               isRecording={isRecording}
               recordingTime={recordingTime}

--- a/src/components/settings/sections/TranscriptionSection.tsx
+++ b/src/components/settings/sections/TranscriptionSection.tsx
@@ -176,6 +176,37 @@ export function TranscriptionSection({ onSectionChange }: TranscriptionSectionPr
         </Row>
 
         <Row
+          label={t("settings.transcription.streaming.title")}
+          hint={t("settings.transcription.streaming.description")}
+        >
+          {cloudSelected ? (
+            <Toggle
+              on={settings.streaming_mode}
+              onClick={() =>
+                updateSetting("streaming_mode", !settings.streaming_mode)
+              }
+              label={
+                settings.streaming_mode
+                  ? t("common.enabled", { defaultValue: "Activé" })
+                  : t("common.disabled", { defaultValue: "Désactivé" })
+              }
+            />
+          ) : (
+            <div className="flex items-center gap-2.5">
+              <Toggle
+                on={false}
+                onClick={() => {}}
+                disabled
+                label={t("common.disabled", { defaultValue: "Désactivé" })}
+              />
+              <ProviderBadge color="var(--vt-accent)">
+                {t("settings.transcription.streaming.cloudOnly")}
+              </ProviderBadge>
+            </div>
+          )}
+        </Row>
+
+        <Row
           label={t("settings.transcription.language")}
           hint={t("settings.transcription.languageHint", {
             defaultValue:

--- a/src/contexts/CloudContext.tsx
+++ b/src/contexts/CloudContext.tsx
@@ -76,7 +76,7 @@ function currentMonthBoundsUtc(): { start: string; end: string } {
 
 export function CloudProvider({ children }: { children: ReactNode }) {
   const { user } = useAuth();
-  const { settings: { transcription_provider } } = useSettings();
+  const { settings: { transcription_provider, streaming_mode } } = useSettings();
 
   const [eligible, setEligible] = useState(false);
   const [trial, setTrial] = useState<TrialStatus>(DEFAULT_TRIAL);
@@ -189,6 +189,16 @@ export function CloudProvider({ children }: { children: ReactNode }) {
     if (!hasCloudSelected) return "local";
     return eligible ? "cloud" : "local";
   }, [user, eligible, hasCloudSelected]);
+
+  // Push the streaming-mode snapshot to Rust: both recording start paths read
+  // it to decide whether to open a streaming session. Effective only when the
+  // user enabled the setting AND the cloud route is actually usable.
+  useEffect(() => {
+    const enabled = Boolean(streaming_mode) && mode === "cloud";
+    void invoke("set_streaming_enabled", { enabled }).catch(() => {
+      // Non-fatal: with a stale/false flag Rust simply keeps batch behavior.
+    });
+  }, [streaming_mode, mode]);
 
   const value = useMemo<CloudContextValue>(
     () => ({

--- a/src/hooks/useMiniWindowState.ts
+++ b/src/hooks/useMiniWindowState.ts
@@ -47,6 +47,7 @@ export function useMiniWindowState() {
     DEFAULT_SETTINGS.settings.show_transcription_in_mini_window,
   );
   const [lastTranscript, setLastTranscript] = useState("");
+  const [liveTranscript, setLiveTranscript] = useState("");
   const [language, setLanguage] = useState<string | undefined>(undefined);
   const [provider, setProvider] = useState<TranscriptionProvider>(
     DEFAULT_SETTINGS.settings.transcription_provider,
@@ -102,6 +103,7 @@ export function useMiniWindowState() {
     let unlistenThemeChangedFn: (() => void) | null = null;
     let unlistenProviderChangedFn: (() => void) | null = null;
     let unlistenPostProcessStartFn: (() => void) | null = null;
+    let unlistenStreamingTranscriptFn: (() => void) | null = null;
 
     const setupListeners = async () => {
       try {
@@ -194,9 +196,19 @@ export function useMiniWindowState() {
               setStatus("recording");
               setErrorMessage("");
               setLastTranscript("");
+              setLiveTranscript("");
             }
           },
         );
+
+        // Live transcript pushed by the main window during a streaming
+        // session (assembled text so far).
+        unlistenStreamingTranscriptFn = await listen<{
+          sessionId: number;
+          text: string;
+        }>("streaming-transcript", (event) => {
+          setLiveTranscript(event.payload?.text ?? "");
+        });
 
         unlistenTranscriptionStartFn = await listen<
           { provider?: TranscriptionProvider } | undefined
@@ -284,6 +296,7 @@ export function useMiniWindowState() {
       if (unlistenThemeChangedFn) unlistenThemeChangedFn();
       if (unlistenProviderChangedFn) unlistenProviderChangedFn();
       if (unlistenPostProcessStartFn) unlistenPostProcessStartFn();
+      if (unlistenStreamingTranscriptFn) unlistenStreamingTranscriptFn();
     };
   }, []);
 
@@ -301,6 +314,7 @@ export function useMiniWindowState() {
     waveformCapacity,
     showTranscriptPreview,
     lastTranscript,
+    liveTranscript,
     language,
     provider,
   };

--- a/src/hooks/useRecordingWorkflow.ts
+++ b/src/hooks/useRecordingWorkflow.ts
@@ -20,6 +20,7 @@ import type {
   TranscriptionInvokeResult,
 } from "@/lib/types";
 import { useCloud } from "@/hooks/useCloud";
+import { useStreamingSession } from "@/hooks/useStreamingSession";
 import { supabase } from "@/lib/supabase";
 import { transcribeCloud, postProcessCloud } from "@/lib/cloud/api";
 import { CloudApiError } from "@/lib/cloud/errors";
@@ -37,6 +38,7 @@ type AddTranscription = (
   postProcessCost?: number,
   duration?: number,
   transcriptionProvider?: string,
+  isStreaming?: boolean,
 ) => Promise<Transcription>;
 
 interface PostProcessOutcome {
@@ -252,6 +254,7 @@ export function useRecordingWorkflow({
       postProcessCost?: number,
       duration?: number,
       transcriptionProvider?: string,
+      isStreaming?: boolean,
     ) => {
       const trimmed = text?.trim();
       if (!trimmed) {
@@ -277,6 +280,7 @@ export function useRecordingWorkflow({
         postProcessCost,
         duration,
         transcriptionProvider,
+        isStreaming,
       );
       onTranscriptionAdded(newEntry);
       playSuccess();
@@ -305,6 +309,80 @@ export function useRecordingWorkflow({
       settings.insertion_mode,
     ],
   );
+
+  // ─── Streaming mode (cloud-only) ──────────────────────────────────────────
+  // The Rust segmenter ships chunks while the user talks; useStreamingSession
+  // uploads them and hands us the assembled text here. Finalization reuses the
+  // exact same pipeline as batch: post-process → snippets → history → paste.
+  const onStreamingFinalize = useCallback(
+    async (text: string, billedSeconds: number, chunksFailed: number) => {
+      setIsTranscribing(true);
+      try {
+        // Same vocab refresh as the batch path so the snippet match in
+        // handleTranscriptionFinal sees fresh Settings edits.
+        try {
+          await refreshVocab();
+        } catch (e) {
+          console.warn("[streaming vocab refresh failed]", e);
+        }
+
+        let postProcessJwt: string | undefined;
+        if (settings.post_process_enabled) {
+          const { data } = await supabase.auth.getSession();
+          postProcessJwt = data.session?.access_token;
+        }
+        const canPostProcess = Boolean(postProcessJwt);
+        if (shouldPostProcess(text, settings, canPostProcess)) {
+          await emit("post-process-start");
+        }
+        const processed: PostProcessOutcome = canPostProcess
+          ? await maybePostProcessCloud(text, settings, postProcessJwt!, tRef.current)
+          : { text };
+
+        await handleTranscriptionFinal(
+          processed.text,
+          "whisper",
+          "", // streaming audio is never written to disk (cloud path parity)
+          0,
+          processed.originalText,
+          undefined,
+          processed.cost,
+          billedSeconds,
+          "Cloud",
+          true,
+        );
+
+        if (chunksFailed > 0) {
+          toast.warning(tRef.current("streaming.partialLoss"));
+        }
+        await emit("transcription-success", { text: processed.text });
+        await invoke("log_separator");
+      } catch (error) {
+        console.error("Streaming finalization error:", error);
+        await emit("transcription-error", { error: String(error) });
+        await invoke("log_separator");
+      } finally {
+        setIsTranscribing(false);
+      }
+    },
+    [settings, handleTranscriptionFinal, refreshVocab],
+  );
+
+  const onStreamingEmpty = useCallback(() => {
+    toast.info(tRef.current("errors.noSound"), {
+      description: tRef.current("errors.noSoundDesc"),
+    });
+    void emit("transcription-error", {
+      error: tRef.current("errors.soundTooLow"),
+    });
+  }, []);
+
+  const { liveTranscript, isStreamingSession, isStreamingSessionRef } =
+    useStreamingSession({
+      settings,
+      onFinalize: onStreamingFinalize,
+      onEmpty: onStreamingEmpty,
+    });
 
   const transcribeAudio = useCallback(
     async (audioData: number[], sampleRate: number) => {
@@ -490,6 +568,13 @@ export function useRecordingWorkflow({
             return;
           }
 
+          // Streaming session: chunks were already shipped and transcribed;
+          // Rust skips this emit when streaming was active, this guard is
+          // defensive only.
+          if (isStreamingSessionRef.current) {
+            return;
+          }
+
           console.log(
             "Audio captured from keyboard shortcut",
             `(RMS: ${event.payload.avgRms.toFixed(4)}, silent: ${event.payload.isSilent})`,
@@ -567,6 +652,11 @@ export function useRecordingWorkflow({
   const handleToggleRecording = useCallback(async () => {
     try {
       if (isRecording) {
+        // Capture the flag BEFORE stopping: the Rust stop path triggers the
+        // streaming session-end event, which may reset the ref before the
+        // invoke below resolves.
+        const wasStreamingSession = isStreamingSessionRef.current;
+
         const result = await invoke<RecordingResult>("stop_recording", {
           silenceThreshold: settings.silence_threshold,
         });
@@ -580,6 +670,12 @@ export function useRecordingWorkflow({
           `(RMS: ${result.avg_rms.toFixed(4)}, silent: ${result.is_silent})`,
         );
         setIsRecording(false);
+
+        if (wasStreamingSession) {
+          // Chunks were transcribed live; the streaming-session-end handler
+          // finalizes (or reports the empty session). Nothing to do here.
+          return;
+        }
 
         if (result.is_silent) {
           console.log("Empty recording detected, transcription cancelled");
@@ -720,5 +816,7 @@ export function useRecordingWorkflow({
     isRecording,
     isTranscribing,
     handleToggleRecording,
+    liveTranscript,
+    isStreamingSession,
   };
 }

--- a/src/hooks/useStreamingSession.ts
+++ b/src/hooks/useStreamingSession.ts
@@ -1,0 +1,231 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { emit, listen, type UnlistenFn } from "@tauri-apps/api/event";
+import { toast } from "sonner";
+import { useTranslation } from "react-i18next";
+import type { AppSettings } from "@/lib/settings";
+import { supabase } from "@/lib/supabase";
+import { transcribeCloud } from "@/lib/cloud/api";
+import {
+  StreamingUploadSession,
+  type FatalReason,
+  type StreamingChunkPayload,
+} from "@/lib/streaming/session";
+import { flog } from "@/lib/flog";
+
+interface StreamingSessionStartedPayload {
+  sessionId: number;
+  sampleRate: number;
+}
+
+interface StreamingSessionEndPayload {
+  sessionId: number;
+  totalChunks: number;
+}
+
+interface UseStreamingSessionOptions {
+  settings: AppSettings["settings"];
+  /** Final assembled text enters the regular finalization pipeline. */
+  onFinalize: (
+    text: string,
+    billedSeconds: number,
+    chunksFailed: number,
+  ) => Promise<void>;
+  /** Session ended with zero speech chunks (the user said nothing). */
+  onEmpty: () => void;
+}
+
+/**
+ * Frontend orchestrator for a Rust streaming session.
+ *
+ * Listens to the `streaming-*` events emitted by the Rust segmenter worker,
+ * uploads each chunk through the existing cloud client (sequential queue,
+ * see `StreamingUploadSession`), broadcasts the assembled text live via the
+ * `streaming-transcript` event (consumed by the mini window), and hands the
+ * final text to the caller when the session ends.
+ *
+ * A fatal upload error (quota exhausted, auth expired, repeated network
+ * failures) aborts the session and stops the recording — keeping the mic
+ * open would only capture audio nobody can transcribe.
+ */
+export function useStreamingSession({
+  settings,
+  onFinalize,
+  onEmpty,
+}: UseStreamingSessionOptions) {
+  const { t } = useTranslation();
+  const tRef = useRef(t);
+  useEffect(() => {
+    tRef.current = t;
+  }, [t]);
+
+  const [liveTranscript, setLiveTranscript] = useState("");
+  const [isStreamingSession, setIsStreamingSession] = useState(false);
+  const isStreamingSessionRef = useRef(false);
+
+  const sessionRef = useRef<StreamingUploadSession | null>(null);
+  const sessionIdRef = useRef<number>(-1);
+
+  // Ref trampolines so the long-lived listeners always see fresh values.
+  const settingsRef = useRef(settings);
+  useEffect(() => {
+    settingsRef.current = settings;
+  }, [settings]);
+  const onFinalizeRef = useRef(onFinalize);
+  useEffect(() => {
+    onFinalizeRef.current = onFinalize;
+  }, [onFinalize]);
+  const onEmptyRef = useRef(onEmpty);
+  useEffect(() => {
+    onEmptyRef.current = onEmpty;
+  }, [onEmpty]);
+
+  const handleFatal = useCallback(async (reason: FatalReason, error: unknown) => {
+    flog(`[streaming] fatal (${reason}): ${String(error)}`, "error");
+    const translate = tRef.current;
+    const message =
+      reason === "quota"
+        ? translate("cloud:errors.quota_exhausted")
+        : reason === "auth"
+          ? translate("cloud:errors.auth_expired")
+          : translate("errors.transcriptionError", { error: String(error) });
+    toast.error(message);
+    await emit("transcription-error", { error: message });
+    // Stop the mic: nothing can be transcribed anymore. The stop path closes
+    // the Rust session, whose end event resolves the aborted upload session.
+    try {
+      await invoke("stop_recording", {
+        silenceThreshold: settingsRef.current.silence_threshold,
+      });
+    } catch {
+      // Already stopped (or stopping) — nothing else to do.
+    }
+  }, []);
+  const handleFatalRef = useRef(handleFatal);
+  useEffect(() => {
+    handleFatalRef.current = handleFatal;
+  }, [handleFatal]);
+
+  useEffect(() => {
+    let disposed = false;
+    const unlisteners: UnlistenFn[] = [];
+
+    const setup = async () => {
+      const listeners = await Promise.all([
+        listen<StreamingSessionStartedPayload>(
+          "streaming-session-started",
+          (event) => {
+            const { sessionId } = event.payload;
+            // A new uuid per session keeps idempotency keys unique across
+            // app restarts (Rust session ids restart from 1).
+            const sessionUuid = crypto.randomUUID();
+            sessionIdRef.current = sessionId;
+            sessionRef.current = new StreamingUploadSession({
+              sessionId,
+              language: settingsRef.current.language,
+              getJwt: async () => {
+                const { data } = await supabase.auth.getSession();
+                return data.session?.access_token;
+              },
+              transport: async (chunk, jwt, language) => {
+                const result = await transcribeCloud({
+                  samples: Int16Array.from(chunk.samples),
+                  sampleRate: chunk.sampleRate,
+                  language,
+                  jwt,
+                  idempotencyKey: `${sessionUuid}-${chunk.chunkIndex}`,
+                });
+                return { text: result.text, duration_ms: result.duration_ms };
+              },
+              onTranscript: (assembledText) => {
+                setLiveTranscript(assembledText);
+                void emit("streaming-transcript", {
+                  sessionId,
+                  text: assembledText,
+                });
+              },
+              onFatal: (reason, error) => {
+                void handleFatalRef.current(reason, error);
+              },
+            });
+            setLiveTranscript("");
+            setIsStreamingSession(true);
+            isStreamingSessionRef.current = true;
+          },
+        ),
+
+        listen<StreamingChunkPayload>("streaming-chunk", (event) => {
+          if (event.payload.sessionId !== sessionIdRef.current) return;
+          sessionRef.current?.enqueue(event.payload);
+        }),
+
+        listen<StreamingSessionEndPayload>(
+          "streaming-session-end",
+          async (event) => {
+            if (event.payload.sessionId !== sessionIdRef.current) return;
+            const session = sessionRef.current;
+            sessionRef.current = null;
+            if (!session) return;
+
+            const { totalChunks } = event.payload;
+            // Skip the processing state when the session already died on a
+            // fatal error — transcription-error was emitted there, and
+            // re-emitting transcription-start would leave the mini window
+            // stuck on "processing".
+            if (totalChunks > 0 && session.active) {
+              await emit("transcription-start", { provider: "Cloud" });
+            }
+            const outcome = await session.finish();
+
+            setIsStreamingSession(false);
+            isStreamingSessionRef.current = false;
+            setLiveTranscript("");
+
+            if (outcome.aborted) return; // fatal path already surfaced it
+            if (totalChunks === 0) {
+              onEmptyRef.current();
+              return;
+            }
+            if (outcome.chunksOk === 0) {
+              const message = tRef.current("streaming.allChunksFailed");
+              toast.error(message);
+              await emit("transcription-error", { error: message });
+              return;
+            }
+            await onFinalizeRef.current(
+              outcome.text,
+              outcome.billedMs / 1000,
+              outcome.chunksFailed,
+            );
+          },
+        ),
+
+        listen<{ sessionId: number }>("streaming-session-cancelled", (event) => {
+          if (event.payload.sessionId !== sessionIdRef.current) return;
+          sessionRef.current?.abort();
+          sessionRef.current = null;
+          setIsStreamingSession(false);
+          isStreamingSessionRef.current = false;
+          setLiveTranscript("");
+        }),
+      ]);
+
+      if (disposed) {
+        listeners.forEach((fn) => fn());
+      } else {
+        unlisteners.push(...listeners);
+      }
+    };
+
+    void setup().catch((error) => {
+      console.error("Failed to register streaming listeners:", error);
+    });
+
+    return () => {
+      disposed = true;
+      unlisteners.forEach((fn) => fn());
+    };
+  }, []);
+
+  return { liveTranscript, isStreamingSession, isStreamingSessionRef };
+}

--- a/src/hooks/useTranscriptionHistory.ts
+++ b/src/hooks/useTranscriptionHistory.ts
@@ -78,6 +78,7 @@ export function useTranscriptionHistory(historyKeepLast?: number) {
     postProcessCost?: number,
     duration?: number,
     transcriptionProvider?: string,
+    isStreaming?: boolean,
   ): Promise<Transcription> => {
     const now = new Date();
     const pad = (n: number) => String(n).padStart(2, '0');
@@ -95,6 +96,7 @@ export function useTranscriptionHistory(historyKeepLast?: number) {
       text,
       provider,
       duration,
+      isStreaming,
       audioPath,
       apiCost,
       transcriptionProvider,

--- a/src/lib/settings.ts
+++ b/src/lib/settings.ts
@@ -19,6 +19,12 @@ export interface AppSettings {
     keep_model_in_memory: boolean | null;
     language: string;
     smart_formatting: boolean;
+    /**
+     * Live sentence-by-sentence transcription while recording. Cloud-only:
+     * only effective when the provider is LexenaCloud and the user is
+     * cloud-eligible (CloudContext pushes the combined flag to Rust).
+     */
+    streaming_mode: boolean;
 
     // Translation
     translate_mode: boolean;
@@ -120,6 +126,7 @@ export const DEFAULT_SETTINGS: AppSettings = {
     keep_model_in_memory: null, // null = auto (GPU: keep, CPU: unload after 2min)
     language: "fr-FR",
     smart_formatting: true,
+    streaming_mode: false,
 
     // Translation
     translate_mode: false,

--- a/src/lib/streaming/assembler.test.ts
+++ b/src/lib/streaming/assembler.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "vitest";
+import { TranscriptAssembler } from "./assembler";
+
+describe("TranscriptAssembler", () => {
+  it("joins chunks in index order even when upserted out of order", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(2, "trois.");
+    a.upsert(0, "Un,");
+    a.upsert(1, "deux,");
+    expect(a.assembled()).toBe("Un, deux, trois.");
+  });
+
+  it("skips missing indexes without blocking assembly", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "Début");
+    a.upsert(3, "fin.");
+    expect(a.assembled()).toBe("Début fin.");
+  });
+
+  it("excludes failed chunks from the join but counts them", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "Bonjour");
+    a.markFailed(1);
+    a.upsert(2, "monde.");
+    expect(a.assembled()).toBe("Bonjour monde.");
+    expect(a.okCount).toBe(2);
+    expect(a.failedCount).toBe(1);
+  });
+
+  it("ignores empty and whitespace-only chunk texts in the join", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "Texte");
+    a.upsert(1, "   ");
+    a.upsert(2, "");
+    a.upsert(3, "suite.");
+    expect(a.assembled()).toBe("Texte suite.");
+  });
+
+  it("normalizes runs of whitespace between chunks", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "  Un  ");
+    a.upsert(1, "\ndeux\t");
+    expect(a.assembled()).toBe("Un deux");
+  });
+
+  it("overwrites on double upsert of the same index", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "brouillon");
+    a.upsert(0, "final.");
+    expect(a.assembled()).toBe("final.");
+    expect(a.okCount).toBe(1);
+  });
+
+  it("a later success clears a previous failure for that index", () => {
+    const a = new TranscriptAssembler();
+    a.markFailed(0);
+    a.upsert(0, "récupéré.");
+    expect(a.assembled()).toBe("récupéré.");
+    expect(a.failedCount).toBe(0);
+  });
+});

--- a/src/lib/streaming/assembler.ts
+++ b/src/lib/streaming/assembler.ts
@@ -1,0 +1,41 @@
+/**
+ * Ordered assembly of per-chunk transcripts for a streaming session.
+ *
+ * Chunks are uploaded sequentially but this stays defensive: results are
+ * keyed by chunk index and joined in order, so an out-of-order or missing
+ * result can never scramble the final text. Failed chunks leave a gap (the
+ * caller warns the user) but never block assembly.
+ */
+export class TranscriptAssembler {
+  private texts = new Map<number, string>();
+  private failed = new Set<number>();
+
+  upsert(index: number, text: string): void {
+    this.failed.delete(index);
+    this.texts.set(index, text);
+  }
+
+  markFailed(index: number): void {
+    this.texts.delete(index);
+    this.failed.add(index);
+  }
+
+  /** Ordered join of every non-empty chunk text, single-spaced and trimmed. */
+  assembled(): string {
+    const indexes = [...this.texts.keys()].sort((a, b) => a - b);
+    return indexes
+      .map((i) => (this.texts.get(i) ?? "").trim())
+      .filter((t) => t.length > 0)
+      .join(" ")
+      .replace(/\s+/g, " ")
+      .trim();
+  }
+
+  get okCount(): number {
+    return this.texts.size;
+  }
+
+  get failedCount(): number {
+    return this.failed.size;
+  }
+}

--- a/src/lib/streaming/session.test.ts
+++ b/src/lib/streaming/session.test.ts
@@ -1,0 +1,176 @@
+import { describe, expect, it, vi } from "vitest";
+import { CloudApiError } from "@/lib/cloud/errors";
+import {
+  StreamingUploadSession,
+  type StreamingChunkPayload,
+} from "./session";
+
+function chunk(index: number): StreamingChunkPayload {
+  return {
+    sessionId: 1,
+    chunkIndex: index,
+    samples: [0, 0, 0],
+    sampleRate: 48000,
+    startMs: index * 1000,
+    endMs: index * 1000 + 900,
+  };
+}
+
+const jwtOk = async () => "jwt-token";
+
+describe("StreamingUploadSession", () => {
+  it("uploads sequentially (never more than one in flight) and in order", async () => {
+    let inFlight = 0;
+    let maxInFlight = 0;
+    const order: number[] = [];
+    const session = new StreamingUploadSession({
+      sessionId: 1,
+      getJwt: jwtOk,
+      transport: async (c) => {
+        inFlight += 1;
+        maxInFlight = Math.max(maxInFlight, inFlight);
+        // First chunk is the slowest: sequentiality must still hold.
+        await new Promise((r) => setTimeout(r, c.chunkIndex === 0 ? 30 : 1));
+        order.push(c.chunkIndex);
+        inFlight -= 1;
+        return { text: `t${c.chunkIndex}`, duration_ms: 1000 };
+      },
+      onTranscript: () => {},
+      onFatal: () => {},
+    });
+
+    session.enqueue(chunk(0));
+    session.enqueue(chunk(1));
+    session.enqueue(chunk(2));
+    const outcome = await session.finish();
+
+    expect(maxInFlight).toBe(1);
+    expect(order).toEqual([0, 1, 2]);
+    expect(outcome.text).toBe("t0 t1 t2");
+    expect(outcome.chunksOk).toBe(3);
+    expect(outcome.billedMs).toBe(3000);
+    expect(outcome.aborted).toBe(false);
+  });
+
+  it("reports the assembled text after each chunk", async () => {
+    const seen: string[] = [];
+    const session = new StreamingUploadSession({
+      sessionId: 1,
+      getJwt: jwtOk,
+      transport: async (c) => ({ text: `t${c.chunkIndex}`, duration_ms: 500 }),
+      onTranscript: (text) => seen.push(text),
+      onFatal: () => {},
+    });
+    session.enqueue(chunk(0));
+    session.enqueue(chunk(1));
+    await session.finish();
+    expect(seen).toEqual(["t0", "t0 t1"]);
+  });
+
+  it("aborts with reason quota on a 402 and stops processing", async () => {
+    const onFatal = vi.fn();
+    let calls = 0;
+    const session = new StreamingUploadSession({
+      sessionId: 1,
+      getJwt: jwtOk,
+      transport: async () => {
+        calls += 1;
+        throw new CloudApiError(402, "quota_exhausted", "no minutes left");
+      },
+      onTranscript: () => {},
+      onFatal,
+    });
+    session.enqueue(chunk(0));
+    session.enqueue(chunk(1));
+    const outcome = await session.finish();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(onFatal.mock.calls[0][0]).toBe("quota");
+    expect(calls).toBe(1); // chunk 1 dropped after abort
+    expect(outcome.aborted).toBe(true);
+  });
+
+  it("aborts with reason auth when no JWT is available", async () => {
+    const onFatal = vi.fn();
+    const transport = vi.fn();
+    const session = new StreamingUploadSession({
+      sessionId: 1,
+      getJwt: async () => undefined,
+      transport,
+      onTranscript: () => {},
+      onFatal,
+    });
+    session.enqueue(chunk(0));
+    await session.finish();
+    expect(onFatal.mock.calls[0][0]).toBe("auth");
+    expect(transport).not.toHaveBeenCalled();
+  });
+
+  it("tolerates isolated failures but aborts after too many consecutive ones", async () => {
+    const onFatal = vi.fn();
+    const session = new StreamingUploadSession({
+      sessionId: 1,
+      getJwt: jwtOk,
+      transport: async (c) => {
+        if (c.chunkIndex >= 1) throw new Error("http 500");
+        return { text: `t${c.chunkIndex}`, duration_ms: 700 };
+      },
+      onTranscript: () => {},
+      onFatal,
+    });
+    // 0 ok, then 1, 2 fail (tolerated: max 2), 3 fails → fatal network.
+    for (let i = 0; i < 4; i++) session.enqueue(chunk(i));
+    const outcome = await session.finish();
+
+    expect(onFatal).toHaveBeenCalledTimes(1);
+    expect(onFatal.mock.calls[0][0]).toBe("network");
+    expect(outcome.aborted).toBe(true);
+    expect(outcome.chunksOk).toBe(1);
+  });
+
+  it("a single failure then success leaves a gap without aborting", async () => {
+    const onFatal = vi.fn();
+    const session = new StreamingUploadSession({
+      sessionId: 1,
+      getJwt: jwtOk,
+      transport: async (c) => {
+        if (c.chunkIndex === 1) throw new Error("http 500");
+        return { text: `t${c.chunkIndex}`, duration_ms: 1000 };
+      },
+      onTranscript: () => {},
+      onFatal,
+    });
+    session.enqueue(chunk(0));
+    session.enqueue(chunk(1));
+    session.enqueue(chunk(2));
+    const outcome = await session.finish();
+
+    expect(onFatal).not.toHaveBeenCalled();
+    expect(outcome.text).toBe("t0 t2");
+    expect(outcome.chunksOk).toBe(2);
+    expect(outcome.chunksFailed).toBe(1);
+    expect(outcome.billedMs).toBe(2000); // only successful chunks are billed
+    expect(outcome.aborted).toBe(false);
+  });
+
+  it("abort() drops queued chunks", async () => {
+    let calls = 0;
+    const session = new StreamingUploadSession({
+      sessionId: 1,
+      getJwt: jwtOk,
+      transport: async (c) => {
+        calls += 1;
+        await new Promise((r) => setTimeout(r, 10));
+        return { text: `t${c.chunkIndex}`, duration_ms: 100 };
+      },
+      onTranscript: () => {},
+      onFatal: () => {},
+    });
+    session.enqueue(chunk(0));
+    session.enqueue(chunk(1));
+    session.abort();
+    const outcome = await session.finish();
+    expect(calls).toBeLessThanOrEqual(1);
+    expect(outcome.aborted).toBe(true);
+  });
+});

--- a/src/lib/streaming/session.ts
+++ b/src/lib/streaming/session.ts
@@ -1,0 +1,135 @@
+import { CloudApiError } from "@/lib/cloud/errors";
+import { TranscriptAssembler } from "./assembler";
+
+/** Payload of the Rust `streaming-chunk` event (camelCase, see streaming.rs). */
+export interface StreamingChunkPayload {
+  sessionId: number;
+  chunkIndex: number;
+  samples: number[];
+  sampleRate: number;
+  startMs: number;
+  endMs: number;
+}
+
+/** Uploads one chunk and returns its transcript. Injected for testability —
+ *  production wires `transcribeCloud` here (which already retries transient
+ *  network errors internally). */
+export type ChunkTransport = (
+  chunk: StreamingChunkPayload,
+  jwt: string,
+  language?: string,
+) => Promise<{ text: string; duration_ms: number }>;
+
+export type FatalReason = "quota" | "auth" | "network";
+
+export interface StreamingOutcome {
+  text: string;
+  billedMs: number;
+  chunksOk: number;
+  chunksFailed: number;
+  aborted: boolean;
+}
+
+export interface StreamingSessionOptions {
+  sessionId: number;
+  language?: string;
+  getJwt: () => Promise<string | undefined>;
+  transport: ChunkTransport;
+  /** Called after each successful chunk with the full assembled text so far. */
+  onTranscript: (assembledText: string) => void;
+  /** A fatal error aborts the session; the caller stops the recording. */
+  onFatal: (reason: FatalReason, error: unknown) => void;
+  /** Consecutive non-fatal failures tolerated before aborting. Default 2. */
+  maxConsecutiveFailures?: number;
+}
+
+/**
+ * Sequential upload pump for one streaming session: chunks are transcribed
+ * one at a time, in order (this also throttles the request rate towards the
+ * worker). Quota/auth errors are fatal immediately; other errors skip the
+ * chunk and only become fatal after `maxConsecutiveFailures` in a row.
+ */
+export class StreamingUploadSession {
+  private readonly opts: StreamingSessionOptions;
+  private readonly assembler = new TranscriptAssembler();
+  private readonly maxConsecutiveFailures: number;
+
+  private pump: Promise<void> = Promise.resolve();
+  private billedMs = 0;
+  private consecutiveFailures = 0;
+  private aborted = false;
+  private fatalSignaled = false;
+
+  constructor(opts: StreamingSessionOptions) {
+    this.opts = opts;
+    this.maxConsecutiveFailures = opts.maxConsecutiveFailures ?? 2;
+  }
+
+  get active(): boolean {
+    return !this.aborted;
+  }
+
+  enqueue(chunk: StreamingChunkPayload): void {
+    if (this.aborted) return;
+    this.pump = this.pump.then(() => this.processChunk(chunk));
+  }
+
+  /** Resolves once every enqueued chunk has been processed (or dropped). */
+  async finish(): Promise<StreamingOutcome> {
+    await this.pump;
+    return {
+      text: this.assembler.assembled(),
+      billedMs: this.billedMs,
+      chunksOk: this.assembler.okCount,
+      chunksFailed: this.assembler.failedCount,
+      aborted: this.aborted,
+    };
+  }
+
+  /** Drop all pending work; in-flight upload finishes but is discarded. */
+  abort(): void {
+    this.aborted = true;
+  }
+
+  private fatal(reason: FatalReason, error: unknown): void {
+    this.abort();
+    if (!this.fatalSignaled) {
+      this.fatalSignaled = true;
+      this.opts.onFatal(reason, error);
+    }
+  }
+
+  private async processChunk(chunk: StreamingChunkPayload): Promise<void> {
+    if (this.aborted) return;
+
+    const jwt = await this.opts.getJwt();
+    if (!jwt) {
+      this.fatal("auth", new Error("no active session JWT"));
+      return;
+    }
+
+    try {
+      const result = await this.opts.transport(chunk, jwt, this.opts.language);
+      if (this.aborted) return;
+      this.assembler.upsert(chunk.chunkIndex, result.text);
+      this.billedMs += result.duration_ms;
+      this.consecutiveFailures = 0;
+      this.opts.onTranscript(this.assembler.assembled());
+    } catch (error) {
+      if (this.aborted) return;
+      if (error instanceof CloudApiError && error.isQuotaIssue()) {
+        this.fatal("quota", error);
+        return;
+      }
+      if (error instanceof CloudApiError && error.isAuthIssue()) {
+        this.fatal("auth", error);
+        return;
+      }
+      this.assembler.markFailed(chunk.chunkIndex);
+      this.consecutiveFailures += 1;
+      if (this.consecutiveFailures > this.maxConsecutiveFailures) {
+        this.fatal("network", error);
+      }
+    }
+  }
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -477,6 +477,11 @@
       "providerLocalSub": "offline · CPU/GPU",
       "smartFormatting": "Smart formatting (punctuation, capitals, spaces)",
       "smartFormattingHint": "Fixes capitalization, punctuation and spaces on the Whisper output.",
+      "streaming": {
+        "title": "Live transcription",
+        "description": "Text appears sentence by sentence while you speak, instead of waiting for the recording to end.",
+        "cloudOnly": "Lexena Cloud exclusive"
+      },
       "cloudStatus": {
         "signinRequired": "Sign-in required",
         "trialActive": "Trial active",
@@ -941,6 +946,10 @@
     "codeTitle": "Code and separators",
     "codeDesc": "<p>Type <code>---</code> to insert a separator, or <code>```</code> for a code block.</p>",
     "start": "<p>Start writing your first note!</p>"
+  },
+  "streaming": {
+    "partialLoss": "Some passages could not be transcribed (network issue). The text may be incomplete.",
+    "allChunksFailed": "Live transcription failed: no segment could be transcribed."
   },
   "errors": {
     "transcriptionError": "Transcription error: {{error}}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -477,6 +477,11 @@
       "providerLocalSub": "hors-ligne · CPU/GPU",
       "smartFormatting": "Formatage intelligent (ponctuation, majuscules, espaces)",
       "smartFormattingHint": "Corrige majuscules, ponctuation et espaces sur la sortie Whisper.",
+      "streaming": {
+        "title": "Transcription en continu",
+        "description": "Le texte apparaît phrase par phrase pendant que tu parles, au lieu d'attendre la fin de l'enregistrement.",
+        "cloudOnly": "Exclusif Lexena Cloud"
+      },
       "cloudStatus": {
         "signinRequired": "Connexion requise",
         "trialActive": "Essai actif",
@@ -941,6 +946,10 @@
     "codeTitle": "Code et séparateurs",
     "codeDesc": "<p>Tapez <code>---</code> pour insérer un séparateur, ou <code>```</code> pour un bloc de code.</p>",
     "start": "<p>Commencez à écrire votre première note !</p>"
+  },
+  "streaming": {
+    "partialLoss": "Certains passages n'ont pas pu être transcrits (problème réseau). Le texte peut être incomplet.",
+    "allChunksFailed": "La transcription en continu a échoué : aucun segment n'a pu être transcrit."
   },
   "errors": {
     "transcriptionError": "Erreur de transcription : {{error}}",


### PR DESCRIPTION
## Mode streaming — transcription en continu (cloud-only) 🎙️⚡

Implémenté en session autonome (nuit du 2026-07-01 → 02) sur mandat explicite : « fais le mode streaming, cloud d'abord, pour donner envie de payer l'abonnement ».

### Ce que ça fait

Pendant l'enregistrement, le texte apparaît **phrase par phrase** (~1-2 s après chaque pause naturelle) au lieu d'attendre la fin :

- **Mini window** : le texte live remplace le visualiseur pendant la dictée (dot rouge + timer conservés)
- **Carte héro Accueil** : zone « prompteur » qui grandit au fil de la dictée
- À l'arrêt, le texte assemblé suit le pipeline **inchangé** : post-process IA → snippets → historique (`isStreaming: true`) → collage

Exclusif **Lexena Cloud** : le toggle (Réglages → Dictée → Transcription) est grisé avec badge « Exclusif Lexena Cloud » quand le provider est Local — c'est l'upsell.

### Architecture (spec complète : `docs/superpowers/specs/2026-07-02-streaming-transcription-design.md`)

**Choix structurant** : segmentation aux silences côté Rust + envoi de chaque segment à l'endpoint `/transcribe` existant. **Zéro changement worker** : billing, quotas, trial, idempotence restent la source de vérité (coût = somme des durées des segments = identique au batch). L'alternative OpenAI Realtime (deltas mot à mot) est documentée en §10 du spec — elle exige un endpoint de token éphémère côté worker (repo non accessible) et un contournement du billing actuel.

- **Rust** (`streaming.rs`) : `SpeechSegmenter` pur (fenêtres RMS 20 ms, seuil adaptatif façon `audio_trim`, coupe ≥ 600 ms de silence, min 1,4 s, coupe forcée 15 s au RMS minimal, garde anti-clic, silence pur jamais émis → mémoire bornée) + tap optionnel dans le callback cpal → worker thread → événements `streaming-*`. Câblé dans les deux chemins de démarrage (commande + hotkey), jamais dans le test micro. Sur stop hotkey avec session active, `audio-captured` n'est pas émis (pas de double transcription).
- **Frontend** : `useStreamingSession` + `lib/streaming/{assembler,session}.ts` (purs, testés) — file d'upload séquentielle via `transcribeCloud` existant (JWT frais par segment, clé d'idempotence par chunk), assemblage ordonné, événement `streaming-transcript` pour l'UI.
- **Politique d'erreurs** : quota/auth → abort + arrêt du micro + toasts i18n existants ; échec réseau isolé → segment sauté (toast d'avertissement en fin) ; > 2 échecs consécutifs → abort.
- **Parité batch garantie** : `streaming_mode=false` (défaut) ou provider Local → aucun changement de comportement.

### Tests

- Rust : 8 tests unitaires segmenter (coupes, min/max, contiguïté de la parole, clic isolé, flush, mémoire bornée) — `cargo test --no-default-features`
- Vitest : 14 tests (assembler ×7, session queue/erreurs ×7)
- Checklist E2E manuelle : `docs/v3/streaming-e2e-checklist.md` (17 cas) — **à dérouler avant merge**

### À vérifier avant beta (hors repo)

- Rate-limit du worker sur `/transcribe` (~6 req/min/user en dictée continue ; file séquentielle donc ≤ 1 req en vol)
- Minimum de facturation par requête éventuel côté worker

### Hors scope (volontaire, cf. spec §7)

Insertion continue au curseur (phase 2), streaming local, transport OpenAI Realtime, sync cloud du setting.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
