### PR TITLE
chore: gitignore local Codex config and docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,6 +33,10 @@ artifacts/
 .auto-claude/
 .mcp.json
 
+# Codex local config/docs
+.codex/
+AGENTS.md
+
 .design-handoff/
 
 # Auto Claude generated files


### PR DESCRIPTION
## Summary
- Add `.codex/` and `AGENTS.md` to `.gitignore` — local Codex tool config/docs, same treatment as `.mcp.json`

## Test plan
- N/A (gitignore-only change)