### PR TITLE
feat: show active profile avatar in the mini window

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,7 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Notes sidebar** — new toolbar button to collapse or expand all folders and sections (Favorites, Recents, Unfiled) at once.
 - **Local-only notes** — a per-note "local note" toggle (editor header cloud icon + sidebar context menu) keeps a note out of cloud sync entirely. Switching a synced note to local removes it from the cloud and other devices while keeping the local copy intact; switching back re-uploads it. Empty notes are no longer pushed to the cloud.
 - **Folder emojis** — pick an emoji per folder (curated grid + free input) shown in the sidebar, move-to menus and editor breadcrumb; synced across devices.
-- **Profile pictures** — set a local photo per profile from the profile manager (center-cropped and resized to 256×256, stored on this device only, never synced); shown in the profile switcher button and list, with initials as fallback.
+- **Profile pictures** — set a local photo per profile from the profile manager (center-cropped and resized to 256×256, stored on this device only, never synced); shown in the profile switcher button and list, with initials as fallback. The active profile's picture also appears in the mini window, so you can tell at a glance which profile is recording.
 
 ### Fixed
 - **Streaming mode** — hesitation pauses no longer leave stray ellipses ("...") in the live transcript and the final text; Whisper's hesitation artifacts are stripped from each segment. A session made only of hesitations is now treated as an empty recording instead of producing a junk "..." history entry.

--- a/docs/superpowers/plans/2026-07-13-mini-window-avatar.md
+++ b/docs/superpowers/plans/2026-07-13-mini-window-avatar.md
@@ -1,0 +1,289 @@
+# Mini Window Active-Profile Avatar Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the active profile's avatar (photo or initials) at the left of the mini window's main row, so the user instantly sees which profile is recording.
+
+**Architecture:** A tiny mount-time data hook (`useActiveProfileInfo`) fetches the active profile's name + avatar via the existing Tauri commands; `MiniShell` renders the existing `ProfileAvatar` component with it. No events needed — `switch_profile` reloads every WebView, so mount-time data is always fresh. Spec: `docs/superpowers/specs/2026-07-13-mini-window-avatar-design.md`.
+
+**Tech Stack:** React 19 + TypeScript, Vitest + jsdom + Testing Library (renderHook), react-i18next. No Rust change, no dependency change.
+
+## Global Constraints
+
+- **Branch is stacked on `feat/profile-avatar`** (PR #81): `ProfileAvatar` and `get_profile_avatar` come from it. Do not touch anything from PR #81.
+- **Purely local**: no migration, no Edge Function, no sync change, no `capabilities/mini.json` change (the mini window already invokes custom commands).
+- **The mini window must NEVER break over an avatar failure** — every invoke wrapped, errors swallowed, component renders nothing until `name` is loaded.
+- **Every UI string via react-i18next** in BOTH locales. New key: `mini.activeProfile` = fr `"Profil actif : {{name}}"` / en `"Active profile: {{name}}"`.
+- Avatar sizes: layout `compact` → `h-5 w-5 text-[8px]`; `standard`/`extended` → `h-6 w-6 text-[10px]`.
+- Shown only in the main row (`status === "idle" || status === "recording"`, streaming included); NOT in the transient status row.
+- CHANGELOG: EXTEND the existing "Profile pictures" bullet (same unreleased release) — no new bullet.
+- Test baseline on this branch: Vitest **490 tests / 68 files**. Expected after: **493 tests / 69 files** (+3 hook tests).
+- Conventional commits in English.
+
+## File Structure
+
+- Create `src/hooks/useActiveProfileInfo.ts` + `src/hooks/useActiveProfileInfo.test.ts` — mount-time fetch, swallow-all error policy.
+- Modify `src/components/mini-window/MiniShell.tsx` — render `ProfileAvatar` at the left of the main row.
+- Modify `src/locales/fr.json` + `src/locales/en.json` — 1 key in the existing `"mini"` section (fr.json line ~856, after `"liveBadge"` line 868).
+- Modify `CHANGELOG.md` — extend the "Profile pictures" bullet (line 19).
+
+---
+
+### Task 1: `useActiveProfileInfo` hook
+
+**Files:**
+- Create: `src/hooks/useActiveProfileInfo.ts`
+- Test: `src/hooks/useActiveProfileInfo.test.ts`
+
+**Interfaces:**
+- Consumes: Tauri commands `get_active_profile` → `string`, `list_profiles` → `{ id, name, createdAt }[]`, `get_profile_avatar({ id })` → `string | null`.
+- Produces (used by Task 2): `useActiveProfileInfo(): { name: string | null; avatarUrl: string | null }` — both `null` until loaded or on failure.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `src/hooks/useActiveProfileInfo.test.ts`:
+
+```ts
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { useActiveProfileInfo } from "./useActiveProfileInfo";
+
+const DATA_URL = "data:image/png;base64,AAAA";
+const PROFILES = [
+  { id: "default", name: "Default", createdAt: "" },
+  { id: "perso", name: "Perso", createdAt: "" },
+];
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+describe("useActiveProfileInfo", () => {
+  it("loads the active profile name and avatar", async () => {
+    invokeMock.mockImplementation(async (cmd: unknown) => {
+      if (cmd === "get_active_profile") return "perso";
+      if (cmd === "list_profiles") return PROFILES;
+      if (cmd === "get_profile_avatar") return DATA_URL;
+      return undefined;
+    });
+    const { result } = renderHook(() => useActiveProfileInfo());
+    await waitFor(() => expect(result.current.name).toBe("Perso"));
+    expect(result.current.avatarUrl).toBe(DATA_URL);
+    expect(invokeMock).toHaveBeenCalledWith("get_profile_avatar", {
+      id: "perso",
+    });
+  });
+
+  it("returns a null avatarUrl for a profile without a photo", async () => {
+    invokeMock.mockImplementation(async (cmd: unknown) => {
+      if (cmd === "get_active_profile") return "default";
+      if (cmd === "list_profiles") return PROFILES;
+      if (cmd === "get_profile_avatar") return null;
+      return undefined;
+    });
+    const { result } = renderHook(() => useActiveProfileInfo());
+    await waitFor(() => expect(result.current.name).toBe("Default"));
+    expect(result.current.avatarUrl).toBeNull();
+  });
+
+  it("stays null on invoke failure without throwing", async () => {
+    invokeMock.mockRejectedValue(new Error("ipc down"));
+    const { result } = renderHook(() => useActiveProfileInfo());
+    // Give the effect a tick to settle; nothing must throw or reject unhandled.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(result.current).toEqual({ name: null, avatarUrl: null });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pnpm vitest run src/hooks/useActiveProfileInfo.test.ts`
+Expected: FAIL (cannot resolve `./useActiveProfileInfo`).
+
+- [ ] **Step 3: Implement**
+
+Create `src/hooks/useActiveProfileInfo.ts`:
+
+```ts
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+interface ProfileMeta {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface ActiveProfileInfo {
+  name: string | null;
+  avatarUrl: string | null;
+}
+
+/**
+ * Loads the active profile's name and avatar once on mount. Errors are
+ * swallowed (the mini window must never break over an avatar), and no
+ * listener is needed: switching profiles reloads every WebView, so
+ * mount-time data is always fresh.
+ */
+export function useActiveProfileInfo(): ActiveProfileInfo {
+  const [info, setInfo] = useState<ActiveProfileInfo>({
+    name: null,
+    avatarUrl: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [id, profiles] = await Promise.all([
+          invoke<string>("get_active_profile"),
+          invoke<ProfileMeta[]>("list_profiles"),
+        ]);
+        const name = profiles.find((p) => p.id === id)?.name ?? null;
+        const avatarUrl = await invoke<string | null>("get_profile_avatar", {
+          id,
+        }).catch(() => null);
+        if (!cancelled) {
+          setInfo({
+            name,
+            avatarUrl: typeof avatarUrl === "string" ? avatarUrl : null,
+          });
+        }
+      } catch {
+        // Swallow — the mini window renders without the avatar.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return info;
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pnpm vitest run src/hooks/useActiveProfileInfo.test.ts`
+Expected: 3 passed, output pristine (no unhandled rejection warnings).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/hooks/useActiveProfileInfo.ts src/hooks/useActiveProfileInfo.test.ts
+git commit -m "feat: useActiveProfileInfo hook (mini window profile identity)"
+```
+
+---
+
+### Task 2: MiniShell wiring, i18n, CHANGELOG
+
+**Files:**
+- Modify: `src/components/mini-window/MiniShell.tsx`
+- Modify: `src/locales/fr.json` (inside `"mini"`, after `"liveBadge": "LIVE"` line ~868 — add a comma to that line)
+- Modify: `src/locales/en.json` (same position)
+- Modify: `CHANGELOG.md` (line 19)
+
+**Interfaces:**
+- Consumes: `useActiveProfileInfo` (Task 1), `ProfileAvatar` (`@/components/dashboard/ProfileAvatar`, from PR #81), existing `layout` from `useMiniWindowSize` and `status` from `useMiniWindowState`.
+- Produces: final user-facing feature; no new exports.
+
+- [ ] **Step 1: Wire the avatar into MiniShell**
+
+In `src/components/mini-window/MiniShell.tsx`:
+
+1. Add imports (after the existing hook imports):
+
+```tsx
+import { useActiveProfileInfo } from "@/hooks/useActiveProfileInfo";
+import { ProfileAvatar } from "@/components/dashboard/ProfileAvatar";
+```
+
+2. Inside `MiniShell()`, after `const layout = useMiniWindowSize();`:
+
+```tsx
+  const { name: profileName, avatarUrl: profileAvatarUrl } =
+    useActiveProfileInfo();
+```
+
+3. In the main row (the `{(status === "idle" || status === "recording") && (` block), insert as the FIRST child of the `<div className="flex flex-1 items-center gap-2 min-h-0" data-tauri-drag-region>`, before the streaming/visualizer conditional:
+
+```tsx
+            {profileName && (
+              <span
+                className="flex-shrink-0"
+                title={t("mini.activeProfile", { name: profileName })}
+                aria-label={t("mini.activeProfile", { name: profileName })}
+              >
+                <ProfileAvatar
+                  avatarUrl={profileAvatarUrl}
+                  name={profileName}
+                  className={
+                    layout === "compact"
+                      ? "h-5 w-5 text-[8px]"
+                      : "h-6 w-6 text-[10px]"
+                  }
+                />
+              </span>
+            )}
+```
+
+- [ ] **Step 2: i18n keys**
+
+In `src/locales/fr.json`, inside `"mini"`, after `"liveBadge": "LIVE"` (add a comma to that line):
+
+```json
+    "activeProfile": "Profil actif : {{name}}"
+```
+
+In `src/locales/en.json`, same position after `"liveBadge": "LIVE"`:
+
+```json
+    "activeProfile": "Active profile: {{name}}"
+```
+
+- [ ] **Step 3: CHANGELOG**
+
+In `CHANGELOG.md` line 19, extend the existing bullet — replace:
+
+```markdown
+- **Profile pictures** — set a local photo per profile from the profile manager (center-cropped and resized to 256×256, stored on this device only, never synced); shown in the profile switcher button and list, with initials as fallback.
+```
+
+with:
+
+```markdown
+- **Profile pictures** — set a local photo per profile from the profile manager (center-cropped and resized to 256×256, stored on this device only, never synced); shown in the profile switcher button and list, with initials as fallback. The active profile's picture also appears in the mini window, so you can tell at a glance which profile is recording.
+```
+
+- [ ] **Step 4: Full verification**
+
+```bash
+pnpm vitest run
+pnpm build
+```
+Expected: **493 passed, 69 files**, 0 failures; tsc + Vite build clean.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/components/mini-window/MiniShell.tsx src/locales/fr.json src/locales/en.json CHANGELOG.md
+git commit -m "feat: show active profile avatar in the mini window"
+```
+
+---
+
+## Self-Review Notes
+
+- **Spec coverage:** hook + swallow-all policy (Task 1), left-of-main-row placement idle+recording incl. streaming, layout-dependent sizes, title/aria via `mini.activeProfile` fr+en, no capabilities change, CHANGELOG extension (Task 2). Status row untouched — avatar only renders inside the main-row conditional.
+- **Type consistency:** `ActiveProfileInfo { name: string | null; avatarUrl: string | null }` consumed as `profileName`/`profileAvatarUrl`; `ProfileAvatar` props match PR #81's contract (`avatarUrl?: string | null`, `name: string`, `className`).
+- **Test math:** 490 + 3 = **493 tests / 69 files** after Task 1 (Task 2 adds none).
+- **Drag region note:** the wrapper `<span>` is non-interactive, so window dragging over it keeps working (only `data-tauri-drag-region="false"` elements opt out).

--- a/docs/superpowers/plans/2026-07-13-mini-window-avatar.md
+++ b/docs/superpowers/plans/2026-07-13-mini-window-avatar.md
@@ -286,4 +286,4 @@ git commit -m "feat: show active profile avatar in the mini window"
 - **Spec coverage:** hook + swallow-all policy (Task 1), left-of-main-row placement idle+recording incl. streaming, layout-dependent sizes, title/aria via `mini.activeProfile` fr+en, no capabilities change, CHANGELOG extension (Task 2). Status row untouched — avatar only renders inside the main-row conditional.
 - **Type consistency:** `ActiveProfileInfo { name: string | null; avatarUrl: string | null }` consumed as `profileName`/`profileAvatarUrl`; `ProfileAvatar` props match PR #81's contract (`avatarUrl?: string | null`, `name: string`, `className`).
 - **Test math:** 490 + 3 = **493 tests / 69 files** after Task 1 (Task 2 adds none).
-- **Drag region note:** the wrapper `<span>` is non-interactive, so window dragging over it keeps working (only `data-tauri-drag-region="false"` elements opt out).
+- **Drag region note:** Tauri drag regions do NOT inherit — the attribute must be stamped on each element (verified in tauri 2.10.3 drag.js). The avatar span is therefore a small non-drag dead zone, consistent with the neighboring visualizer/header elements which don't stamp it either.

--- a/docs/superpowers/specs/2026-07-13-mini-window-avatar-design.md
+++ b/docs/superpowers/specs/2026-07-13-mini-window-avatar-design.md
@@ -26,8 +26,10 @@ d'un coup d'œil le profil en cours de dictée. Fallback initiales pour les prof
   `invoke("get_profile_avatar", { id })` → data-URL ou null.
 - Retourne `{ name: string | null, avatarUrl: string | null }` (null tant que non chargé ou
   en cas d'erreur — chaque étape est enveloppée, échec silencieux).
-- Pas de listener : `switch_profile` recharge toutes les WebViews (`window.location.reload()`),
-  donc un fetch au montage est toujours frais.
+- Fraîcheur : `switch_profile` recharge toutes les WebViews (fetch au montage à jour au switch) ;
+  pour les éditions EN SESSION (photo changée/retirée, profil renommé), la fenêtre principale
+  émet `profile-identity-changed` (constante `PROFILE_IDENTITY_CHANGED_EVENT`) et le hook
+  ré-exécute son fetch à réception (finding revue finale — la mini window vit toute la session).
 
 **Affichage** — dans `MiniShell` (`src/components/mini-window/MiniShell.tsx`) :
 
@@ -45,7 +47,7 @@ d'un coup d'œil le profil en cours de dictée. Fallback initiales pour les prof
 
 - Vitest, hook `useActiveProfileInfo` (mock `@tauri-apps/api/core`) : (1) chargement nominal
   nom + avatar ; (2) profil sans photo → `avatarUrl` null, nom présent ; (3) invoke qui rejette
-  → `{ null, null }` sans erreur non gérée. Base : 490/68 (branche #81) → attendu 493/69.
+  → `{ null, null }` sans erreur non gérée ; (4) re-fetch sur événement identité. Base : 490/68 (branche #81) → attendu 495/69.
 - Vérification manuelle : mini window en dictée, avatar visible ; switch profil → avatar mis à jour.
 
 ## Livraison

--- a/docs/superpowers/specs/2026-07-13-mini-window-avatar-design.md
+++ b/docs/superpowers/specs/2026-07-13-mini-window-avatar-design.md
@@ -1,0 +1,56 @@
+# Mini window — avatar du profil actif (design)
+
+**Date** : 2026-07-13 · **Statut** : validé (conversation) · **Suite de** : PR 5 série UX (avatars de profils, PR #81)
+
+## Objectif
+
+Afficher l'avatar du profil actif dans la mini window (visualiseur flottant) pour identifier
+d'un coup d'œil le profil en cours de dictée. Fallback initiales pour les profils sans photo
+(décision utilisateur — l'identification doit marcher photo ou pas).
+
+## Contraintes
+
+- Dépend de la PR #81 (`ProfileAvatar`, commandes `get_profile_avatar` etc.) — branche stackée
+  sur `feat/profile-avatar` tant que #81 n'est pas mergée.
+- Feature 100 % locale : aucune migration, aucune Edge Function, aucun changement sync.
+- Toute string UI via react-i18next (fr + en).
+- La mini window ne doit JAMAIS être cassée par un échec avatar (erreurs avalées).
+- Aucune modification de `src-tauri/capabilities/mini.json` (la mini window invoke déjà des
+  commandes custom : `set_translate_mode`, `close_mini_window`).
+
+## Design
+
+**Données** — nouveau hook `src/hooks/useActiveProfileInfo.ts` :
+
+- Au montage : `invoke("get_active_profile")` → id, `invoke("list_profiles")` → nom,
+  `invoke("get_profile_avatar", { id })` → data-URL ou null.
+- Retourne `{ name: string | null, avatarUrl: string | null }` (null tant que non chargé ou
+  en cas d'erreur — chaque étape est enveloppée, échec silencieux).
+- Pas de listener : `switch_profile` recharge toutes les WebViews (`window.location.reload()`),
+  donc un fetch au montage est toujours frais.
+
+**Affichage** — dans `MiniShell` (`src/components/mini-window/MiniShell.tsx`) :
+
+- `<ProfileAvatar avatarUrl={...} name={...} className={...} />` tout à gauche de la rangée
+  principale (avant `MiniStreamingHud`/`MiniVisualizer`), rendu seulement si `name` est chargé.
+- Visible en `idle` et `recording` (y compris streaming). Masqué dans la status row
+  (processing/success/error — états transitoires de 2-3 s).
+- Tailles par layout (`useMiniWindowSize`) : compact `h-5 w-5 text-[8px]`, standard/extended
+  `h-6 w-6 text-[10px]`. `shrink-0` (déjà porté par ProfileAvatar).
+- Wrapper avec `title` + `aria-label` = `t("mini.activeProfile", { name })` :
+  fr « Profil actif : {{name}} », en « Active profile: {{name}} ». Non interactif
+  (le drag de la fenêtre reste fonctionnel).
+
+## Tests
+
+- Vitest, hook `useActiveProfileInfo` (mock `@tauri-apps/api/core`) : (1) chargement nominal
+  nom + avatar ; (2) profil sans photo → `avatarUrl` null, nom présent ; (3) invoke qui rejette
+  → `{ null, null }` sans erreur non gérée. Base : 490/68 (branche #81) → attendu 493/69.
+- Vérification manuelle : mini window en dictée, avatar visible ; switch profil → avatar mis à jour.
+
+## Livraison
+
+Branche `feat/mini-window-avatar` (base `feat/profile-avatar`), PR stackée — retarget
+automatique vers main au merge de #81. CHANGELOG : étendre la bullet « Profile pictures »
+existante de la section Unreleased (même release) avec la mention mini window — pas de
+nouvelle bullet.

--- a/src/components/mini-window/MiniShell.tsx
+++ b/src/components/mini-window/MiniShell.tsx
@@ -2,6 +2,8 @@ import { useEffect } from "react";
 import { useTranslation } from "react-i18next";
 import { useMiniWindowState } from "@/hooks/useMiniWindowState";
 import { useMiniWindowSize } from "@/hooks/useMiniWindowSize";
+import { useActiveProfileInfo } from "@/hooks/useActiveProfileInfo";
+import { ProfileAvatar } from "@/components/dashboard/ProfileAvatar";
 import { MiniVisualizer } from "./MiniVisualizer";
 import { MiniHeader } from "./MiniHeader";
 import { MiniStreamingHud } from "./MiniStreamingHud";
@@ -35,6 +37,8 @@ export function MiniShell() {
   const translateDisabled = false;
   const translateDisabledReason: string | undefined = undefined;
   const layout = useMiniWindowSize();
+  const { name: profileName, avatarUrl: profileAvatarUrl } =
+    useActiveProfileInfo();
 
   // Transparent background for the frameless window. We also apply the
   // `vt-app` design system scope so MiniHeader/MiniVisualizer/MiniTranscriptPreview
@@ -86,6 +90,23 @@ export function MiniShell() {
             className="flex flex-1 items-center gap-2 min-h-0"
             data-tauri-drag-region
           >
+            {profileName && (
+              <span
+                className="flex-shrink-0"
+                title={t("mini.activeProfile", { name: profileName })}
+                aria-label={t("mini.activeProfile", { name: profileName })}
+              >
+                <ProfileAvatar
+                  avatarUrl={profileAvatarUrl}
+                  name={profileName}
+                  className={
+                    layout === "compact"
+                      ? "h-5 w-5 text-[8px]"
+                      : "h-6 w-6 text-[10px]"
+                  }
+                />
+              </span>
+            )}
             {status === "recording" && isStreamingLive ? (
               // Streaming session: live-dictation HUD from the first second —
               // audio pip + transcript tail (or listening placeholder) + caret.

--- a/src/components/mini-window/MiniShell.tsx
+++ b/src/components/mini-window/MiniShell.tsx
@@ -93,6 +93,7 @@ export function MiniShell() {
             {profileName && (
               <span
                 className="flex-shrink-0"
+                role="img"
                 title={t("mini.activeProfile", { name: profileName })}
                 aria-label={t("mini.activeProfile", { name: profileName })}
               >

--- a/src/contexts/ProfilesContext.avatars.test.tsx
+++ b/src/contexts/ProfilesContext.avatars.test.tsx
@@ -8,6 +8,11 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
 }));
 
+const emitMock = vi.fn(async (..._args: unknown[]) => {});
+vi.mock("@tauri-apps/api/event", () => ({
+  emit: (...args: unknown[]) => emitMock(...args),
+}));
+
 import { ProfilesProvider, useProfiles } from "./ProfilesContext";
 
 const DATA_URL = "data:image/png;base64,AAAA";
@@ -34,6 +39,7 @@ const wrapper = ({ children }: { children: ReactNode }) => (
 beforeEach(() => {
   invokeMock.mockReset();
   mockBackend();
+  emitMock.mockReset();
 });
 
 describe("ProfilesContext avatars", () => {
@@ -66,5 +72,21 @@ describe("ProfilesContext avatars", () => {
       id: "default",
     });
     expect(result.current.avatars).toEqual({});
+  });
+
+  it("broadcasts an identity change on avatar set, clear and rename", async () => {
+    const { result } = renderHook(() => useProfiles(), { wrapper });
+    await waitFor(() => expect(result.current.isLoaded).toBe(true));
+
+    await act(() => result.current.setProfileAvatar("work", NEW_URL));
+    await act(() => result.current.clearProfileAvatar("default"));
+    await act(() => result.current.renameProfile("work", "Boulot"));
+
+    const events = emitMock.mock.calls.map((c) => c[0]);
+    expect(events).toEqual([
+      "profile-identity-changed",
+      "profile-identity-changed",
+      "profile-identity-changed",
+    ]);
   });
 });

--- a/src/contexts/ProfilesContext.tsx
+++ b/src/contexts/ProfilesContext.tsx
@@ -7,6 +7,8 @@ import {
   type ReactNode,
 } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { emit } from "@tauri-apps/api/event";
+import { PROFILE_IDENTITY_CHANGED_EVENT } from "@/hooks/useActiveProfileInfo";
 
 export interface ProfileMeta {
   id: string;
@@ -31,6 +33,12 @@ interface ProfilesContextType {
 const ProfilesContext = createContext<ProfilesContextType | undefined>(
   undefined
 );
+
+function broadcastProfileIdentityChanged() {
+  void emit(PROFILE_IDENTITY_CHANGED_EVENT).catch(() => {
+    // Non-fatal: other windows keep their current display until reload.
+  });
+}
 
 export function ProfilesProvider({ children }: { children: ReactNode }) {
   const [profiles, setProfiles] = useState<ProfileMeta[]>([]);
@@ -82,6 +90,7 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
       setProfiles((prev) =>
         prev.map((p) => (p.id === id ? { ...p, name: newName } : p))
       );
+      broadcastProfileIdentityChanged();
     },
     []
   );
@@ -100,6 +109,7 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
     async (id: string, dataUrl: string): Promise<void> => {
       await invoke("set_profile_avatar", { id, dataUrl });
       setAvatars((prev) => ({ ...prev, [id]: dataUrl }));
+      broadcastProfileIdentityChanged();
     },
     []
   );
@@ -111,6 +121,7 @@ export function ProfilesProvider({ children }: { children: ReactNode }) {
       delete next[id];
       return next;
     });
+    broadcastProfileIdentityChanged();
   }, []);
 
   const switchProfile = useCallback(async (id: string): Promise<void> => {

--- a/src/hooks/useActiveProfileInfo.test.ts
+++ b/src/hooks/useActiveProfileInfo.test.ts
@@ -1,0 +1,57 @@
+// @vitest-environment jsdom
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, waitFor } from "@testing-library/react";
+
+const invokeMock = vi.fn();
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: (...args: unknown[]) => invokeMock(...args),
+}));
+
+import { useActiveProfileInfo } from "./useActiveProfileInfo";
+
+const DATA_URL = "data:image/png;base64,AAAA";
+const PROFILES = [
+  { id: "default", name: "Default", createdAt: "" },
+  { id: "perso", name: "Perso", createdAt: "" },
+];
+
+beforeEach(() => {
+  invokeMock.mockReset();
+});
+
+describe("useActiveProfileInfo", () => {
+  it("loads the active profile name and avatar", async () => {
+    invokeMock.mockImplementation(async (cmd: unknown) => {
+      if (cmd === "get_active_profile") return "perso";
+      if (cmd === "list_profiles") return PROFILES;
+      if (cmd === "get_profile_avatar") return DATA_URL;
+      return undefined;
+    });
+    const { result } = renderHook(() => useActiveProfileInfo());
+    await waitFor(() => expect(result.current.name).toBe("Perso"));
+    expect(result.current.avatarUrl).toBe(DATA_URL);
+    expect(invokeMock).toHaveBeenCalledWith("get_profile_avatar", {
+      id: "perso",
+    });
+  });
+
+  it("returns a null avatarUrl for a profile without a photo", async () => {
+    invokeMock.mockImplementation(async (cmd: unknown) => {
+      if (cmd === "get_active_profile") return "default";
+      if (cmd === "list_profiles") return PROFILES;
+      if (cmd === "get_profile_avatar") return null;
+      return undefined;
+    });
+    const { result } = renderHook(() => useActiveProfileInfo());
+    await waitFor(() => expect(result.current.name).toBe("Default"));
+    expect(result.current.avatarUrl).toBeNull();
+  });
+
+  it("stays null on invoke failure without throwing", async () => {
+    invokeMock.mockRejectedValue(new Error("ipc down"));
+    const { result } = renderHook(() => useActiveProfileInfo());
+    // Give the effect a tick to settle; nothing must throw or reject unhandled.
+    await new Promise((r) => setTimeout(r, 0));
+    expect(result.current).toEqual({ name: null, avatarUrl: null });
+  });
+});

--- a/src/hooks/useActiveProfileInfo.test.ts
+++ b/src/hooks/useActiveProfileInfo.test.ts
@@ -7,6 +7,15 @@ vi.mock("@tauri-apps/api/core", () => ({
   invoke: (...args: unknown[]) => invokeMock(...args),
 }));
 
+let identityHandler: (() => void) | null = null;
+const unlistenMock = vi.fn();
+vi.mock("@tauri-apps/api/event", () => ({
+  listen: (_event: string, handler: () => void) => {
+    identityHandler = handler;
+    return Promise.resolve(unlistenMock);
+  },
+}));
+
 import { useActiveProfileInfo } from "./useActiveProfileInfo";
 
 const DATA_URL = "data:image/png;base64,AAAA";
@@ -17,6 +26,7 @@ const PROFILES = [
 
 beforeEach(() => {
   invokeMock.mockReset();
+  identityHandler = null;
 });
 
 describe("useActiveProfileInfo", () => {
@@ -53,5 +63,23 @@ describe("useActiveProfileInfo", () => {
     // Give the effect a tick to settle; nothing must throw or reject unhandled.
     await new Promise((r) => setTimeout(r, 0));
     expect(result.current).toEqual({ name: null, avatarUrl: null });
+  });
+
+  it("reloads the identity when the main window broadcasts a change", async () => {
+    let avatar: string | null = DATA_URL;
+    invokeMock.mockImplementation(async (cmd: unknown) => {
+      if (cmd === "get_active_profile") return "perso";
+      if (cmd === "list_profiles") return PROFILES;
+      if (cmd === "get_profile_avatar") return avatar;
+      return undefined;
+    });
+    const { result } = renderHook(() => useActiveProfileInfo());
+    await waitFor(() => expect(result.current.avatarUrl).toBe(DATA_URL));
+
+    avatar = null;
+    expect(identityHandler).not.toBeNull();
+    identityHandler!();
+    await waitFor(() => expect(result.current.avatarUrl).toBeNull());
+    expect(result.current.name).toBe("Perso");
   });
 });

--- a/src/hooks/useActiveProfileInfo.ts
+++ b/src/hooks/useActiveProfileInfo.ts
@@ -1,0 +1,55 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+
+interface ProfileMeta {
+  id: string;
+  name: string;
+  createdAt: string;
+}
+
+export interface ActiveProfileInfo {
+  name: string | null;
+  avatarUrl: string | null;
+}
+
+/**
+ * Loads the active profile's name and avatar once on mount. Errors are
+ * swallowed (the mini window must never break over an avatar), and no
+ * listener is needed: switching profiles reloads every WebView, so
+ * mount-time data is always fresh.
+ */
+export function useActiveProfileInfo(): ActiveProfileInfo {
+  const [info, setInfo] = useState<ActiveProfileInfo>({
+    name: null,
+    avatarUrl: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+    void (async () => {
+      try {
+        const [id, profiles] = await Promise.all([
+          invoke<string>("get_active_profile"),
+          invoke<ProfileMeta[]>("list_profiles"),
+        ]);
+        const name = profiles.find((p) => p.id === id)?.name ?? null;
+        const avatarUrl = await invoke<string | null>("get_profile_avatar", {
+          id,
+        }).catch(() => null);
+        if (!cancelled) {
+          setInfo({
+            name,
+            avatarUrl: typeof avatarUrl === "string" ? avatarUrl : null,
+          });
+        }
+      } catch {
+        // Swallow — the mini window renders without the avatar.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return info;
+}

--- a/src/hooks/useActiveProfileInfo.ts
+++ b/src/hooks/useActiveProfileInfo.ts
@@ -1,5 +1,6 @@
 import { useEffect, useState } from "react";
 import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
 
 interface ProfileMeta {
   id: string;
@@ -13,10 +14,16 @@ export interface ActiveProfileInfo {
 }
 
 /**
- * Loads the active profile's name and avatar once on mount. Errors are
- * swallowed (the mini window must never break over an avatar), and no
- * listener is needed: switching profiles reloads every WebView, so
- * mount-time data is always fresh.
+ * Emitted by the main window whenever a profile's display identity (name,
+ * avatar) changes, so long-lived windows (mini) can refresh what they show.
+ */
+export const PROFILE_IDENTITY_CHANGED_EVENT = "profile-identity-changed";
+
+/**
+ * Loads the active profile's name and avatar on mount, and reloads on
+ * PROFILE_IDENTITY_CHANGED_EVENT (avatar/name edits in the main window).
+ * Errors are swallowed (the mini window must never break over an avatar).
+ * Profile switches reload every WebView, so they need no extra handling.
  */
 export function useActiveProfileInfo(): ActiveProfileInfo {
   const [info, setInfo] = useState<ActiveProfileInfo>({
@@ -26,7 +33,8 @@ export function useActiveProfileInfo(): ActiveProfileInfo {
 
   useEffect(() => {
     let cancelled = false;
-    void (async () => {
+
+    async function load() {
       try {
         const [id, profiles] = await Promise.all([
           invoke<string>("get_active_profile"),
@@ -45,9 +53,16 @@ export function useActiveProfileInfo(): ActiveProfileInfo {
       } catch {
         // Swallow — the mini window renders without the avatar.
       }
-    })();
+    }
+
+    void load();
+    const unlistenPromise = listen(PROFILE_IDENTITY_CHANGED_EVENT, () => {
+      void load();
+    });
+
     return () => {
       cancelled = true;
+      void unlistenPromise.then((unlisten) => unlisten()).catch(() => {});
     };
   }, []);
 

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -865,7 +865,8 @@
     "recordingHint": "Recording…",
     "noTranscriptYet": "No transcription yet",
     "listening": "Listening…",
-    "liveBadge": "LIVE"
+    "liveBadge": "LIVE",
+    "activeProfile": "Active profile: {{name}}"
   },
   "logs": {
     "limitReached": "(limit reached)",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -865,7 +865,8 @@
     "recordingHint": "Enregistrement…",
     "noTranscriptYet": "Aucune transcription pour l'instant",
     "listening": "J'écoute…",
-    "liveBadge": "LIVE"
+    "liveBadge": "LIVE",
+    "activeProfile": "Profil actif : {{name}}"
   },
   "logs": {
     "limitReached": "(limite atteinte)",


### PR DESCRIPTION
Follow-up de la PR #81 — spec `docs/superpowers/specs/2026-07-13-mini-window-avatar-design.md`, plan `docs/superpowers/plans/2026-07-13-mini-window-avatar.md`.

> ⚠️ **PR stackée sur `feat/profile-avatar` (#81)** — merger #81 d'abord ; GitHub retargetera automatiquement cette PR vers main.

## Ce que ça fait

La **mini window affiche l'avatar du profil actif** (photo, ou initiales en fallback) tout à gauche de la rangée principale — on voit d'un coup d'œil quel profil enregistre.

- Visible en idle et pendant l'enregistrement (streaming inclus) ; masqué pendant les états transitoires (envoi/succès/erreur). Tailles : 20 px en layout compact, 24 px sinon. Tooltip + aria-label « Profil actif : {nom} » (i18n fr/en, `role="img"`).
- **Données** : hook `useActiveProfileInfo` — fetch au montage (`get_active_profile` + `list_profiles` + `get_profile_avatar`), erreurs avalées (la mini window ne casse jamais pour un avatar).
- **Fraîcheur en session** (finding Important de la revue finale) : la fenêtre principale émet `profile-identity-changed` après changement/retrait de photo ou renommage de profil ; le hook ré-exécute son fetch à réception. Le switch de profil recharge déjà toutes les WebViews (inchangé).
- Aucun changement Rust, aucune dépendance, aucun changement `capabilities/mini.json` (commandes app non soumises à l'ACL, pattern déjà utilisé par la mini window).

## Tests

- Vitest : **495/495** (69 fichiers) — +5 vs #81 (4 tests hook dont re-fetch sur événement, +1 test broadcast dans ProfilesContext).
- `pnpm build` (tsc + Vite) clean.
- Revue finale de branche : Ready to merge YES ; fix du finding Important appliqué (a31f5fc), compteurs reproduits sur le HEAD exact.

## Déploiement

**Aucun** — feature 100 % locale.

## Smoke test suggéré (`pnpm tauri dev`)

- [ ] Lancer une dictée → l'avatar du profil actif apparaît à gauche de la mini window (photo ou initiales).
- [ ] Changer la photo du profil actif dans « Gérer les profils » pendant que l'app tourne → la mini window se met à jour sans redémarrage (idem retrait de photo et renommage → initiales à jour).
- [ ] Changer de profil → après le reload, la mini window montre le nouvel avatar.
- [ ] Mode streaming : l'avatar cohabite avec le HUD sans casser la largeur ; layout compact (fenêtre réduite) : avatar 20 px.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
