### PR TITLE
feat: strip Whisper hesitation ellipses in streaming mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Streaming mode (live transcription)** — Lexena Cloud exclusive. When enabled (Settings → Dictation → Transcription), speech is segmented at natural pauses on the Rust side and each segment is transcribed while you keep talking: the text appears sentence by sentence in the mini window (in place of the visualizer) and in the home hero card (teleprompter style), ~1-2 s after each pause. On stop, the assembled text goes through the unchanged pipeline (AI post-process, snippets, history, auto-paste). Works with the toggle hotkey, push-to-talk and the record button; cancel (Escape) discards everything. Billing is identical to batch (sum of segment durations through the existing `/transcribe` endpoint); quota/auth errors stop the recording cleanly, isolated network failures skip a segment with a warning.
 
+### Fixed
+- **Streaming mode** — hesitation pauses no longer leave stray ellipses ("...") in the live transcript and the final text; Whisper's hesitation artifacts are stripped from each segment. A session made only of hesitations is now treated as an empty recording instead of producing an empty history entry.
+
 ---
 
 ## [3.0.0] - 2026-06-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Streaming mode (live transcription)** — Lexena Cloud exclusive. When enabled (Settings → Dictation → Transcription), speech is segmented at natural pauses on the Rust side and each segment is transcribed while you keep talking: the text appears sentence by sentence in the mini window (in place of the visualizer) and in the home hero card (teleprompter style), ~1-2 s after each pause. On stop, the assembled text goes through the unchanged pipeline (AI post-process, snippets, history, auto-paste). Works with the toggle hotkey, push-to-talk and the record button; cancel (Escape) discards everything. Billing is identical to batch (sum of segment durations through the existing `/transcribe` endpoint); quota/auth errors stop the recording cleanly, isolated network failures skip a segment with a warning.
 
 ### Fixed
-- **Streaming mode** — hesitation pauses no longer leave stray ellipses ("...") in the live transcript and the final text; Whisper's hesitation artifacts are stripped from each segment. A session made only of hesitations is now treated as an empty recording instead of producing an empty history entry.
+- **Streaming mode** — hesitation pauses no longer leave stray ellipses ("...") in the live transcript and the final text; Whisper's hesitation artifacts are stripped from each segment. A session made only of hesitations is now treated as an empty recording instead of producing a junk "..." history entry.
 
 ---
 

--- a/docs/superpowers/plans/2026-07-12-pr1-streaming-strip-ellipses.md
+++ b/docs/superpowers/plans/2026-07-12-pr1-streaming-strip-ellipses.md
@@ -1,0 +1,259 @@
+# PR 1 — Streaming Ellipsis Cleanup Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Supprimer les points de suspension parasites (`...`, `…`) que Whisper produit sur les hésitations en mode streaming, du live HUD comme du texte final.
+
+**Architecture:** Une fonction pure `stripEllipses` exportée depuis `src/lib/streaming/assembler.ts`, appliquée dans `TranscriptAssembler.upsert()` — point de passage unique du live et du final. Une garde dans `useStreamingSession` traite une session assemblée vide (que des hésitations) comme une session vide au lieu de la finaliser.
+
+**Tech Stack:** TypeScript, Vitest. Aucun changement Rust, aucune dépendance nouvelle.
+
+**Spec:** `docs/superpowers/specs/2026-07-12-ux-improvements-multi-pr-design.md` (section PR 1)
+
+## Global Constraints
+
+- Branche `main` protégée : jamais de commit direct, la PR part d'une branche dédiée.
+- Le mode batch (non-streaming) n'est **pas** modifié.
+- On ne répare pas le reste de la ponctuation de Whisper (point orphelin conservé).
+- Aucune nouvelle string UI dans cette PR (donc pas d'i18n à toucher).
+- CHANGELOG en anglais.
+- Suite de tests : `pnpm test` (vitest run) ; ciblé : `pnpm exec vitest run src/lib/streaming/assembler.test.ts`.
+
+## Setup (avant Task 1)
+
+La branche du spec `docs/ux-improvements-spec` contient déjà le design doc (commit `d87e45f`). La PR 1 embarque le spec et ce plan :
+
+```bash
+git checkout docs/ux-improvements-spec
+git checkout -b feat/streaming-strip-ellipses
+git add docs/superpowers/plans/2026-07-12-pr1-streaming-strip-ellipses.md
+git commit -m "docs: add PR1 streaming ellipsis cleanup plan"
+```
+
+---
+
+### Task 1: Fonction pure `stripEllipses`
+
+**Files:**
+- Modify: `src/lib/streaming/assembler.ts` (ajout d'une fonction exportée en tête de fichier)
+- Test: `src/lib/streaming/assembler.test.ts`
+
+**Interfaces:**
+- Consumes: rien.
+- Produces: `export function stripEllipses(text: string): string` — supprime toute séquence de 3 points ou plus et tout `…` (répété inclus), normalise les espaces, trim. Utilisée par Task 2.
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Ajouter en fin de `src/lib/streaming/assembler.test.ts` (l'import existant devient `import { TranscriptAssembler, stripEllipses } from "./assembler";`) :
+
+```ts
+describe("stripEllipses", () => {
+  it("removes a trailing ellipsis glued to a word", () => {
+    expect(stripEllipses("ni le feu ni la glace ne serait... atteindre")).toBe(
+      "ni le feu ni la glace ne serait atteindre",
+    );
+  });
+
+  it("removes a free-standing ellipsis between sentences", () => {
+    expect(stripEllipses("dans l'illusion. ... de son cœur.")).toBe(
+      "dans l'illusion. de son cœur.",
+    );
+  });
+
+  it("removes unicode ellipses, including repeated ones", () => {
+    expect(stripEllipses("Bonjour… monde")).toBe("Bonjour monde");
+    expect(stripEllipses("Attends……")).toBe("Attends");
+  });
+
+  it("removes runs of more than three dots", () => {
+    expect(stripEllipses("euh.... donc")).toBe("euh donc");
+  });
+
+  it("returns an empty string for ellipsis-only text", () => {
+    expect(stripEllipses("...")).toBe("");
+    expect(stripEllipses(" … ")).toBe("");
+  });
+
+  it("keeps sentence punctuation preceding an ellipsis", () => {
+    expect(stripEllipses("Quoi ?...")).toBe("Quoi ?");
+    expect(stripEllipses("Non !...")).toBe("Non !");
+  });
+
+  it("keeps two dots (not an ellipsis)", () => {
+    expect(stripEllipses("Attends..")).toBe("Attends..");
+  });
+
+  it("leaves text without ellipses unchanged", () => {
+    expect(stripEllipses("Un, deux, trois.")).toBe("Un, deux, trois.");
+  });
+});
+```
+
+- [ ] **Step 2: Vérifier qu'ils échouent**
+
+Run: `pnpm exec vitest run src/lib/streaming/assembler.test.ts`
+Expected: FAIL — `stripEllipses` n'est pas exporté (erreur d'import / `stripEllipses is not a function`).
+
+- [ ] **Step 3: Implémenter `stripEllipses`**
+
+Dans `src/lib/streaming/assembler.ts`, au-dessus de la classe :
+
+```ts
+/**
+ * Whisper transcribes hesitation pauses as ellipses ("...", "…"), which
+ * pollute streamed dictation with stray dots the user then has to edit out.
+ * Dictating a literal ellipsis is rare enough that we strip them all
+ * (spec 2026-07-12, PR 1).
+ */
+export function stripEllipses(text: string): string {
+  return text
+    .replace(/(?:\.{3,}|…+)/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+```
+
+- [ ] **Step 4: Vérifier que les tests passent**
+
+Run: `pnpm exec vitest run src/lib/streaming/assembler.test.ts`
+Expected: PASS (8 nouveaux tests + 7 existants).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/streaming/assembler.ts src/lib/streaming/assembler.test.ts
+git commit -m "feat: add stripEllipses helper for streaming transcripts"
+```
+
+---
+
+### Task 2: Application dans `TranscriptAssembler.upsert`
+
+**Files:**
+- Modify: `src/lib/streaming/assembler.ts:13-16` (méthode `upsert`)
+- Test: `src/lib/streaming/assembler.test.ts`
+
+**Interfaces:**
+- Consumes: `stripEllipses(text: string): string` (Task 1).
+- Produces: `TranscriptAssembler.upsert(index: number, text: string): void` stocke désormais le texte nettoyé — signature inchangée, aucun appelant à modifier (`session.ts` appelle déjà `upsert`).
+
+- [ ] **Step 1: Écrire les tests qui échouent**
+
+Ajouter dans le `describe("TranscriptAssembler", ...)` existant :
+
+```ts
+  it("strips ellipses from chunk texts before assembly", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "ni le feu ni la glace ne serait...");
+    a.upsert(1, "atteindre en intensité, ce qu'enferme un homme dans l'illusion.");
+    a.upsert(2, "... de son cœur.");
+    expect(a.assembled()).toBe(
+      "ni le feu ni la glace ne serait atteindre en intensité, ce qu'enferme un homme dans l'illusion. de son cœur.",
+    );
+  });
+
+  it("excludes chunks that were only ellipses from the join", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "Début");
+    a.upsert(1, "...");
+    a.upsert(2, "fin.");
+    expect(a.assembled()).toBe("Début fin.");
+  });
+```
+
+- [ ] **Step 2: Vérifier qu'ils échouent**
+
+Run: `pnpm exec vitest run src/lib/streaming/assembler.test.ts`
+Expected: FAIL — les `...` apparaissent encore dans `assembled()`.
+
+- [ ] **Step 3: Nettoyer dans `upsert`**
+
+Dans `src/lib/streaming/assembler.ts`, remplacer :
+
+```ts
+  upsert(index: number, text: string): void {
+    this.failed.delete(index);
+    this.texts.set(index, text);
+  }
+```
+
+par :
+
+```ts
+  upsert(index: number, text: string): void {
+    this.failed.delete(index);
+    this.texts.set(index, stripEllipses(text));
+  }
+```
+
+Note : un chunk réduit à `""` reste compté dans `okCount` (sémantique inchangée — `okCount` compte les uploads réussis) mais est déjà exclu du join par `assembled()`.
+
+- [ ] **Step 4: Vérifier que tout passe**
+
+Run: `pnpm exec vitest run src/lib/streaming/assembler.test.ts`
+Expected: PASS (17 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/lib/streaming/assembler.ts src/lib/streaming/assembler.test.ts
+git commit -m "feat: strip Whisper hesitation ellipses from streaming chunks"
+```
+
+---
+
+### Task 3: Garde session vide + CHANGELOG
+
+**Files:**
+- Modify: `src/hooks/useStreamingSession.ts:184-199` (handler `streaming-session-end`)
+- Modify: `CHANGELOG.md` (section `[Unreleased]`)
+
+**Interfaces:**
+- Consumes: `outcome.text` (résultat de `StreamingUploadSession.finish()`, déjà nettoyé par Tasks 1-2) ; `onEmptyRef` (existant dans le hook).
+- Produces: rien de nouveau — comportement : une session dont le texte assemblé est vide déclenche `onEmpty()` (toast « aucun son ») au lieu de `onFinalize("")`.
+
+**Pourquoi :** avant cette PR, une session avec des chunks réussis produisait toujours du texte. Après nettoyage, une session faite uniquement d'hésitations (`...`) s'assemble en `""` — la finaliser créerait une entrée d'historique vide et un collage vide. Pas de test unitaire dédié : le hook n'a pas de harnais (mocks Tauri lourds) et la garde est un `if` de 3 lignes — vérification au smoke test manuel.
+
+- [ ] **Step 1: Ajouter la garde**
+
+Dans `src/hooks/useStreamingSession.ts`, dans le listener `streaming-session-end`, après le bloc `if (outcome.chunksOk === 0) { ... }` et avant `await onFinalizeRef.current(...)`, insérer :
+
+```ts
+            // A session made only of hesitations assembles to "" after
+            // ellipsis stripping — treat it as empty instead of finalizing
+            // (an empty history entry + empty paste would be useless).
+            if (outcome.text.length === 0) {
+              onEmptyRef.current();
+              return;
+            }
+```
+
+- [ ] **Step 2: Vérifier la compilation et la suite complète**
+
+Run: `pnpm build` puis `pnpm test`
+Expected: build OK, tous les tests passent (aucune régression — 266+ tests Vitest).
+
+- [ ] **Step 3: Entrée CHANGELOG**
+
+Dans `CHANGELOG.md`, sous `## [Unreleased]`, ajouter après la section `### Added` :
+
+```markdown
+### Fixed
+- **Streaming mode** — hesitation pauses no longer leave stray ellipses ("...") in the live transcript and the final text; Whisper's hesitation artifacts are stripped from each segment. A session made only of hesitations is now treated as an empty recording instead of producing an empty history entry.
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/hooks/useStreamingSession.ts CHANGELOG.md
+git commit -m "fix: treat all-hesitation streaming session as empty"
+```
+
+---
+
+### Vérification finale (avant PR)
+
+- [ ] `pnpm test` — suite complète verte.
+- [ ] `pnpm build` — compilation TypeScript + Vite OK.
+- [ ] Smoke test manuel (nécessite `pnpm tauri dev` lancé par l'utilisateur — ne pas le lancer soi-même) : dicter en streaming avec des hésitations volontaires → plus aucun `...` dans le HUD ni dans le texte collé ; session faite uniquement d'hésitations → toast « aucun son », pas d'entrée d'historique.
+- [ ] Ouvrir la PR vers `main` : `feat/streaming-strip-ellipses` (contient aussi le spec + ce plan).

--- a/docs/superpowers/specs/2026-07-12-ux-improvements-multi-pr-design.md
+++ b/docs/superpowers/specs/2026-07-12-ux-improvements-multi-pr-design.md
@@ -1,0 +1,274 @@
+# Améliorations UX — série de 5 PR (design)
+
+**Date** : 2026-07-12
+**Statut** : validé (brainstorming du 2026-07-12)
+**Portée** : 5 features indépendantes, livrées en 5 PR séparées, dans cet ordre :
+
+| # | PR | Taille estimée | Touche la sync/DB |
+|---|----|----------------|-------------------|
+| 1 | Nettoyage des `...` en streaming | XS | non |
+| 2 | Tout replier / tout déplier (sidebar notes) | XS | non |
+| 3 | Toggle « note locale » (jamais synchronisée) | M | oui (comportement client, pas de migration) |
+| 4 | Emoji par dossier (synchronisé) | M | oui (migration + Edge Functions) |
+| 5 | Photo de profil (locale) | M | non |
+
+Chaque PR suit le cycle habituel : branche → implémentation TDD → PR vers `main`
+(branche protégée, jamais de commit direct).
+
+---
+
+## PR 1 — Nettoyage des `...` en streaming
+
+### Problème
+
+En mode streaming, les hésitations en cours de phrase produisent des chunks que
+Whisper transcrit avec des points de suspension (`...` en fin de chunk coupé,
+chunks entiers réduits à `...`). Résultat constaté :
+
+> « ni le feu ni la glace ne serait... atteindre En intensité, ce qu'enferme un
+> homme dans l'illusion. ... de son cœur. »
+
+L'utilisateur doit rééditer chaque phrase, au point de désactiver le streaming.
+
+### Décision
+
+**Suppression totale** des ellipses, appliquée par chunk au moment de
+l'assemblage — donc visible dans le live HUD **et** dans le texte final.
+
+### Design
+
+- Nouvelle fonction pure `stripEllipses(text: string): string` exportée depuis
+  `src/lib/streaming/assembler.ts` :
+  - supprime toute séquence de **3 points ou plus** (`\.{3,}`) et tout `…`
+    (U+2026, y compris répété) ;
+  - remplacement par un espace, puis renormalisation des espaces (le
+    `assembled()` existant fait déjà `replace(/\s+/g, " ")` + `trim()`) ;
+  - un chunk réduit à des ellipses devient chaîne vide → déjà filtré par
+    `assembled()`.
+- Appel dans `TranscriptAssembler.upsert(index, text)` : on stocke le texte
+  nettoyé. Aucun autre point d'entrée à modifier (live et final passent tous
+  deux par l'assembler).
+
+### Hors périmètre
+
+- Le mode batch (non-streaming) n'est pas modifié.
+- On ne répare pas le reste de la ponctuation de Whisper (ex. le point orphelin
+  dans « l'illusion. de son cœur » reste tel quel).
+
+### Tests
+
+Cas unitaires (Vitest, `assembler.test.ts` ou fichier dédié) :
+
+- `serait... atteindre` → `serait atteindre` (ellipse collée au mot) ;
+- ` ... ` isolé → espace unique ;
+- `…` unicode et `……` ;
+- chunk entièrement `...` → exclu de l'assemblage ;
+- texte sans ellipse → inchangé ;
+- `..` (deux points) → **conservé** (pas une ellipse) ;
+- `?...` / `!...` → `?` / `!` conservés.
+
+---
+
+## PR 2 — Tout replier / tout déplier (sidebar notes)
+
+### Décision
+
+Un **seul bouton toggle** dans la barre d'outils de la sidebar notes, qui agit
+sur **les dossiers ET les sections** (Favoris, Récents, Non classées).
+
+### Design
+
+- `useSidebarCollapseState` (`src/hooks/useSidebarCollapseState.ts`) gagne
+  `setAll(collapsed: boolean, folderIds: string[])` : écrit d'un coup
+  `favorites`, `recents`, `root` et une entrée par dossier. Persistance
+  inchangée (store par profil, debounce 300 ms).
+- `NotesSidebarSection.tsx` : bouton ajouté à côté de « + » et « nouveau
+  dossier » :
+  - si **au moins une** section ou un dossier est déplié → action « tout
+    replier », icône `ChevronsDownUp` (lucide) ;
+  - sinon → « tout déplier », icône `ChevronsUpDown`.
+- i18n : `notes.collapseAll` / `notes.expandAll` dans **toutes** les locales
+  existantes (title + aria-label — jamais de texte en dur).
+
+---
+
+## PR 3 — Toggle « note locale » (jamais synchronisée)
+
+### Problème
+
+Le titre d'une note est toujours **dérivé de la première ligne du contenu**
+(`deriveTitle`) — il n'existe pas de champ titre séparé. L'idée initiale
+« pas de titre → pas de sync » est donc inapplicable. Besoin réel : pouvoir
+créer une note temporaire sans qu'elle parte dans le cloud (où sa suppression
+laisserait un tombstone 30 jours).
+
+### Décision
+
+Toggle **explicite par note** : « note locale » (cloud-off). Tant qu'il est
+actif, la note n'est jamais poussée. En bonus, une note au contenu vide n'est
+plus poussée du tout.
+
+### Design
+
+**Modèle** :
+
+- `notes.rs` : champ `local_only: bool` sur la note, `#[serde(default)]`
+  (défaut `false`), exposé `localOnly` dans `NoteMeta` TS.
+- Purement local : jamais mappé vers le cloud (`mapping.ts` ne le transporte
+  pas), survit au backup/restore local (le restore passe par
+  `import_note_for_backup` qui préserve la meta).
+
+**Gate de sync** (même mécanique que le cap de taille `isNoteSyncable`) :
+
+- `notes-store.ts` : `enqueueNoteUpsertIfSyncable` saute toute note
+  `localOnly` ; le enqueue de création est sauté si `localOnly` **ou** contenu
+  vide (le premier update non vide poussera — `sync-push` fait des upserts,
+  pas de dépendance à une op de création).
+- `SyncContext.fullPush` : le scan initial saute les notes `localOnly` et les
+  notes vides.
+
+**Sémantique de bascule** (validée) :
+
+- **synced → locale** : enqueue `note-delete` → tombstone cloud 30 j, la note
+  disparaît des autres appareils au pull. La copie locale de l'appareil
+  courant est intacte.
+- **locale → synced** : enqueue un upsert complet, la note repart normalement.
+- Garde tombstone existante de `notes-store` : inchangée.
+
+**UI** :
+
+- Icône cloud / cloud-off dans l'en-tête de l'éditeur (`NotesEditorHeader`) ;
+- entrée dans le menu contextuel des notes de la sidebar ;
+- indicateur discret cloud-off sur l'item sidebar d'une note locale ;
+- i18n complet (fr + autres locales).
+
+**Interaction avec les compteurs** : `SyncActivationModal` et
+`AccountSection::SyncedInventoryGrid` comptent des notes synchronisées — les
+notes `localOnly` en sont exclues.
+
+### Tests
+
+- Rust : persistance du champ (`local_only` survit save/load + backup import).
+- Vitest `notes-store` : pas d'enqueue quand `localOnly` ; pas d'enqueue à la
+  création vide ; enqueue `note-delete` sur bascule synced → locale ; upsert
+  sur bascule inverse.
+- Le prédicat de push est extrait en helper pur (ex. `shouldPushNote(meta,
+  content)` regroupant cap de taille + `localOnly` + contenu vide) et testé
+  unitairement ; `notes-store` et `fullPush` consomment tous deux ce helper.
+
+---
+
+## PR 4 — Emoji par dossier (synchronisé)
+
+### Décision
+
+Icône de dossier = **emoji libre**, champ **synchronisé** (comme le nom).
+Picker frugal : grille curatée + saisie libre, pas de lib lourde
+(emoji-mart ≈ 500 Ko rejeté).
+
+### Design
+
+**Modèle** :
+
+- `folders.rs` : `icon: Option<String>` (`#[serde(default)]`), exposé
+  `icon?: string` dans `FolderMeta`.
+- L'emoji voyage dans le row LWW existant (`updated_at`) — aucune logique de
+  merge supplémentaire (`mergeFolderLWW` inchangé).
+
+**DB / sync** :
+
+- Migration Supabase additive : `ALTER TABLE user_folders ADD COLUMN icon
+  TEXT;` (nullable, **timestamp réel** `YYYYMMDDHHMMSS`). RLS inchangé.
+- `schemas.ts` : `CloudUserFolderRowSchema` + champ `icon` nullable.
+- `mapping.ts` : transport `icon` dans les deux sens.
+- Edge Functions : `sync-push` stampe `icon` sur les `folder-upsert` ;
+  `account-export` inclut la colonne. Redéploiement des deux requis.
+- Rétro-compat : anciens clients ignorent la colonne ; `icon` absent → `null`.
+
+**UI** :
+
+- `FolderNameDialog` (création **et** renommage) : grille d'environ 24 emojis
+  courants + champ de saisie libre (un emoji tapé/collé, ex. via Win+.) +
+  bouton « aucun » (retour à l'icône dossier par défaut).
+- Affichage : partout où `<Folder>` (lucide) représente un dossier nommé —
+  sidebar (`FolderSection`), menu contextuel « déplacer vers », fil d'ariane
+  de l'éditeur. Fallback : icône `Folder` actuelle si `icon` absent.
+- i18n pour les nouveaux libellés du dialog.
+
+**Déploiement** (à exécuter pendant la PR, état explicite en fin de PR) :
+
+1. `pnpm exec supabase db push` (migration additive) ;
+2. `pnpm exec supabase functions deploy sync-push` ;
+3. `pnpm exec supabase functions deploy account-export`.
+
+### Tests
+
+- Vitest : mapping aller-retour avec/sans `icon`, schéma Zod (null / absent /
+  string).
+- Deno Edge : `folder-upsert` avec `icon` persisté ; export inclut `icon`.
+- Rust : persistance locale du champ.
+- pgtap : artefact mis à jour si les tests folders référencent les colonnes.
+
+---
+
+## PR 5 — Photo de profil (locale)
+
+### Décision
+
+Avatar **local uniquement** (les profils sont locaux — `profiles.json` ; pas de
+Supabase Storage). Image croppée/redimensionnée côté frontend, stockée dans le
+dossier du profil.
+
+### Design
+
+**Stockage** :
+
+- Fichier `profiles/<id>/avatar.png`, 256×256 px.
+- La présence du fichier fait foi — **aucun champ** ajouté à `ProfileMeta` /
+  `profiles.json`.
+- La suppression d'un profil emporte son dossier, donc son avatar (comportement
+  existant).
+
+**Commandes Rust** (`commands/profiles.rs`) :
+
+- `set_profile_avatar(profile_id, bytes: Vec<u8>)` — écrit le PNG (valide que
+  le profil existe dans le manifest) ;
+- `get_profile_avatar(profile_id) -> Option<String>` — data-URL base64
+  (≈ 30-80 Ko) ou `None` si absent ;
+- `clear_profile_avatar(profile_id)` — supprime le fichier.
+
+**Traitement d'image (frontend)** :
+
+- File picker (input file image/*) → `FileReader` → `Image` → canvas :
+  crop carré centré + resize 256×256 → `toBlob("image/png")` → bytes vers
+  `set_profile_avatar`. Aucune dépendance image côté Rust.
+
+**UI** :
+
+- `ProfilesManageDialog` : changer / retirer la photo par profil.
+- `ProfileSwitcher` : l'avatar (bouton principal 28 px + liste du dropdown
+  24 px) affiche l'image si présente, sinon les initiales actuelles
+  (`getInitials`).
+- L'avatar du **compte** (cercle initiales-email en haut du dropdown) n'est
+  pas concerné.
+- i18n pour les nouveaux libellés.
+
+### Tests
+
+- Rust : set/get/clear + profil inexistant → erreur.
+- Vitest : utilitaire de crop/resize si extrait en fonction pure testable
+  (sinon vérification manuelle).
+
+---
+
+## Risques et points d'attention transverses
+
+- **PR 3** : c'est la seule PR avec une sémantique cloud non triviale
+  (tombstone à la bascule). Bien vérifier sur un second appareil que la note
+  disparaît au pull sans toucher la copie locale de l'appareil source.
+- **PR 4** : migration prod directe (pas de DB de test) — additive et
+  nullable, risque faible ; déployer les Edge Functions dans la même fenêtre
+  que le `db push` pour éviter un `sync-push` qui ignore `icon`.
+- **i18n** : toute string UI passe par react-i18next (title/aria-label
+  compris) — vaut pour les 5 PR.
+- **CHANGELOG** : en anglais, une entrée par PR.

--- a/src/hooks/useStreamingSession.ts
+++ b/src/hooks/useStreamingSession.ts
@@ -192,6 +192,13 @@ export function useStreamingSession({
               await emit("transcription-error", { error: message });
               return;
             }
+            // A session made only of hesitations assembles to "" after
+            // ellipsis stripping — treat it as empty instead of finalizing
+            // (an empty history entry + empty paste would be useless).
+            if (outcome.text.length === 0) {
+              onEmptyRef.current();
+              return;
+            }
             await onFinalizeRef.current(
               outcome.text,
               outcome.billedMs / 1000,

--- a/src/hooks/useStreamingSession.ts
+++ b/src/hooks/useStreamingSession.ts
@@ -186,7 +186,13 @@ export function useStreamingSession({
               onEmptyRef.current();
               return;
             }
-            if (outcome.chunksOk === 0) {
+            // An empty assembled text with failed chunks means real speech may
+            // have been lost (the successful chunks were hesitations stripped
+            // to "") — surface the failure instead of pretending silence.
+            if (
+              outcome.chunksOk === 0 ||
+              (outcome.text.length === 0 && outcome.chunksFailed > 0)
+            ) {
               const message = tRef.current("streaming.allChunksFailed");
               toast.error(message);
               await emit("transcription-error", { error: message });

--- a/src/lib/streaming/assembler.test.ts
+++ b/src/lib/streaming/assembler.test.ts
@@ -76,6 +76,13 @@ describe("TranscriptAssembler", () => {
     a.upsert(2, "fin.");
     expect(a.assembled()).toBe("Début fin.");
   });
+
+  it("still counts an ellipsis-only chunk as a successful upload", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "...");
+    expect(a.okCount).toBe(1);
+    expect(a.assembled()).toBe("");
+  });
 });
 
 describe("stripEllipses", () => {
@@ -116,5 +123,15 @@ describe("stripEllipses", () => {
 
   it("leaves text without ellipses unchanged", () => {
     expect(stripEllipses("Un, deux, trois.")).toBe("Un, deux, trois.");
+  });
+
+  it("does not leave a space before a comma or period after stripping", () => {
+    expect(stripEllipses("Il faudrait..., je pense")).toBe("Il faudrait, je pense");
+    expect(stripEllipses("voilà… .")).toBe("voilà.");
+  });
+
+  it("keeps the French space before ? and !", () => {
+    expect(stripEllipses("Quoi... ?")).toBe("Quoi ?");
+    expect(stripEllipses("Non… !")).toBe("Non !");
   });
 });

--- a/src/lib/streaming/assembler.test.ts
+++ b/src/lib/streaming/assembler.test.ts
@@ -58,6 +58,24 @@ describe("TranscriptAssembler", () => {
     expect(a.assembled()).toBe("récupéré.");
     expect(a.failedCount).toBe(0);
   });
+
+  it("strips ellipses from chunk texts before assembly", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "ni le feu ni la glace ne serait...");
+    a.upsert(1, "atteindre en intensité, ce qu'enferme un homme dans l'illusion.");
+    a.upsert(2, "... de son cœur.");
+    expect(a.assembled()).toBe(
+      "ni le feu ni la glace ne serait atteindre en intensité, ce qu'enferme un homme dans l'illusion. de son cœur.",
+    );
+  });
+
+  it("excludes chunks that were only ellipses from the join", () => {
+    const a = new TranscriptAssembler();
+    a.upsert(0, "Début");
+    a.upsert(1, "...");
+    a.upsert(2, "fin.");
+    expect(a.assembled()).toBe("Début fin.");
+  });
 });
 
 describe("stripEllipses", () => {

--- a/src/lib/streaming/assembler.test.ts
+++ b/src/lib/streaming/assembler.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { TranscriptAssembler } from "./assembler";
+import { TranscriptAssembler, stripEllipses } from "./assembler";
 
 describe("TranscriptAssembler", () => {
   it("joins chunks in index order even when upserted out of order", () => {
@@ -57,5 +57,46 @@ describe("TranscriptAssembler", () => {
     a.upsert(0, "récupéré.");
     expect(a.assembled()).toBe("récupéré.");
     expect(a.failedCount).toBe(0);
+  });
+});
+
+describe("stripEllipses", () => {
+  it("removes a trailing ellipsis glued to a word", () => {
+    expect(stripEllipses("ni le feu ni la glace ne serait... atteindre")).toBe(
+      "ni le feu ni la glace ne serait atteindre",
+    );
+  });
+
+  it("removes a free-standing ellipsis between sentences", () => {
+    expect(stripEllipses("dans l'illusion. ... de son cœur.")).toBe(
+      "dans l'illusion. de son cœur.",
+    );
+  });
+
+  it("removes unicode ellipses, including repeated ones", () => {
+    expect(stripEllipses("Bonjour… monde")).toBe("Bonjour monde");
+    expect(stripEllipses("Attends……")).toBe("Attends");
+  });
+
+  it("removes runs of more than three dots", () => {
+    expect(stripEllipses("euh.... donc")).toBe("euh donc");
+  });
+
+  it("returns an empty string for ellipsis-only text", () => {
+    expect(stripEllipses("...")).toBe("");
+    expect(stripEllipses(" … ")).toBe("");
+  });
+
+  it("keeps sentence punctuation preceding an ellipsis", () => {
+    expect(stripEllipses("Quoi ?...")).toBe("Quoi ?");
+    expect(stripEllipses("Non !...")).toBe("Non !");
+  });
+
+  it("keeps two dots (not an ellipsis)", () => {
+    expect(stripEllipses("Attends..")).toBe("Attends..");
+  });
+
+  it("leaves text without ellipses unchanged", () => {
+    expect(stripEllipses("Un, deux, trois.")).toBe("Un, deux, trois.");
   });
 });

--- a/src/lib/streaming/assembler.ts
+++ b/src/lib/streaming/assembler.ts
@@ -8,6 +8,7 @@ export function stripEllipses(text: string): string {
   return text
     .replace(/(?:\.{3,}|…+)/g, " ")
     .replace(/\s+/g, " ")
+    .replace(/ ([,.])/g, "$1")
     .trim();
 }
 

--- a/src/lib/streaming/assembler.ts
+++ b/src/lib/streaming/assembler.ts
@@ -25,7 +25,7 @@ export class TranscriptAssembler {
 
   upsert(index: number, text: string): void {
     this.failed.delete(index);
-    this.texts.set(index, text);
+    this.texts.set(index, stripEllipses(text));
   }
 
   markFailed(index: number): void {

--- a/src/lib/streaming/assembler.ts
+++ b/src/lib/streaming/assembler.ts
@@ -1,4 +1,17 @@
 /**
+ * Whisper transcribes hesitation pauses as ellipses ("...", "…"), which
+ * pollute streamed dictation with stray dots the user then has to edit out.
+ * Dictating a literal ellipsis is rare enough that we strip them all
+ * (spec 2026-07-12, PR 1).
+ */
+export function stripEllipses(text: string): string {
+  return text
+    .replace(/(?:\.{3,}|…+)/g, " ")
+    .replace(/\s+/g, " ")
+    .trim();
+}
+
+/**
  * Ordered assembly of per-chunk transcripts for a streaming session.
  *
  * Chunks are uploaded sequentially but this stays defensive: results are


### PR DESCRIPTION
## Summary

In streaming mode, mid-sentence hesitations made Whisper emit stray ellipses ("...", "…") in the transcript, forcing manual cleanup of nearly every dictated sentence (bad enough to disable streaming entirely).

- New pure `stripEllipses` helper in `src/lib/streaming/assembler.ts`: removes any run of 3+ dots and any `…`, renormalizes spaces, and collapses the stray space left before `,`/`.` (French spacing before `? ! ; :` preserved)
- Applied in `TranscriptAssembler.upsert`, so both the live HUD text and the final assembled text are clean — no caller changes, batch mode untouched
- `useStreamingSession`: a session that assembles to an empty string is now treated as an empty recording (no junk history entry / empty paste); if chunks failed, the failure is surfaced instead (no silent speech loss)

Also carries the design spec for the 5-PR UX series (`docs/superpowers/specs/2026-07-12-ux-improvements-multi-pr-design.md`) and this PR's implementation plan.

## Tests

- 13 new Vitest cases (glued/free-standing/unicode ellipses, dot-run thresholds, punctuation preservation, ellipsis-only chunks, `okCount` semantics, assembler integration)
- Full suite: 427/427 passing, `pnpm build` clean
- Multi-agent review: per-task spec+quality gates + whole-branch final review (1 Important finding fixed: empty-session guard no longer masks failed-chunk loss)

## Remaining before merge

- [ ] Manual smoke test (`pnpm tauri dev`): dictate with deliberate hesitations → no `...` in HUD or pasted text; hesitation-only session → "no sound" toast, no history entry

🤖 Generated with [Claude Code](https://claude.com/claude-code)