### PR TITLE
feat: drag note tabs out to detach them

### DIFF
--- a/docs/detachable-notes-e2e-checklist.md
+++ b/docs/detachable-notes-e2e-checklist.md
@@ -46,11 +46,17 @@ packagé avant release.
 
 ## PR 2 — Drag-out
 
-- [ ] Glisser un onglet hors de la fenêtre principale → fantôme pendant le
-      drag, fenêtre créée au point de lâcher.
-- [ ] Lâcher DANS la fenêtre principale → annulation, rien ne se passe,
-      le clic simple active toujours l'onglet.
+- [ ] Glisser un onglet et lâcher HORS de la barre d'onglets (même dans la
+      fenêtre, ex. au milieu de l'éditeur) → fantôme pendant le drag,
+      fenêtre créée au point de lâcher.
+- [ ] Fenêtre principale MAXIMISÉE → le détachement fonctionne (critère
+      « hors barre », pas « hors fenêtre »).
+- [ ] Lâcher SUR la barre d'onglets → annulation, rien ne se passe, et le
+      clic simple suivant active toujours son onglet.
 - [ ] Échap pendant le drag → annulation.
-- [ ] Drag vers un second écran (DPI différent si possible) → la fenêtre
-      apparaît près du curseur.
+- [ ] Glisser hors de la fenêtre principale (fenêtre restaurée) → fenêtre
+      créée au point de lâcher.
+- [ ] Drag vers un second écran (DPI différent si possible, et écran disposé
+      À GAUCHE du principal si possible) → la fenêtre apparaît près du
+      curseur.
 - [ ] Clic molette sur un onglet ferme toujours l'onglet (régression).

--- a/docs/superpowers/specs/2026-07-24-detachable-notes-design.md
+++ b/docs/superpowers/specs/2026-07-24-detachable-notes-design.md
@@ -183,14 +183,18 @@ fenêtre détachée (émet `note-detached-updated` pour que le main rafraîchiss
 
 - `pointerdown` sur un onglet + déplacement au-delà d'un seuil → mode drag :
   un **fantôme** (petit rectangle avec le titre de la note) suit le curseur.
-- `pointerup` **hors des limites de la fenêtre principale** (détection en
-  coordonnées CSS client, `clientX/clientY` vs `innerWidth/innerHeight` — aucun
-  calcul DPI côté JS) → `open_note_window(id, { atCursor: true })` ; côté Rust,
-  la position de dépose est résolue depuis le curseur OS (`app.cursor_position()`,
-  déjà en coordonnées physiques, gère nativement les moniteurs multiples) →
-  détachement standard (§4).
-- `pointerup` **dans** la fenêtre → annulation (le réordonnancement d'onglets par
-  drag est un non-goal, cf. §8). `Escape` annule le drag en cours.
+  Une capture de pointeur explicite (`setPointerCapture`) garantit la livraison
+  des événements même hors de la fenêtre OS (WebView2 ne la garantit pas sans).
+- `pointerup` **hors de la barre d'onglets** — style Bloc-notes Windows : même
+  à l'intérieur de la fenêtre (détection en coordonnées CSS client contre le
+  rect de la barre, marge de tolérance ~8 px — aucun calcul DPI côté JS) →
+  `open_note_window(id, { atCursor: true })` ; côté Rust, la position de dépose
+  est résolue depuis le curseur OS (`app.cursor_position()`, déjà en coordonnées
+  physiques, gère nativement les moniteurs multiples) → détachement standard
+  (§4). Ce critère reste utilisable fenêtre maximisée sur un seul écran, là où
+  un critère « hors fenêtre » ne l'est pas (décision utilisateur, 2026-07-24).
+- `pointerup` **sur la barre d'onglets** → annulation (le réordonnancement
+  d'onglets par drag est un non-goal, cf. §8). `Escape` annule le drag en cours.
 - L'icône « détacher » sur l'onglet actif reste le déclencheur secondaire
   (découvrabilité, accessibilité, fallback).
 - Les calculs de coordonnées/seuils sont extraits en fonctions pures testables ;

--- a/docs/superpowers/specs/2026-07-24-detachable-notes-design.md
+++ b/docs/superpowers/specs/2026-07-24-detachable-notes-design.md
@@ -183,11 +183,12 @@ fenêtre détachée (émet `note-detached-updated` pour que le main rafraîchiss
 
 - `pointerdown` sur un onglet + déplacement au-delà d'un seuil → mode drag :
   un **fantôme** (petit rectangle avec le titre de la note) suit le curseur.
-- `pointerup` **hors des limites de la fenêtre principale** → conversion des
-  coordonnées écran CSS (`screenX/screenY`) en coordonnées **physiques**
-  (scale factor du moniteur courant — le code de positionnement de la mini window
-  gère déjà les moniteurs) → `open_note_window(id, { x, y })` → détachement
-  standard (§4).
+- `pointerup` **hors des limites de la fenêtre principale** (détection en
+  coordonnées CSS client, `clientX/clientY` vs `innerWidth/innerHeight` — aucun
+  calcul DPI côté JS) → `open_note_window(id, { atCursor: true })` ; côté Rust,
+  la position de dépose est résolue depuis le curseur OS (`app.cursor_position()`,
+  déjà en coordonnées physiques, gère nativement les moniteurs multiples) →
+  détachement standard (§4).
 - `pointerup` **dans** la fenêtre → annulation (le réordonnancement d'onglets par
   drag est un non-goal, cf. §8). `Escape` annule le drag en cours.
 - L'icône « détacher » sur l'onglet actif reste le déclencheur secondaire

--- a/src-tauri/src/window.rs
+++ b/src-tauri/src/window.rs
@@ -406,9 +406,11 @@ fn position_note_window(
 ) {
     if at_cursor {
         if let Ok(cursor) = app.cursor_position() {
+            // Negative physical coordinates are valid on multi-monitor setups
+            // (a monitor left of/above the primary) — must not be clamped.
             let _ = window.set_position(Position::Physical(PhysicalPosition {
-                x: (cursor.x as i32 - 60).max(0),
-                y: (cursor.y as i32 - 20).max(0),
+                x: cursor.x as i32 - 60,
+                y: cursor.y as i32 - 20,
             }));
             return;
         }
@@ -426,10 +428,7 @@ fn position_note_window(
     let offset = NOTE_CASCADE_OFFSET_PX * existing_note_windows as i32;
     let x = pos.x + (main_size.width as i32 - size.width as i32) / 2 + offset;
     let y = pos.y + (main_size.height as i32 - size.height as i32) / 2 + offset;
-    let _ = window.set_position(Position::Physical(PhysicalPosition {
-        x: x.max(0),
-        y: y.max(0),
-    }));
+    let _ = window.set_position(Position::Physical(PhysicalPosition { x, y }));
 }
 
 /// Create the detached window for a note, or focus it if it already exists.

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -459,6 +459,7 @@ export default function Dashboard() {
               onCreateFolder={createFolder}
               readNote={readNote}
               onDetachNote={(id) => void handleDetachNote(id)}
+              onDetachNoteAtCursor={(id) => void handleDetachNote(id, true)}
             />
           ) : activeTab === "notes" ? (
             <div className="flex items-center justify-center h-full text-muted-foreground text-sm">

--- a/src/components/notes/NotesEditor/NotesEditor.tsx
+++ b/src/components/notes/NotesEditor/NotesEditor.tsx
@@ -33,6 +33,7 @@ interface NotesEditorProps {
   onCreateFolder: (name: string, icon?: string | null) => Promise<FolderMeta>;
   readNote: (id: string) => Promise<NoteData>;
   onDetachNote: (id: string) => void;
+  onDetachNoteAtCursor: (id: string) => void;
 }
 
 /**
@@ -58,6 +59,7 @@ export function NotesEditor({
   onCreateFolder,
   readNote,
   onDetachNote,
+  onDetachNoteAtCursor,
 }: NotesEditorProps) {
   const { t } = useTranslation();
 
@@ -185,6 +187,12 @@ export function NotesEditor({
             // switch and write the NEXT note's HTML under this note's id.
             flushSave();
             onDetachNote(id);
+          }}
+          onDetachNoteAtCursor={(id) => {
+            // Same flush-before-transfer invariant as onDetachNote above —
+            // a drag-out is another ownership transfer to a detached window.
+            flushSave();
+            onDetachNoteAtCursor(id);
           }}
         />
 

--- a/src/components/notes/NotesEditor/NotesEditorTitleBar.tsx
+++ b/src/components/notes/NotesEditor/NotesEditorTitleBar.tsx
@@ -14,6 +14,7 @@ import { FolderIcon } from "@/components/notes/FolderIcon";
 import { FolderNameDialog } from "@/components/notes/FolderNameDialog";
 import { type NoteMeta, deriveTitle } from "@/hooks/useNotes";
 import { type FolderMeta } from "@/hooks/useFolders";
+import { useTabDragOut } from "@/hooks/useTabDragOut";
 
 interface NotesEditorTitleBarProps {
   openNotes: NoteMeta[];
@@ -31,6 +32,7 @@ interface NotesEditorTitleBarProps {
   onMoveNote: (noteId: string, folderId: string | null) => Promise<void>;
   onCreateFolder: (name: string, icon?: string | null) => Promise<FolderMeta>;
   onDetachNote: (id: string) => void;
+  onDetachNoteAtCursor: (id: string) => void;
 }
 
 export function NotesEditorTitleBar({
@@ -45,8 +47,12 @@ export function NotesEditorTitleBar({
   onMoveNote,
   onCreateFolder,
   onDetachNote,
+  onDetachNoteAtCursor,
 }: NotesEditorTitleBarProps) {
   const { t } = useTranslation();
+  const { drag, handleTabPointerDown, suppressNextClick } = useTabDragOut({
+    onDetachAtCursor: onDetachNoteAtCursor,
+  });
   const editorText = editor?.getText() ?? "";
   const isEditorInSync = loadedNoteId !== null && loadedNoteId === activeNoteId;
   const [badgeMenu, setBadgeMenu] = useState<{ x: number; y: number } | null>(null);
@@ -135,13 +141,20 @@ export function NotesEditorTitleBar({
               key={note.id}
               className="notes-tab"
               data-active={isActive}
-              onClick={() => onActivateNote(note.id)}
+              onClick={() => {
+                if (suppressNextClick.current) {
+                  suppressNextClick.current = false;
+                  return;
+                }
+                onActivateNote(note.id);
+              }}
               onMouseDown={(e) => {
                 if (e.button === 1) {
                   e.preventDefault();
                   onTabClose(note.id);
                 }
               }}
+              onPointerDown={(e) => handleTabPointerDown(e, note.id, displayTitle)}
             >
               <span className="notes-tab-dot" />
               <span className="notes-tab-title">{displayTitle}</span>
@@ -220,6 +233,21 @@ export function NotesEditorTitleBar({
           void onCreateFolder(name, icon).then((folder) => onMoveNote(noteId, folder.id));
         }}
       />
+
+      {drag && (
+        <div
+          className="fixed z-50 pointer-events-none px-3 py-1.5 rounded-md shadow-lg text-sm max-w-[240px] truncate"
+          style={{
+            left: drag.x + 8,
+            top: drag.y + 8,
+            background: "var(--vt-panel-2)",
+            border: "1px solid var(--vt-border)",
+            color: "var(--vt-fg)",
+          }}
+        >
+          {drag.title}
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/notes/NotesEditor/NotesEditorTitleBar.tsx
+++ b/src/components/notes/NotesEditor/NotesEditorTitleBar.tsx
@@ -50,8 +50,12 @@ export function NotesEditorTitleBar({
   onDetachNoteAtCursor,
 }: NotesEditorTitleBarProps) {
   const { t } = useTranslation();
+  const tabbarRef = useRef<HTMLDivElement>(null);
   const { drag, handleTabPointerDown, suppressNextClick } = useTabDragOut({
     onDetachAtCursor: onDetachNoteAtCursor,
+    // The whole tab bar row is the cancel zone: releasing anywhere else —
+    // even inside the window — detaches (Notepad-style).
+    getStripRect: () => tabbarRef.current?.getBoundingClientRect() ?? null,
   });
   const editorText = editor?.getText() ?? "";
   const isEditorInSync = loadedNoteId !== null && loadedNoteId === activeNoteId;
@@ -121,7 +125,7 @@ export function NotesEditorTitleBar({
     : [];
 
   return (
-    <div className="notes-tabbar flex items-stretch select-none shrink-0">
+    <div ref={tabbarRef} className="notes-tabbar flex items-stretch select-none shrink-0">
       {/* Tabs row (scrollable) */}
       <div
         className="flex items-stretch overflow-x-auto flex-1 min-w-0"

--- a/src/hooks/useTabDragOut.test.ts
+++ b/src/hooks/useTabDragOut.test.ts
@@ -187,4 +187,35 @@ describe("useTabDragOut", () => {
     expect(result.current.suppressNextClick.current).toBe(false);
     expect(result.current.drag).toBeNull();
   });
+
+  it("Escape while dragging (past threshold) suppresses, resets the ghost, and prevents a later detach", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+
+    act(() => {
+      result.current.handleTabPointerDown(
+        makeReactPointerDownEvent({ clientX: 10, clientY: 10 }),
+        "note-1",
+        "Title 1",
+      );
+    });
+    act(() => {
+      dispatch("pointermove", { clientX: 100, clientY: 10 }); // past 6px threshold
+    });
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(result.current.suppressNextClick.current).toBe(true);
+    expect(result.current.drag).toBeNull();
+
+    // The gesture was reset, so a later left release outside the viewport
+    // must not be treated as a completed drag.
+    act(() => {
+      dispatch("pointerup", { clientX: -50, clientY: 10 });
+    });
+    expect(onDetachAtCursor).not.toHaveBeenCalled();
+  });
 });

--- a/src/hooks/useTabDragOut.test.ts
+++ b/src/hooks/useTabDragOut.test.ts
@@ -44,10 +44,14 @@ beforeEach(() => {
   Object.defineProperty(window, "innerHeight", { value: 800, writable: true, configurable: true });
 });
 
+/** Tab bar occupies the top 30px of the 1000x800 viewport. */
+const STRIP = { left: 0, top: 0, right: 1000, bottom: 30 };
+const getStripRect = () => STRIP;
+
 describe("useTabDragOut", () => {
-  it("completed drag released outside the viewport detaches and suppresses the next click", () => {
+  it("completed drag released outside the window detaches and suppresses the next click", () => {
     const onDetachAtCursor = vi.fn();
-    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor, getStripRect }));
 
     act(() => {
       result.current.handleTabPointerDown(
@@ -68,9 +72,9 @@ describe("useTabDragOut", () => {
     expect(result.current.suppressNextClick.current).toBe(true);
   });
 
-  it("release inside the viewport after dragging does not detach but still suppresses", () => {
+  it("release ON the tab bar after dragging cancels (no detach) but still suppresses", () => {
     const onDetachAtCursor = vi.fn();
-    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor, getStripRect }));
 
     act(() => {
       result.current.handleTabPointerDown(
@@ -83,16 +87,62 @@ describe("useTabDragOut", () => {
       dispatch("pointermove", { clientX: 100, clientY: 10 });
     });
     act(() => {
-      dispatch("pointerup", { clientX: 200, clientY: 200 }); // inside viewport
+      dispatch("pointerup", { clientX: 500, clientY: 15 }); // on the tab bar
     });
 
     expect(onDetachAtCursor).not.toHaveBeenCalled();
     expect(result.current.suppressNextClick.current).toBe(true);
   });
 
+  it("release below the tab bar but inside the window detaches (Notepad-style — works maximized)", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor, getStripRect }));
+
+    act(() => {
+      result.current.handleTabPointerDown(
+        makeReactPointerDownEvent({ clientX: 10, clientY: 10 }),
+        "note-1",
+        "Title 1",
+      );
+    });
+    act(() => {
+      dispatch("pointermove", { clientX: 100, clientY: 100 });
+    });
+    act(() => {
+      dispatch("pointerup", { clientX: 200, clientY: 200 }); // inside viewport, off the bar
+    });
+
+    expect(onDetachAtCursor).toHaveBeenCalledTimes(1);
+    expect(onDetachAtCursor).toHaveBeenCalledWith("note-1");
+    expect(result.current.suppressNextClick.current).toBe(true);
+  });
+
+  it("falls back to the outside-viewport criterion when no strip rect is available", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() =>
+      useTabDragOut({ onDetachAtCursor, getStripRect: () => null }),
+    );
+
+    act(() => {
+      result.current.handleTabPointerDown(
+        makeReactPointerDownEvent({ clientX: 10, clientY: 10 }),
+        "note-1",
+        "Title 1",
+      );
+    });
+    act(() => {
+      dispatch("pointermove", { clientX: 100, clientY: 100 });
+    });
+    act(() => {
+      dispatch("pointerup", { clientX: 200, clientY: 200 }); // inside viewport
+    });
+
+    expect(onDetachAtCursor).not.toHaveBeenCalled();
+  });
+
   it("a fresh pointerdown anywhere clears a stale suppressNextClick", () => {
     const onDetachAtCursor = vi.fn();
-    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor, getStripRect }));
 
     // Simulate a stale flag left over from a previous drag whose click
     // never fired (released far from the original target).
@@ -109,7 +159,7 @@ describe("useTabDragOut", () => {
 
   it("a non-left-button pointerup while dragging does not end the drag; a later left release still works", () => {
     const onDetachAtCursor = vi.fn();
-    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor, getStripRect }));
 
     act(() => {
       result.current.handleTabPointerDown(
@@ -138,7 +188,7 @@ describe("useTabDragOut", () => {
 
   it("pointercancel resets without detaching and without suppressing", () => {
     const onDetachAtCursor = vi.fn();
-    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor, getStripRect }));
 
     act(() => {
       result.current.handleTabPointerDown(
@@ -167,7 +217,7 @@ describe("useTabDragOut", () => {
 
   it("Escape while merely armed (no movement past threshold) does not suppress", () => {
     const onDetachAtCursor = vi.fn();
-    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor, getStripRect }));
 
     act(() => {
       result.current.handleTabPointerDown(
@@ -190,7 +240,7 @@ describe("useTabDragOut", () => {
 
   it("Escape while dragging (past threshold) suppresses, resets the ghost, and prevents a later detach", () => {
     const onDetachAtCursor = vi.fn();
-    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor, getStripRect }));
 
     act(() => {
       result.current.handleTabPointerDown(

--- a/src/hooks/useTabDragOut.test.ts
+++ b/src/hooks/useTabDragOut.test.ts
@@ -1,0 +1,190 @@
+// @vitest-environment jsdom
+import { describe, expect, it, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+
+import { useTabDragOut } from "./useTabDragOut";
+
+/** jsdom may not implement PointerEvent; MouseEvent carries the same
+ *  clientX/clientY fields and window listeners don't care about the
+ *  concrete event class, only the type string and those fields. */
+function pointerEvent(
+  type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+  init: { clientX?: number; clientY?: number; button?: number } = {},
+) {
+  const Ctor =
+    typeof PointerEvent !== "undefined" ? PointerEvent : MouseEvent;
+  return new Ctor(type, {
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+    button: init.button ?? 0,
+    bubbles: true,
+    cancelable: true,
+  });
+}
+
+function dispatch(
+  type: "pointerdown" | "pointermove" | "pointerup" | "pointercancel",
+  init?: { clientX?: number; clientY?: number; button?: number },
+) {
+  window.dispatchEvent(pointerEvent(type, init));
+}
+
+function makeReactPointerDownEvent(
+  init: { clientX?: number; clientY?: number; button?: number } = {},
+) {
+  return {
+    button: init.button ?? 0,
+    clientX: init.clientX ?? 0,
+    clientY: init.clientY ?? 0,
+  } as unknown as React.PointerEvent;
+}
+
+beforeEach(() => {
+  Object.defineProperty(window, "innerWidth", { value: 1000, writable: true, configurable: true });
+  Object.defineProperty(window, "innerHeight", { value: 800, writable: true, configurable: true });
+});
+
+describe("useTabDragOut", () => {
+  it("completed drag released outside the viewport detaches and suppresses the next click", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+
+    act(() => {
+      result.current.handleTabPointerDown(
+        makeReactPointerDownEvent({ clientX: 10, clientY: 10 }),
+        "note-1",
+        "Title 1",
+      );
+    });
+    act(() => {
+      dispatch("pointermove", { clientX: 100, clientY: 10 }); // past 6px threshold
+    });
+    act(() => {
+      dispatch("pointerup", { clientX: -50, clientY: 10 }); // outside viewport
+    });
+
+    expect(onDetachAtCursor).toHaveBeenCalledTimes(1);
+    expect(onDetachAtCursor).toHaveBeenCalledWith("note-1");
+    expect(result.current.suppressNextClick.current).toBe(true);
+  });
+
+  it("release inside the viewport after dragging does not detach but still suppresses", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+
+    act(() => {
+      result.current.handleTabPointerDown(
+        makeReactPointerDownEvent({ clientX: 10, clientY: 10 }),
+        "note-1",
+        "Title 1",
+      );
+    });
+    act(() => {
+      dispatch("pointermove", { clientX: 100, clientY: 10 });
+    });
+    act(() => {
+      dispatch("pointerup", { clientX: 200, clientY: 200 }); // inside viewport
+    });
+
+    expect(onDetachAtCursor).not.toHaveBeenCalled();
+    expect(result.current.suppressNextClick.current).toBe(true);
+  });
+
+  it("a fresh pointerdown anywhere clears a stale suppressNextClick", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+
+    // Simulate a stale flag left over from a previous drag whose click
+    // never fired (released far from the original target).
+    act(() => {
+      result.current.suppressNextClick.current = true;
+    });
+
+    act(() => {
+      dispatch("pointerdown", { clientX: 500, clientY: 500 });
+    });
+
+    expect(result.current.suppressNextClick.current).toBe(false);
+  });
+
+  it("a non-left-button pointerup while dragging does not end the drag; a later left release still works", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+
+    act(() => {
+      result.current.handleTabPointerDown(
+        makeReactPointerDownEvent({ clientX: 10, clientY: 10 }),
+        "note-1",
+        "Title 1",
+      );
+    });
+    act(() => {
+      dispatch("pointermove", { clientX: 100, clientY: 10 });
+    });
+    act(() => {
+      dispatch("pointerup", { clientX: -50, clientY: 10, button: 2 }); // right-click release
+    });
+
+    expect(onDetachAtCursor).not.toHaveBeenCalled();
+    expect(result.current.drag).not.toBeNull(); // drag still armed/active
+
+    act(() => {
+      dispatch("pointerup", { clientX: -50, clientY: 10, button: 0 }); // real left release
+    });
+
+    expect(onDetachAtCursor).toHaveBeenCalledTimes(1);
+    expect(onDetachAtCursor).toHaveBeenCalledWith("note-1");
+  });
+
+  it("pointercancel resets without detaching and without suppressing", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+
+    act(() => {
+      result.current.handleTabPointerDown(
+        makeReactPointerDownEvent({ clientX: 10, clientY: 10 }),
+        "note-1",
+        "Title 1",
+      );
+    });
+    act(() => {
+      dispatch("pointermove", { clientX: 100, clientY: 10 });
+    });
+    act(() => {
+      dispatch("pointercancel", { clientX: 100, clientY: 10 });
+    });
+
+    expect(onDetachAtCursor).not.toHaveBeenCalled();
+    expect(result.current.suppressNextClick.current).toBe(false);
+    expect(result.current.drag).toBeNull();
+
+    // A later pointerup should not misfire since the gesture was reset.
+    act(() => {
+      dispatch("pointerup", { clientX: -50, clientY: 10 });
+    });
+    expect(onDetachAtCursor).not.toHaveBeenCalled();
+  });
+
+  it("Escape while merely armed (no movement past threshold) does not suppress", () => {
+    const onDetachAtCursor = vi.fn();
+    const { result } = renderHook(() => useTabDragOut({ onDetachAtCursor }));
+
+    act(() => {
+      result.current.handleTabPointerDown(
+        makeReactPointerDownEvent({ clientX: 10, clientY: 10 }),
+        "note-1",
+        "Title 1",
+      );
+    });
+    // No pointermove past the threshold — gesture is armed but not dragging.
+    act(() => {
+      window.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+
+    expect(onDetachAtCursor).not.toHaveBeenCalled();
+    expect(result.current.suppressNextClick.current).toBe(false);
+    expect(result.current.drag).toBeNull();
+  });
+});

--- a/src/hooks/useTabDragOut.ts
+++ b/src/hooks/useTabDragOut.ts
@@ -41,6 +41,19 @@ export function useTabDragOut({
   const handleTabPointerDown = useCallback(
     (e: React.PointerEvent, id: string, title: string) => {
       if (e.button !== 0) return; // left button only — middle-click closes
+      // Explicit pointer capture keeps move/up events flowing to this
+      // document while the cursor is outside the OS window — WebView2 does
+      // not guarantee delivery beyond the window bounds without it, and the
+      // outside-viewport release would never be observed. Captured events
+      // still bubble, so the window-level listeners below keep working.
+      const el = e.currentTarget as HTMLElement | undefined;
+      if (el?.setPointerCapture) {
+        try {
+          el.setPointerCapture(e.pointerId);
+        } catch {
+          // best-effort: the drag still works inside the window
+        }
+      }
       armedRef.current = { id, title, x: e.clientX, y: e.clientY };
       draggingRef.current = false;
     },
@@ -48,6 +61,10 @@ export function useTabDragOut({
   );
 
   useEffect(() => {
+    // TEMP DIAGNOSTICS (remove before merge): trace pointer delivery while
+    // debugging drag-out event flow on WebView2. Filter console on [drag-out].
+    let lastOutside = false;
+
     const onPointerMove = (e: PointerEvent) => {
       const armed = armedRef.current;
       if (!armed) return;
@@ -58,6 +75,18 @@ export function useTabDragOut({
         draggingRef.current = true;
       }
       if (draggingRef.current) {
+        const out = isOutsideViewport(
+          e.clientX,
+          e.clientY,
+          window.innerWidth,
+          window.innerHeight,
+        );
+        if (out !== lastOutside) {
+          console.log(
+            `[drag-out] move ${out ? "OUTSIDE" : "inside"} @${e.clientX},${e.clientY} viewport=${window.innerWidth}x${window.innerHeight}`,
+          );
+          lastOutside = out;
+        }
         setDrag({ ...armed, x: e.clientX, y: e.clientY });
       }
     };
@@ -75,6 +104,11 @@ export function useTabDragOut({
     };
 
     const onPointerUp = (e: PointerEvent) => {
+      if (armedRef.current) {
+        console.log(
+          `[drag-out] up button=${e.button} @${e.clientX},${e.clientY} viewport=${window.innerWidth}x${window.innerHeight} dragging=${draggingRef.current}`,
+        );
+      }
       if (e.button !== 0) return; // ignore right-click/other buttons
       const armed = armedRef.current;
       if (!armed) return;
@@ -88,14 +122,30 @@ export function useTabDragOut({
       reset();
       if (wasDragging) {
         suppressNextClick.current = true;
-        if (outside) onDetachAtCursorRef.current(armed.id);
+        if (outside) {
+          console.log(`[drag-out] DETACH ${armed.id}`);
+          onDetachAtCursorRef.current(armed.id);
+        }
       }
     };
 
     const onPointerCancel = () => {
       // System-initiated interruption (focus loss, OS gesture) — just
       // disarm, no suppress and no detach.
+      if (armedRef.current) {
+        console.log(
+          `[drag-out] pointercancel dragging=${draggingRef.current}`,
+        );
+      }
       reset();
+    };
+
+    const onLostPointerCapture = () => {
+      if (armedRef.current) {
+        console.log(
+          `[drag-out] lostpointercapture dragging=${draggingRef.current}`,
+        );
+      }
     };
 
     const onKeyDown = (e: KeyboardEvent) => {
@@ -110,12 +160,14 @@ export function useTabDragOut({
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("pointerup", onPointerUp);
     window.addEventListener("pointercancel", onPointerCancel);
+    window.addEventListener("lostpointercapture", onLostPointerCapture);
     window.addEventListener("keydown", onKeyDown);
     return () => {
       window.removeEventListener("pointerdown", onWindowPointerDown, true);
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointercancel", onPointerCancel);
+      window.removeEventListener("lostpointercapture", onLostPointerCapture);
       window.removeEventListener("keydown", onKeyDown);
     };
   }, [reset]);

--- a/src/hooks/useTabDragOut.ts
+++ b/src/hooks/useTabDragOut.ts
@@ -1,0 +1,98 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  exceedsDragThreshold,
+  isOutsideViewport,
+} from "@/lib/notes-window/drag-out";
+
+export interface TabDragState {
+  id: string;
+  title: string;
+  x: number;
+  y: number;
+}
+
+/**
+ * Drag-out gesture for the notes tab strip (spec §6, level 1 « au lâcher »):
+ * pointerdown on a tab arms the gesture; once the pointer travels beyond the
+ * threshold a ghost follows the cursor; releasing OUTSIDE the viewport
+ * detaches the note at the OS cursor position (Rust resolves the physical
+ * coordinates — no DPI math here). Releasing inside, or pressing Escape,
+ * cancels. A completed drag suppresses the click that follows it so the tab
+ * doesn't also activate.
+ */
+export function useTabDragOut({
+  onDetachAtCursor,
+}: {
+  onDetachAtCursor: (id: string) => void;
+}) {
+  const [drag, setDrag] = useState<TabDragState | null>(null);
+  const armedRef = useRef<TabDragState | null>(null);
+  const draggingRef = useRef(false);
+  const suppressNextClick = useRef(false);
+
+  const reset = useCallback(() => {
+    armedRef.current = null;
+    draggingRef.current = false;
+    setDrag(null);
+  }, []);
+
+  const handleTabPointerDown = useCallback(
+    (e: React.PointerEvent, id: string, title: string) => {
+      if (e.button !== 0) return; // left button only — middle-click closes
+      armedRef.current = { id, title, x: e.clientX, y: e.clientY };
+      draggingRef.current = false;
+    },
+    [],
+  );
+
+  useEffect(() => {
+    const onPointerMove = (e: PointerEvent) => {
+      const armed = armedRef.current;
+      if (!armed) return;
+      if (
+        !draggingRef.current &&
+        exceedsDragThreshold(armed.x, armed.y, e.clientX, e.clientY)
+      ) {
+        draggingRef.current = true;
+      }
+      if (draggingRef.current) {
+        setDrag({ ...armed, x: e.clientX, y: e.clientY });
+      }
+    };
+
+    const onPointerUp = (e: PointerEvent) => {
+      const armed = armedRef.current;
+      if (!armed) return;
+      const wasDragging = draggingRef.current;
+      const outside = isOutsideViewport(
+        e.clientX,
+        e.clientY,
+        window.innerWidth,
+        window.innerHeight,
+      );
+      reset();
+      if (wasDragging) {
+        suppressNextClick.current = true;
+        if (outside) onDetachAtCursor(armed.id);
+      }
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape" && armedRef.current) {
+        reset();
+        suppressNextClick.current = true;
+      }
+    };
+
+    window.addEventListener("pointermove", onPointerMove);
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("keydown", onKeyDown);
+    return () => {
+      window.removeEventListener("pointermove", onPointerMove);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("keydown", onKeyDown);
+    };
+  }, [onDetachAtCursor, reset]);
+
+  return { drag, handleTabPointerDown, suppressNextClick };
+}

--- a/src/hooks/useTabDragOut.ts
+++ b/src/hooks/useTabDragOut.ts
@@ -68,7 +68,8 @@ export function useTabDragOut({
     // otherwise stay true and eat the NEXT unrelated tab click. Clearing it
     // at the start of every gesture keeps same-gesture suppression intact
     // (pointerdown clears → pointerup may set → click consumes) while
-    // killing stale flags from a previous gesture.
+    // killing stale flags from a previous gesture. Registered on the capture
+    // phase so a target's stopPropagation() can't prevent this clear.
     const onWindowPointerDown = () => {
       suppressNextClick.current = false;
     };
@@ -105,13 +106,13 @@ export function useTabDragOut({
       }
     };
 
-    window.addEventListener("pointerdown", onWindowPointerDown);
+    window.addEventListener("pointerdown", onWindowPointerDown, true);
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("pointerup", onPointerUp);
     window.addEventListener("pointercancel", onPointerCancel);
     window.addEventListener("keydown", onKeyDown);
     return () => {
-      window.removeEventListener("pointerdown", onWindowPointerDown);
+      window.removeEventListener("pointerdown", onWindowPointerDown, true);
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointercancel", onPointerCancel);

--- a/src/hooks/useTabDragOut.ts
+++ b/src/hooks/useTabDragOut.ts
@@ -1,7 +1,9 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import {
   exceedsDragThreshold,
+  isOutsideStrip,
   isOutsideViewport,
+  type StripRect,
 } from "@/lib/notes-window/drag-out";
 
 export interface TabDragState {
@@ -14,16 +16,21 @@ export interface TabDragState {
 /**
  * Drag-out gesture for the notes tab strip (spec §6, level 1 « au lâcher »):
  * pointerdown on a tab arms the gesture; once the pointer travels beyond the
- * threshold a ghost follows the cursor; releasing OUTSIDE the viewport
- * detaches the note at the OS cursor position (Rust resolves the physical
- * coordinates — no DPI math here). Releasing inside, or pressing Escape,
- * cancels. A completed drag suppresses the click that follows it so the tab
- * doesn't also activate.
+ * threshold a ghost follows the cursor; releasing OUTSIDE the tab bar —
+ * Notepad-style, even inside the app window — detaches the note at the OS
+ * cursor position (Rust resolves the physical coordinates — no DPI math
+ * here). Releasing on the bar, or pressing Escape, cancels. A completed drag
+ * suppresses the click that follows it so the tab doesn't also activate.
  */
 export function useTabDragOut({
   onDetachAtCursor,
+  getStripRect,
 }: {
   onDetachAtCursor: (id: string) => void;
+  /** Bounds of the tab bar (the cancel zone), queried at release time so
+   *  scroll/resize during the drag can't stale it. `null` falls back to the
+   *  outside-viewport criterion. */
+  getStripRect: () => StripRect | null;
 }) {
   const [drag, setDrag] = useState<TabDragState | null>(null);
   const armedRef = useRef<TabDragState | null>(null);
@@ -31,6 +38,8 @@ export function useTabDragOut({
   const suppressNextClick = useRef(false);
   const onDetachAtCursorRef = useRef(onDetachAtCursor);
   onDetachAtCursorRef.current = onDetachAtCursor;
+  const getStripRectRef = useRef(getStripRect);
+  getStripRectRef.current = getStripRect;
 
   const reset = useCallback(() => {
     armedRef.current = null;
@@ -43,9 +52,9 @@ export function useTabDragOut({
       if (e.button !== 0) return; // left button only — middle-click closes
       // Explicit pointer capture keeps move/up events flowing to this
       // document while the cursor is outside the OS window — WebView2 does
-      // not guarantee delivery beyond the window bounds without it, and the
-      // outside-viewport release would never be observed. Captured events
-      // still bubble, so the window-level listeners below keep working.
+      // not guarantee delivery beyond the window bounds without it. Captured
+      // events still bubble, so the window-level listeners below keep
+      // working.
       const el = e.currentTarget as HTMLElement | undefined;
       if (el?.setPointerCapture) {
         try {
@@ -61,10 +70,6 @@ export function useTabDragOut({
   );
 
   useEffect(() => {
-    // TEMP DIAGNOSTICS (remove before merge): trace pointer delivery while
-    // debugging drag-out event flow on WebView2. Filter console on [drag-out].
-    let lastOutside = false;
-
     const onPointerMove = (e: PointerEvent) => {
       const armed = armedRef.current;
       if (!armed) return;
@@ -75,18 +80,6 @@ export function useTabDragOut({
         draggingRef.current = true;
       }
       if (draggingRef.current) {
-        const out = isOutsideViewport(
-          e.clientX,
-          e.clientY,
-          window.innerWidth,
-          window.innerHeight,
-        );
-        if (out !== lastOutside) {
-          console.log(
-            `[drag-out] move ${out ? "OUTSIDE" : "inside"} @${e.clientX},${e.clientY} viewport=${window.innerWidth}x${window.innerHeight}`,
-          );
-          lastOutside = out;
-        }
         setDrag({ ...armed, x: e.clientX, y: e.clientY });
       }
     };
@@ -104,48 +97,30 @@ export function useTabDragOut({
     };
 
     const onPointerUp = (e: PointerEvent) => {
-      if (armedRef.current) {
-        console.log(
-          `[drag-out] up button=${e.button} @${e.clientX},${e.clientY} viewport=${window.innerWidth}x${window.innerHeight} dragging=${draggingRef.current}`,
-        );
-      }
       if (e.button !== 0) return; // ignore right-click/other buttons
       const armed = armedRef.current;
       if (!armed) return;
       const wasDragging = draggingRef.current;
-      const outside = isOutsideViewport(
-        e.clientX,
-        e.clientY,
-        window.innerWidth,
-        window.innerHeight,
-      );
+      const rect = getStripRectRef.current();
+      const outside = rect
+        ? isOutsideStrip(e.clientX, e.clientY, rect)
+        : isOutsideViewport(
+            e.clientX,
+            e.clientY,
+            window.innerWidth,
+            window.innerHeight,
+          );
       reset();
       if (wasDragging) {
         suppressNextClick.current = true;
-        if (outside) {
-          console.log(`[drag-out] DETACH ${armed.id}`);
-          onDetachAtCursorRef.current(armed.id);
-        }
+        if (outside) onDetachAtCursorRef.current(armed.id);
       }
     };
 
     const onPointerCancel = () => {
       // System-initiated interruption (focus loss, OS gesture) — just
       // disarm, no suppress and no detach.
-      if (armedRef.current) {
-        console.log(
-          `[drag-out] pointercancel dragging=${draggingRef.current}`,
-        );
-      }
       reset();
-    };
-
-    const onLostPointerCapture = () => {
-      if (armedRef.current) {
-        console.log(
-          `[drag-out] lostpointercapture dragging=${draggingRef.current}`,
-        );
-      }
     };
 
     const onKeyDown = (e: KeyboardEvent) => {
@@ -160,14 +135,12 @@ export function useTabDragOut({
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("pointerup", onPointerUp);
     window.addEventListener("pointercancel", onPointerCancel);
-    window.addEventListener("lostpointercapture", onLostPointerCapture);
     window.addEventListener("keydown", onKeyDown);
     return () => {
       window.removeEventListener("pointerdown", onWindowPointerDown, true);
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointercancel", onPointerCancel);
-      window.removeEventListener("lostpointercapture", onLostPointerCapture);
       window.removeEventListener("keydown", onKeyDown);
     };
   }, [reset]);

--- a/src/hooks/useTabDragOut.ts
+++ b/src/hooks/useTabDragOut.ts
@@ -29,6 +29,8 @@ export function useTabDragOut({
   const armedRef = useRef<TabDragState | null>(null);
   const draggingRef = useRef(false);
   const suppressNextClick = useRef(false);
+  const onDetachAtCursorRef = useRef(onDetachAtCursor);
+  onDetachAtCursorRef.current = onDetachAtCursor;
 
   const reset = useCallback(() => {
     armedRef.current = null;
@@ -60,7 +62,19 @@ export function useTabDragOut({
       }
     };
 
+    // A native `click` only fires when pointerdown/pointerup share the same
+    // target, so a real drag (released far away, or outside the viewport)
+    // never produces a click to consume `suppressNextClick` — it would
+    // otherwise stay true and eat the NEXT unrelated tab click. Clearing it
+    // at the start of every gesture keeps same-gesture suppression intact
+    // (pointerdown clears → pointerup may set → click consumes) while
+    // killing stale flags from a previous gesture.
+    const onWindowPointerDown = () => {
+      suppressNextClick.current = false;
+    };
+
     const onPointerUp = (e: PointerEvent) => {
+      if (e.button !== 0) return; // ignore right-click/other buttons
       const armed = armedRef.current;
       if (!armed) return;
       const wasDragging = draggingRef.current;
@@ -73,26 +87,37 @@ export function useTabDragOut({
       reset();
       if (wasDragging) {
         suppressNextClick.current = true;
-        if (outside) onDetachAtCursor(armed.id);
+        if (outside) onDetachAtCursorRef.current(armed.id);
       }
+    };
+
+    const onPointerCancel = () => {
+      // System-initiated interruption (focus loss, OS gesture) — just
+      // disarm, no suppress and no detach.
+      reset();
     };
 
     const onKeyDown = (e: KeyboardEvent) => {
       if (e.key === "Escape" && armedRef.current) {
+        const wasDragging = draggingRef.current;
         reset();
-        suppressNextClick.current = true;
+        if (wasDragging) suppressNextClick.current = true;
       }
     };
 
+    window.addEventListener("pointerdown", onWindowPointerDown);
     window.addEventListener("pointermove", onPointerMove);
     window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerCancel);
     window.addEventListener("keydown", onKeyDown);
     return () => {
+      window.removeEventListener("pointerdown", onWindowPointerDown);
       window.removeEventListener("pointermove", onPointerMove);
       window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerCancel);
       window.removeEventListener("keydown", onKeyDown);
     };
-  }, [onDetachAtCursor, reset]);
+  }, [reset]);
 
   return { drag, handleTabPointerDown, suppressNextClick };
 }

--- a/src/lib/notes-window/drag-out.test.ts
+++ b/src/lib/notes-window/drag-out.test.ts
@@ -1,7 +1,9 @@
 import { describe, expect, it } from "vitest";
 import {
   DRAG_START_THRESHOLD_PX,
+  STRIP_EXIT_MARGIN_PX,
   exceedsDragThreshold,
+  isOutsideStrip,
   isOutsideViewport,
 } from "./drag-out";
 
@@ -13,6 +15,30 @@ describe("exceedsDragThreshold", () => {
     expect(exceedsDragThreshold(10, 10, 10 + DRAG_START_THRESHOLD_PX, 10)).toBe(true);
     expect(exceedsDragThreshold(10, 10, 10, 10 - DRAG_START_THRESHOLD_PX)).toBe(true);
     expect(exceedsDragThreshold(10, 10, 15, 15)).toBe(true); // hypot ≈ 7.07
+  });
+});
+
+describe("isOutsideStrip", () => {
+  const strip = { left: 0, top: 0, right: 800, bottom: 30 };
+
+  it("is false on the strip and within the forgiveness margin", () => {
+    expect(isOutsideStrip(400, 15, strip)).toBe(false);
+    expect(isOutsideStrip(0, 0, strip)).toBe(false);
+    expect(isOutsideStrip(800, 30, strip)).toBe(false);
+    expect(isOutsideStrip(400, 30 + STRIP_EXIT_MARGIN_PX, strip)).toBe(false);
+    expect(isOutsideStrip(800 + STRIP_EXIT_MARGIN_PX, 15, strip)).toBe(false);
+  });
+
+  it("is true beyond the margin on any side, even inside the window", () => {
+    expect(isOutsideStrip(400, 30 + STRIP_EXIT_MARGIN_PX + 1, strip)).toBe(true);
+    expect(isOutsideStrip(400, -STRIP_EXIT_MARGIN_PX - 1, strip)).toBe(true);
+    expect(isOutsideStrip(-STRIP_EXIT_MARGIN_PX - 1, 15, strip)).toBe(true);
+    expect(isOutsideStrip(800 + STRIP_EXIT_MARGIN_PX + 1, 15, strip)).toBe(true);
+  });
+
+  it("honors a custom margin", () => {
+    expect(isOutsideStrip(400, 80, strip, 50)).toBe(false);
+    expect(isOutsideStrip(400, 81, strip, 50)).toBe(true);
   });
 });
 

--- a/src/lib/notes-window/drag-out.test.ts
+++ b/src/lib/notes-window/drag-out.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from "vitest";
+import {
+  DRAG_START_THRESHOLD_PX,
+  exceedsDragThreshold,
+  isOutsideViewport,
+} from "./drag-out";
+
+describe("exceedsDragThreshold", () => {
+  it("is false below the threshold", () => {
+    expect(exceedsDragThreshold(10, 10, 12, 12)).toBe(false);
+  });
+  it("is true at or beyond the threshold in any direction", () => {
+    expect(exceedsDragThreshold(10, 10, 10 + DRAG_START_THRESHOLD_PX, 10)).toBe(true);
+    expect(exceedsDragThreshold(10, 10, 10, 10 - DRAG_START_THRESHOLD_PX)).toBe(true);
+    expect(exceedsDragThreshold(10, 10, 15, 15)).toBe(true); // hypot ≈ 7.07
+  });
+});
+
+describe("isOutsideViewport", () => {
+  it("is false inside", () => {
+    expect(isOutsideViewport(100, 100, 800, 600)).toBe(false);
+    expect(isOutsideViewport(0, 0, 800, 600)).toBe(false);
+    expect(isOutsideViewport(800, 600, 800, 600)).toBe(false);
+  });
+  it("is true outside any edge", () => {
+    expect(isOutsideViewport(-1, 100, 800, 600)).toBe(true);
+    expect(isOutsideViewport(100, -1, 800, 600)).toBe(true);
+    expect(isOutsideViewport(801, 100, 800, 600)).toBe(true);
+    expect(isOutsideViewport(100, 601, 800, 600)).toBe(true);
+  });
+});

--- a/src/lib/notes-window/drag-out.ts
+++ b/src/lib/notes-window/drag-out.ts
@@ -28,3 +28,33 @@ export function isOutsideViewport(
     clientY > viewportHeight
   );
 }
+
+/** Releases within this distance (px) of the tab bar still count as "on the
+ *  bar" — a small forgiveness band so a sloppy release right at its edge
+ *  doesn't detach. */
+export const STRIP_EXIT_MARGIN_PX = 8;
+
+export interface StripRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+/** Notepad-style drop criterion (spec §6): releasing OUTSIDE the tab bar —
+ *  even inside the app window — is a detach drop; releasing on the bar
+ *  cancels. Unlike an outside-the-window criterion, this stays reachable
+ *  when the window is maximized on a single monitor. */
+export function isOutsideStrip(
+  clientX: number,
+  clientY: number,
+  rect: StripRect,
+  margin: number = STRIP_EXIT_MARGIN_PX,
+): boolean {
+  return (
+    clientX < rect.left - margin ||
+    clientX > rect.right + margin ||
+    clientY < rect.top - margin ||
+    clientY > rect.bottom + margin
+  );
+}

--- a/src/lib/notes-window/drag-out.ts
+++ b/src/lib/notes-window/drag-out.ts
@@ -1,0 +1,30 @@
+/** Pointer must travel this far (px) from pointerdown before a tab drag
+ *  starts — below it, the gesture stays a plain click. */
+export const DRAG_START_THRESHOLD_PX = 6;
+
+export function exceedsDragThreshold(
+  startX: number,
+  startY: number,
+  x: number,
+  y: number,
+): boolean {
+  return Math.hypot(x - startX, y - startY) >= DRAG_START_THRESHOLD_PX;
+}
+
+/** Client coordinates are viewport-relative and DPI-free: outside the
+ *  viewport ⇒ outside the OS window ⇒ this is a detach drop. The final
+ *  window position is resolved by Rust from the OS cursor (`at_cursor`),
+ *  so no CSS→physical conversion happens in JS (spec §6). */
+export function isOutsideViewport(
+  clientX: number,
+  clientY: number,
+  viewportWidth: number,
+  viewportHeight: number,
+): boolean {
+  return (
+    clientX < 0 ||
+    clientY < 0 ||
+    clientX > viewportWidth ||
+    clientY > viewportHeight
+  );
+}


### PR DESCRIPTION
## PR 2 — Drag-out for detachable note windows

Level-1 drag-out (« au lâcher ») completing the detachable-notes feature (#87): pointerdown on a tab beyond a 6px threshold shows a ghost following the cursor; releasing **outside the tab bar** — Notepad-style, even inside the app window — detaches the note into its own OS window created at the OS cursor position (Rust resolves physical coordinates via `open_note_window(id, atCursor: true)` — zero DPI math in JS). Releasing on the bar or pressing Escape cancels; single click and middle-click-close behavior preserved. Spec §6 of `docs/superpowers/specs/2026-07-24-detachable-notes-design.md`.

### Design change validated in smoke test
The spec's original drop criterion (release outside the main window) proved **unusable with a maximized window on a single monitor** — the cursor cannot leave the screen — and undiscoverable. Per user decision (2026-07-24), the criterion is now **release outside the tab bar row** (8px forgiveness margin; the bar is the cancel zone), matching Windows Notepad. Spec §6 and the E2E checklist are updated accordingly.

### Fixes surfaced by review loops and smoke testing
- Explicit `setPointerCapture` on drag start: WebView2 does not guarantee pointer-event delivery beyond the OS window without it (confirmed by instrumented user logs).
- Stale `suppressNextClick` flag cleared at every new gesture — a completed drag no longer swallows the next unrelated tab click (was Critical in task review).
- Left-button filter on release, `pointercancel` reset, Escape suppresses only during an actual drag.
- `position_note_window` no longer clamps physical coordinates to 0 — drops on monitors left of/above the primary (negative coordinates) land at the cursor instead of teleporting to the primary edge.

### Tests
- 541/541 Vitest (16 dedicated: 7 pure helpers, 9 jsdom gesture tests incl. maximized-window Notepad-style drop, cancel-on-bar, stale-flag, button filter, pointercancel, Escape variants), `pnpm build` clean, 81/81 cargo, `cargo check --no-default-features` clean.
- Manual E2E: section « PR 2 — Drag-out » of `docs/detachable-notes-e2e-checklist.md` (updated) — to be walked before merge.

### Known limitation (triaged non-blocking)
No `pointerId` filtering: two simultaneous pointers (touch + mouse) on the tab strip can interfere; single-mouse usage — this app's primary input — is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)