### PR TITLE
chore: fix cargo audit gate (crossbeam-epoch bump + quick-xml ignores)

### DIFF
--- a/.github/workflows/security-audit.yml
+++ b/.github/workflows/security-audit.yml
@@ -47,6 +47,9 @@ jobs:
         # HIGH/CRITICAL gate: warnings (unmaintained) ne cassent pas le job.
         # Les RUSTSECs ignorés viennent de dépendances transitives via Tauri 2.10.x
         # (pas de fix disponible sans bump Tauri majeur). À revoir au prochain bump.
+        # RUSTSEC-2026-0194/0195 : quick-xml <0.41 (DoS parsing XML), aucun backport ;
+        # tiré par wayland-scanner (proc-macro build-time, clipboard Linux) et
+        # plist (Tauri, parsing de bundles macOS de confiance) — input non attaquable.
         run: |
           cargo audit \
             --ignore RUSTSEC-2026-0007 \
@@ -57,4 +60,6 @@ jobs:
             --ignore RUSTSEC-2026-0099 \
             --ignore RUSTSEC-2026-0068 \
             --ignore RUSTSEC-2026-0067 \
-            --ignore RUSTSEC-2026-0009
+            --ignore RUSTSEC-2026-0009 \
+            --ignore RUSTSEC-2026-0194 \
+            --ignore RUSTSEC-2026-0195

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -942,9 +942,9 @@ dependencies = [
 
 [[package]]
 name = "crossbeam-epoch"
-version = "0.9.18"
+version = "0.9.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
 dependencies = [
  "crossbeam-utils",
 ]


### PR DESCRIPTION
## Summary

The Security Audit workflow has been failing daily on main since 2026-07-08 (5 vulnerabilities flagged). This PR brings the `cargo audit (HIGH/CRITICAL gate)` back to green:

- **crossbeam-epoch 0.9.18 → 0.9.20** ([RUSTSEC-2026-0204](https://rustsec.org/advisories/RUSTSEC-2026-0204), invalid pointer dereference): targeted, semver-compatible `cargo update -p crossbeam-epoch`. Pulled via `sysinfo → rayon`.
- **quick-xml 0.37.5 / 0.38.3** ([RUSTSEC-2026-0194](https://rustsec.org/advisories/RUSTSEC-2026-0194) + [RUSTSEC-2026-0195](https://rustsec.org/advisories/RUSTSEC-2026-0195), CVSS 7.5 DoS in XML parsing): **no backport exists** — the fix only ships in `>=0.41.0`, unreachable until `wayland-scanner` (^0.37, max 0.39 via 0.31.10) and `plist` (^0.38, via Tauri 2.10.x) bump their requirement. Added documented `--ignore` entries following the existing convention (9 prior Tauri-transitive ignores).

### Why ignoring quick-xml is acceptable

- `wayland-scanner` is a **build-time proc-macro** (Linux clipboard path) — never parses runtime input
- `plist` parses **trusted macOS app bundles** — not attacker-controlled input
- To revisit at the next Tauri bump (same as the existing ignore list)

## Test plan

- [x] `cargo check --no-default-features` passes with the updated Cargo.lock
- [x] `cargo audit` with the gate's full ignore list exits 0 locally (only non-fatal unmaintained/yanked warnings remain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)